### PR TITLE
Fixes geojson GeometryDeserializer.java and tests

### DIFF
--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/GeometryDeserializer.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/GeometryDeserializer.java
@@ -21,7 +21,7 @@ public class GeometryDeserializer implements JsonDeserializer<Geometry> {
         String geometryType = json.getAsJsonObject().get("type").getAsString();
         try {
             // Use the current context to deserialize it
-            Type classType = Class.forName("com.mapbox.services.geojson." + geometryType);
+            Type classType = Class.forName("com.mapbox.services.commons.geojson." + geometryType);
             return context.deserialize(json, classType);
         } catch (ClassNotFoundException e) {
             // Unknown geometry

--- a/libjava/lib/src/test/java/com/mapbox/services/geojson/FeatureCollectionTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/geojson/FeatureCollectionTest.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.geojson;
 
+import com.mapbox.services.commons.geojson.FeatureCollection;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -11,7 +13,7 @@ public class FeatureCollectionTest extends BaseGeoJSON {
 
     @Test
     public void fromJson() {
-        com.mapbox.services.commons.geojson.FeatureCollection geo = com.mapbox.services.commons.geojson.FeatureCollection.fromJson(BaseGeoJSON.SAMPLE_FEATURECOLLECTION);
+        FeatureCollection geo = FeatureCollection.fromJson(BaseGeoJSON.SAMPLE_FEATURECOLLECTION);
         assertEquals(geo.getType(), "FeatureCollection");
         assertEquals(geo.getFeatures().size(), 3);
         assertEquals(geo.getFeatures().get(0).getType(), "Feature");
@@ -24,7 +26,7 @@ public class FeatureCollectionTest extends BaseGeoJSON {
 
     @Test
     public void toJson() {
-        com.mapbox.services.commons.geojson.FeatureCollection geo = com.mapbox.services.commons.geojson.FeatureCollection.fromJson(BaseGeoJSON.SAMPLE_FEATURECOLLECTION);
+        FeatureCollection geo = FeatureCollection.fromJson(BaseGeoJSON.SAMPLE_FEATURECOLLECTION);
         compareJson(BaseGeoJSON.SAMPLE_FEATURECOLLECTION, geo.toJson());
     }
 

--- a/libjava/lib/src/test/java/com/mapbox/services/geojson/FeatureTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/geojson/FeatureTest.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.geojson;
 
+import com.mapbox.services.commons.geojson.Feature;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -11,7 +13,7 @@ public class FeatureTest extends BaseGeoJSON {
 
     @Test
     public void fromJson() {
-        com.mapbox.services.commons.geojson.Feature geo = com.mapbox.services.commons.geojson.Feature.fromJson(BaseGeoJSON.SAMPLE_FEATURE);
+        Feature geo = Feature.fromJson(BaseGeoJSON.SAMPLE_FEATURE);
         assertEquals(geo.getType(), "Feature");
         assertEquals(geo.getGeometry().getType(), "Point");
         assertEquals(geo.getProperties().get("name").getAsString(), "Dinagat Islands");
@@ -19,7 +21,7 @@ public class FeatureTest extends BaseGeoJSON {
 
     @Test
     public void toJson() {
-        com.mapbox.services.commons.geojson.Feature geo = com.mapbox.services.commons.geojson.Feature.fromJson(BaseGeoJSON.SAMPLE_FEATURE);
+        Feature geo = Feature.fromJson(BaseGeoJSON.SAMPLE_FEATURE);
         compareJson(BaseGeoJSON.SAMPLE_FEATURE, geo.toJson());
     }
 

--- a/libjava/lib/src/test/java/com/mapbox/services/geojson/GeometryCollectionTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/geojson/GeometryCollectionTest.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.geojson;
 
+import com.mapbox.services.commons.geojson.GeometryCollection;
+
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -11,7 +13,7 @@ public class GeometryCollectionTest extends BaseGeoJSON {
 
     @Test
     public void fromJson() {
-        com.mapbox.services.commons.geojson.GeometryCollection geo = com.mapbox.services.commons.geojson.GeometryCollection.fromJson(BaseGeoJSON.SAMPLE_GEOMETRYCOLLECTION);
+        GeometryCollection geo = GeometryCollection.fromJson(BaseGeoJSON.SAMPLE_GEOMETRYCOLLECTION);
         assertEquals(geo.getType(), "GeometryCollection");
         assertEquals(geo.getGeometries().get(0).getType(), "Point");
         assertEquals(geo.getGeometries().get(1).getType(), "LineString");
@@ -19,7 +21,7 @@ public class GeometryCollectionTest extends BaseGeoJSON {
 
     @Test
     public void toJson() {
-        com.mapbox.services.commons.geojson.GeometryCollection geo = com.mapbox.services.commons.geojson.GeometryCollection.fromJson(BaseGeoJSON.SAMPLE_GEOMETRYCOLLECTION);
+        GeometryCollection geo = GeometryCollection.fromJson(BaseGeoJSON.SAMPLE_GEOMETRYCOLLECTION);
         compareJson(BaseGeoJSON.SAMPLE_GEOMETRYCOLLECTION, geo.toJson());
     }
 

--- a/scripts/bitrise.yml
+++ b/scripts/bitrise.yml
@@ -66,7 +66,7 @@ workflows:
         - content: |-
             #!/bin/bash
             cd libjava
-            ./gradlew testReleaseUnitTest --continue
+            ./gradlew test
         - is_debug: 'yes'
     - script:
         title: Run Android Project Unit Tests
@@ -74,7 +74,7 @@ workflows:
         - content: |-
             #!/bin/bash
             cd libandroid
-            ./gradlew testReleaseUnitTest --continue
+            ./gradlew test
         - is_debug: 'yes'
     - slack:
         title: Post to Slack
@@ -155,14 +155,14 @@ workflows:
         - content: |-
             #!/bin/bash
             cd libjava
-            ./gradlew testReleaseUnitTest --continue
+            ./gradlew test
     - script:
         title: Run Android Project Unit Tests
         inputs:
         - content: |-
             #!/bin/bash
             cd libandroid
-            ./gradlew testReleaseUnitTest --continue
+            ./gradlew test
     - script:
         title: Publish Java Services To Maven Central
         inputs:


### PR DESCRIPTION
Fixes #41.

Turns out there was an actual bug in the `GeometryDeserializer` object after the package was moved.
