### PR TITLE
#18 fixed javadoc warnings

### DIFF
--- a/libjava/lib/src/main/java/com/mapbox/services/directions/v4/models/FeatureProperties.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/directions/v4/models/FeatureProperties.java
@@ -9,7 +9,7 @@ public class FeatureProperties {
     private String name;
 
     /**
-     * Gives the name of the closest street to the {@link DirectionFeature} point.
+     * Gives the name of the closest street to the {@link DirectionsFeature} point.
      *
      * @return String name.
      */

--- a/libjava/lib/src/main/java/com/mapbox/services/directions/v4/models/Waypoint.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/directions/v4/models/Waypoint.java
@@ -11,6 +11,9 @@ public class Waypoint {
 
     /**
      * Construct a location with a longitude latitude pair.
+     *
+     * @param longitude double value ranging from -180.0 to 180.0.
+     * @param latitude  double value ranging from -90.0 to 90.0.
      */
     public Waypoint(double longitude, double latitude) {
         this.longitude = longitude;
@@ -33,7 +36,7 @@ public class Waypoint {
     /**
      * The longitude of the location.
      *
-     * @return double value ranging from -180.0 to 180.0
+     * @return double value ranging from -180.0 to 180.0.
      */
     public double getLongitude() {
         return longitude;

--- a/libjava/lib/src/main/java/com/mapbox/services/directions/v5/MapboxDirections.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/directions/v5/MapboxDirections.java
@@ -178,8 +178,7 @@ public class MapboxDirections implements MapboxService<DirectionsResponse> {
          * origin with setOrigin() or a destination with setDestination(), those will be
          * overridden.
          *
-         * @param coordinates
-         * @return
+         * @param coordinates List of {@link Position} giving origin and destination(s) coordinates.
          */
         public Builder setCoordinates(ArrayList<Position> coordinates) {
             this.coordinates = coordinates;
@@ -191,8 +190,7 @@ public class MapboxDirections implements MapboxService<DirectionsResponse> {
          * set other coordinates previously with setCoordinates() those elements are kept
          * and their index will be moved up by one (the coordinates are moved to the right).
          *
-         * @param origin
-         * @return
+         * @param origin {@link Position} of route origin.
          */
         public Builder setOrigin(Position origin) {
             if (coordinates == null) {
@@ -213,8 +211,7 @@ public class MapboxDirections implements MapboxService<DirectionsResponse> {
          * set other coordinates previously with setCoordinates() those elements are kept
          * and the destination is added at the end of the list.
          *
-         * @param destination
-         * @return
+         * @param destination {@link Position} of route destination.
          */
         public Builder setDestination(Position destination) {
             if (coordinates == null) {

--- a/libjava/lib/src/main/java/com/mapbox/services/directions/v5/models/StepManeuver.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/directions/v5/models/StepManeuver.java
@@ -47,7 +47,7 @@ public class StepManeuver {
 
     /**
      * This indicates the type of maneuver. It can be any of these listed:
-     * <p/>
+     * <br>
      * <ul>
      * <li>turn - a basic turn into direction of the modifier</li>
      * <li>new name - the road name changes (after a mandatory turn)</li>


### PR DESCRIPTION
All warnings should be taken care of now. Only ones left I see are for testapp and no `@return` for setters (don't need annotation). A few warnings exist for comments @zugaldia made but I haven't gotten a chance to review the classes yet.
