### PR TITLE
Improvements to Static Image API service

### DIFF
--- a/libjava/lib/src/main/java/com/mapbox/services/staticimage/v1/MapboxStaticImage.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/staticimage/v1/MapboxStaticImage.java
@@ -3,6 +3,7 @@ package com.mapbox.services.staticimage.v1;
 import com.mapbox.services.Constants;
 import com.mapbox.services.commons.MapboxBuilder;
 import com.mapbox.services.commons.ServicesException;
+import com.mapbox.services.commons.models.Position;
 
 import java.util.Locale;
 
@@ -131,6 +132,17 @@ public class MapboxStaticImage {
          */
         public Builder setLat(double lat) {
             this.lat = lat;
+            return this;
+        }
+
+        /**
+         * Location for the center point of the static map.
+         *
+         * @param position Position object with valid latitude and longitude values
+         */
+        public Builder setLocation(Position position) {
+            this.lat = position.getLatitude();
+            this.lon = position.getLongitude();
             return this;
         }
 

--- a/libjava/lib/src/main/java/com/mapbox/services/staticimage/v1/MapboxStaticImage.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/staticimage/v1/MapboxStaticImage.java
@@ -301,8 +301,14 @@ public class MapboxStaticImage {
                 throw new ServicesException("You need to set the map zoom level.");
             }
 
-            if (width == null || height == null) {
-                throw new ServicesException("You need to set the map width/height dimensions.");
+            if (width == null || width < 1 || width > 1280) {
+                throw new ServicesException(
+                        "You need to set a valid image width (between 1 and 1280).");
+            }
+
+            if (height == null || height < 1 || height > 1280) {
+                throw new ServicesException(
+                        "You need to set a valid image height (between 1 and 1280).");
             }
 
             return new MapboxStaticImage(this);

--- a/libjava/lib/src/test/java/com/mapbox/services/staticimage/v1/MapboxStaticImageTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/staticimage/v1/MapboxStaticImageTest.java
@@ -92,7 +92,7 @@ public class MapboxStaticImageTest {
     @Test
     public void requireWidth() throws ServicesException {
         thrown.expect(ServicesException.class);
-        thrown.expectMessage(startsWith("You need to set the map width/height dimensions."));
+        thrown.expectMessage(startsWith("You need to set a valid image width (between 1 and 1280)."));
         new MapboxStaticImage.Builder()
                 .setAccessToken("pk.")
                 .setStyleId(Constants.MAPBOX_STYLE_STREETS)
@@ -105,13 +105,27 @@ public class MapboxStaticImageTest {
     @Test
     public void requireHeight() throws ServicesException {
         thrown.expect(ServicesException.class);
-        thrown.expectMessage(startsWith("You need to set the map width/height dimensions."));
+        thrown.expectMessage(startsWith("You need to set a valid image height (between 1 and 1280)."));
         new MapboxStaticImage.Builder()
                 .setAccessToken("pk.")
                 .setStyleId(Constants.MAPBOX_STYLE_STREETS)
                 .setLat(1.0).setLon(2.0)
                 .setZoom(10)
                 .setWidth(100)
+                .build();
+    }
+
+    @Test
+    public void requireHeightInRange() throws ServicesException {
+        thrown.expect(ServicesException.class);
+        thrown.expectMessage(startsWith("You need to set a valid image height (between 1 and 1280)."));
+        new MapboxStaticImage.Builder()
+                .setAccessToken("pk.")
+                .setStyleId(Constants.MAPBOX_STYLE_STREETS)
+                .setLat(1.0).setLon(2.0)
+                .setZoom(10)
+                .setWidth(100)
+                .setHeight(5000)
                 .build();
     }
 

--- a/libjava/lib/src/test/java/com/mapbox/services/staticimage/v1/MapboxStaticImageTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/staticimage/v1/MapboxStaticImageTest.java
@@ -2,11 +2,14 @@ package com.mapbox.services.staticimage.v1;
 
 import com.mapbox.services.Constants;
 import com.mapbox.services.commons.ServicesException;
+import com.mapbox.services.commons.models.Position;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import okhttp3.HttpUrl;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class MapboxStaticImageTest {
@@ -127,6 +130,22 @@ public class MapboxStaticImageTest {
                 .setWidth(100)
                 .setHeight(5000)
                 .build();
+    }
+
+    @Test
+    public void testPrecision() throws ServicesException {
+        MapboxStaticImage client = new MapboxStaticImage.Builder()
+                .setAccessToken("pk.")
+                .setStyleId(Constants.MAPBOX_STYLE_STREETS)
+                .setLocation(Position.fromCoordinates(1.23456789, -98.76))
+                .setZoom(10).setBearing(345.67890123456789).setPitch(0.000000005)
+                .setWidth(100).setHeight(200)
+                .setPrecision(5)
+                .build();
+        HttpUrl url = client.getUrl();
+        assertEquals(
+                url.toString(),
+                "https://api.mapbox.com/styles/v1/mapbox/streets-v9/static/1.23456,-98.76000,10.00000,345.67890,0.00000/100x200?access_token=pk.");
     }
 
 }


### PR DESCRIPTION
This PR fixes three proposed improvement to the Static Image API service. Namely:

1. Provide option to specify position as Position #65
2. Validate image dimensions on value range #67
3. Add precision setter on builder #69

/cc: @ivovandongen @cammace 
