### PR TITLE
Lower api level requirement to API 14

### DIFF
--- a/libandroid/lib/build.gradle
+++ b/libandroid/lib/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "23.0.3"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 14
         targetSdkVersion 23
 
         // This should be updated together with gradle.properties


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-java/issues/126.

Note that this does not affect the TestApp, only the library, as the TestApp has API 15 requirements in LOST and the Mapbox SDK.
