### PR TITLE
added missing javadoc and fixed errors

### DIFF
--- a/libandroid/lib/src/main/java/com/mapbox/services/android/Constants.java
+++ b/libandroid/lib/src/main/java/com/mapbox/services/android/Constants.java
@@ -1,13 +1,9 @@
 package com.mapbox.services.android;
 
 /**
- * Created by antonio on 1/30/16.
+ * Namespace to avoid constants collision.
  */
 public class Constants {
-
-    /*
-     * Namespace to avoid constants collision
-     */
 
     private final static String PACKAGE_NAME = "com.mapbox.services.android";
 

--- a/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/AndroidGeocoder.java
+++ b/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/AndroidGeocoder.java
@@ -17,7 +17,11 @@ import java.util.Locale;
 import retrofit2.Response;
 
 /**
- * Created by antonio on 1/30/16.
+ * Class is used for geocoding and reverse geocoding. Modified from the android geocoder class, this
+ * class uses Mapbox Geocoder.
+ *
+ * @see <a href="https://developer.android.com/reference/android/location/Geocoder.html">Original Android Geocoder documentation</a>
+ * @since 1.0.0
  */
 public class AndroidGeocoder {
 
@@ -33,9 +37,9 @@ public class AndroidGeocoder {
      * given Locale.
      *
      * @param context the Context of the calling Activity
-     * @param locale the desired Locale for the query results
-     *
+     * @param locale  the desired Locale for the query results
      * @throws NullPointerException if Locale is null
+     * @since 1.0.0
      */
     public AndroidGeocoder(Context context, Locale locale) {
         _context = context;
@@ -47,6 +51,7 @@ public class AndroidGeocoder {
      * default system Locale.
      *
      * @param context the Context of the calling Activity
+     * @since 1.0.0
      */
     public AndroidGeocoder(Context context) {
         _context = context;
@@ -57,35 +62,36 @@ public class AndroidGeocoder {
      * getFromLocationName are implemented.  Lack of network
      * connectivity may still cause these methods to return null or
      * empty lists.
+     *
+     * @since 1.0.0
      */
     public static boolean isPresent() {
         return true;
     }
 
     /**
-     * Returns an array of Addresses that are known to describe the
+     * <p>Returns an array of Addresses that are known to describe the
      * area immediately surrounding the given latitude and longitude.
      * The returned addresses will be localized for the locale
-     * provided to this class's constructor.
+     * provided to this class's constructor.</p>
      *
-     * <p> The returned values may be obtained by means of a network lookup.
+     * <p>The returned values may be obtained by means of a network lookup.
      * The results are a best guess and are not guaranteed to be meaningful or
      * correct. It may be useful to call this method from a thread separate from your
-     * primary UI thread.
+     * primary UI thread.</p>
      *
-     * @param latitude the latitude a point for the search
-     * @param longitude the longitude a point for the search
+     * @param latitude   the latitude a point for the search
+     * @param longitude  the longitude a point for the search
      * @param maxResults max number of addresses to return. Smaller numbers (1 to 5) are recommended
-     *
      * @return a list of Address objects. Returns null or empty list if no matches were
      * found or there is no backend service available.
-     *
      * @throws IllegalArgumentException if latitude is
-     * less than -90 or greater than 90
+     *                                  less than -90 or greater than 90
      * @throws IllegalArgumentException if longitude is
-     * less than -180 or greater than 180
-     * @throws IOException if the network is unavailable or any other
-     * I/O problem occurs
+     *                                  less than -180 or greater than 180
+     * @throws IOException              if the network is unavailable or any other
+     *                                  I/O problem occurs
+     * @since 1.0.0
      */
     public List<Address> getFromLocation(double latitude, double longitude, int maxResults)
             throws IOException, ServicesException {
@@ -110,7 +116,7 @@ public class AndroidGeocoder {
         }
 
         // Convert from FeatureModel to Address
-        for (CarmenFeature feature: features) {
+        for (CarmenFeature feature : features) {
             addresses.add(GeocoderUtils.featureToAddress(feature, _locale));
         }
 
@@ -118,27 +124,26 @@ public class AndroidGeocoder {
     }
 
     /**
-     * Returns an array of Addresses that are known to describe the
+     * <p>Returns an array of Addresses that are known to describe the
      * named location, which may be a place name such as "Dalvik,
      * Iceland", an address such as "1600 Amphitheatre Parkway,
      * Mountain View, CA", an airport code such as "SFO", etc..  The
      * returned addresses will be localized for the locale provided to
-     * this class's constructor.
+     * this class's constructor.</p>
      *
      * <p> The query will block and returned values will be obtained by means of a network lookup.
      * The results are a best guess and are not guaranteed to be meaningful or
      * correct. It may be useful to call this method from a thread separate from your
-     * primary UI thread.
+     * primary UI thread.</p>
      *
      * @param locationName a user-supplied description of a location
-     * @param maxResults max number of results to return. Smaller numbers (1 to 5) are recommended
-     *
+     * @param maxResults   max number of results to return. Smaller numbers (1 to 5) are recommended
      * @return a list of Address objects. Returns null or empty list if no matches were
      * found or there is no backend service available.
-     *
      * @throws IllegalArgumentException if locationName is null
-     * @throws IOException if the network is unavailable or any other
-     * I/O problem occurs
+     * @throws IOException              if the network is unavailable or any other
+     *                                  I/O problem occurs
+     * @since 1.0.0
      */
     public List<Address> getFromLocationName(String locationName, int maxResults) throws IOException, ServicesException {
         List<Address> addresses = new ArrayList<>();
@@ -161,7 +166,7 @@ public class AndroidGeocoder {
         }
 
         // Convert from FeatureModel to Address
-        for (CarmenFeature feature: features) {
+        for (CarmenFeature feature : features) {
             addresses.add(GeocoderUtils.featureToAddress(feature, _locale));
         }
 
@@ -169,39 +174,32 @@ public class AndroidGeocoder {
     }
 
     /**
-     * Returns an array of Addresses that are known to describe the
-     * named location, which may be a place name such as "Dalvik,
-     * Iceland", an address such as "1600 Amphitheatre Parkway,
-     * Mountain View, CA", an airport code such as "SFO", etc..  The
-     * returned addresses will be localized for the locale provided to
-     * this class's constructor.
+     * <p>Returns an array of Addresses that are known to describe the named location, which may be a
+     * place name such as "Dalvik, Iceland", an address such as "1600 Amphitheatre Parkway, Mountain
+     * View, CA", an airport code such as "SFO", etc..  The returned addresses will be localized for
+     * the locale provided to this class's constructor.</p>
      *
-     * <p> You may specify a bounding box for the search results by including
-     * the Latitude and Longitude of the Lower Left point and Upper Right
-     * point of the box.
+     * <p>You may specify a bounding box for the search results by including the Latitude and Longitude
+     * of the Lower Left point and Upper Right point of the box.</p>
      *
-     * <p> The query will block and returned values will be obtained by means of a network lookup.
-     * The results are a best guess and are not guaranteed to be meaningful or
-     * correct. It may be useful to call this method from a thread separate from your
-     * primary UI thread.
+     * <p>The query will block and returned values will be obtained by means of a network lookup. The
+     * results are a best guess and are not guaranteed to be meaningful or correct. It may be useful
+     * to call this method from a thread separate from your primary UI thread.</p>
      *
-     * @param locationName a user-supplied description of a location
-     * @param maxResults max number of addresses to return. Smaller numbers (1 to 5) are recommended
-     * @param lowerLeftLatitude the latitude of the lower left corner of the bounding box
-     * @param lowerLeftLongitude the longitude of the lower left corner of the bounding box
-     * @param upperRightLatitude the latitude of the upper right corner of the bounding box
+     * @param locationName        a user-supplied description of a location
+     * @param maxResults          max number of addresses to return. Smaller numbers (1 to 5) are recommended
+     * @param lowerLeftLatitude   the latitude of the lower left corner of the bounding box
+     * @param lowerLeftLongitude  the longitude of the lower left corner of the bounding box
+     * @param upperRightLatitude  the latitude of the upper right corner of the bounding box
      * @param upperRightLongitude the longitude of the upper right corner of the bounding box
-     *
      * @return a list of Address objects. Returns null or empty list if no matches were
      * found or there is no backend service available.
-     *
-     * @throws IllegalArgumentException if locationName is null
-     * @throws IllegalArgumentException if any latitude is
-     * less than -90 or greater than 90
-     * @throws IllegalArgumentException if any longitude is
-     * less than -180 or greater than 180
-     * @throws IOException if the network is unavailable or any other
-     * I/O problem occurs
+     * @throws IllegalArgumentException if locationName is null, if any longitude is less than -180
+     *                                  or greater than 180, if any latitude is less than -90 or
+     *                                  greater than 90
+     * @throws IOException              if the network is unavailable or any other
+     *                                  I/O problem occurs
+     * @since 1.0.0
      */
     public List<Address> getFromLocationName(String locationName, int maxResults,
                                              double lowerLeftLatitude, double lowerLeftLongitude,
@@ -228,7 +226,7 @@ public class AndroidGeocoder {
 
         // Find results not contained within the bbox
         List<CarmenFeature> featuresToRemove = new ArrayList<>();
-        for (CarmenFeature feature: features) {
+        for (CarmenFeature feature : features) {
             Position featurePosition = feature.asPosition();
             if (featurePosition.getLatitude() < lowerLeftLatitude) {
                 featuresToRemove.add(feature);
@@ -241,7 +239,6 @@ public class AndroidGeocoder {
             }
         }
 
-
         // Remove features outside the bbox
         if (featuresToRemove.size() > 0) {
             features.removeAll(featuresToRemove);
@@ -253,7 +250,7 @@ public class AndroidGeocoder {
         }
 
         // Convert from FeatureModel to Address
-        for (CarmenFeature feature: features) {
+        for (CarmenFeature feature : features) {
             addresses.add(GeocoderUtils.featureToAddress(feature, _locale));
         }
 
@@ -264,8 +261,14 @@ public class AndroidGeocoder {
      * Extended API
      */
 
+    /**
+     * You'll need to have a Mapbox access token to use the geocoding API within MAS.
+     *
+     * @param accessToken Your Mapbox access token
+     * @see <a href="https://www.mapbox.com/help/define-access-token/">Mapbox access token</a>
+     * @since 1.0.0
+     */
     public void setAccessToken(String accessToken) {
         _accessToken = accessToken;
     }
-
 }

--- a/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/GeocoderUtils.java
+++ b/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/GeocoderUtils.java
@@ -8,10 +8,20 @@ import com.mapbox.services.geocoding.v5.models.CarmenFeature;
 import java.util.Locale;
 
 /**
- * Created by antonio on 1/30/16.
+ * Android Geocoder utils class used for the {@link AndroidGeocoder}.
+ *
+ * @since 1.0.0
  */
 public class GeocoderUtils {
 
+    /**
+     * Used to convert from FeatureModel to an Address.
+     *
+     * @param geocodingFeature a {@link CarmenFeature}.
+     * @param locale           {@link Locale}.
+     * @return {@link Address}
+     * @since 1.0.0
+     */
     public static Address featureToAddress(CarmenFeature geocodingFeature, Locale locale) {
         Address address = new Address(locale);
         address.setAddressLine(0, geocodingFeature.getPlaceName());
@@ -23,5 +33,4 @@ public class GeocoderUtils {
 
         return address;
     }
-
 }

--- a/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/ui/GeocoderAdapter.java
+++ b/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/ui/GeocoderAdapter.java
@@ -22,7 +22,10 @@ import java.util.List;
 import retrofit2.Response;
 
 /**
- * Created by antonio on 2/1/16.
+ * Adapter for the {@link GeocoderAutoCompleteView}. In this class we make the Mapbox Geocoding API
+ * call.
+ *
+ * @since 1.0.0
  */
 public class GeocoderAdapter extends BaseAdapter implements Filterable {
 
@@ -43,26 +46,69 @@ public class GeocoderAdapter extends BaseAdapter implements Filterable {
      * Getters and setters
      */
 
+    /**
+     * Get the access token used with making the Mapbox geocoding API call.
+     *
+     * @return String containing your Mapbox access token.
+     * @see <a href="https://www.mapbox.com/help/define-access-token/">Mapbox access token</a>
+     * @since 1.0.0
+     */
     public String getAccessToken() {
         return accessToken;
     }
 
+    /**
+     * You'll need to have a Mapbox access token to use the geocoding API within MAS.
+     *
+     * @param accessToken Your Mapbox access token
+     * @see <a href="https://www.mapbox.com/help/define-access-token/">Mapbox access token</a>
+     * @since 1.0.0
+     */
     public void setAccessToken(String accessToken) {
         this.accessToken = accessToken;
     }
 
+    /**
+     * Get the geocoder filter type.
+     *
+     * @return String containing "place", "poi", "neighborhood", etc.
+     * @see <a href="https://www.mapbox.com/api-documentation/#request-format">Geocoding API documentation</a>
+     * @since 1.0.0
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Configure the geocoder type, pass in one of the constants found within
+     * {@link com.mapbox.services.geocoding.v5.GeocodingCriteria}.
+     *
+     * @param type String containing "place", "poi", "neighborhood", etc.
+     * @see <a href="https://www.mapbox.com/api-documentation/#request-format">Geocoding API documentation</a>
+     * @since 1.0.0
+     */
     public void setType(String type) {
         this.type = type;
     }
 
+    /**
+     * Location around which to bias geocoder results.
+     *
+     * @return {@link Position} coordinate.
+     * @see <a href="https://www.mapbox.com/api-documentation/#request-format">Geocoding API documentation</a>
+     * @since 1.0.0
+     */
     public Position getProximity() {
         return position;
     }
 
+    /**
+     * Location around which to bias geocoder results.
+     *
+     * @param position {@link Position} coordinate.
+     * @see <a href="https://www.mapbox.com/api-documentation/#request-format">Geocoding API documentation</a>
+     * @since 1.0.0
+     */
     public void setProximity(Position position) {
         this.position = position;
     }
@@ -71,25 +117,55 @@ public class GeocoderAdapter extends BaseAdapter implements Filterable {
      * Required by BaseAdapter
      */
 
+    /**
+     * Gives How many items are in the data set represented by this Adapter.
+     *
+     * @return int value.
+     * @see <a href="https://developer.android.com/reference/android/widget/Adapter.html">Android Adapter</a>
+     * @since 1.0.0
+     */
     @Override
     public int getCount() {
         return features.size();
     }
 
+    /**
+     * Get the data item associated with the specified position in the data set.
+     *
+     * @param position int position within the data.
+     * @return {@link CarmenFeature}.
+     * @see <a href="https://developer.android.com/reference/android/widget/Adapter.html">Android Adapter</a>
+     * @since 1.0.0
+     */
     @Override
     public CarmenFeature getItem(int position) {
         return features.get(position);
     }
 
+    /**
+     * Get the row id associated with the specified position in the list.
+     *
+     * @param position int position within the data.
+     * @return long value
+     * @see <a href="https://developer.android.com/reference/android/widget/Adapter.html">Android Adapter</a>
+     * @since 1.0.0
+     */
     @Override
     public long getItemId(int position) {
         return position;
     }
 
-    /*
+    /**
      * Get a View that displays the data at the specified position in the data set.
+     *
+     * @param position    The position of the item within the adapter's data set of the item whose
+     *                    view we want.
+     * @param convertView The old view to reuse, if possible.
+     * @param parent      The parent that this view will eventually be attached to.
+     * @return A View corresponding to the data at the specified position.
+     * @see <a href="https://developer.android.com/reference/android/widget/Adapter.html">Android Adapter</a>
+     * @since 1.0.0
      */
-
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         // Get view
@@ -115,6 +191,13 @@ public class GeocoderAdapter extends BaseAdapter implements Filterable {
      * Required by Filterable
      */
 
+    /**
+     * Returns a filter that can be used to constrain data with a filtering pattern.
+     *
+     * @return a filter used to constrain data
+     * @see <a href="https://developer.android.com/reference/android/widget/Filterable.html">Filterable Class</a>
+     * @since 1.0.0
+     */
     @Override
     public Filter getFilter() {
         if (geocoderFilter == null) {

--- a/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/ui/GeocoderAutoCompleteView.java
+++ b/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/ui/GeocoderAutoCompleteView.java
@@ -14,7 +14,14 @@ import com.mapbox.services.geocoding.v5.models.CarmenFeature;
 import com.mapbox.services.commons.models.Position;
 
 /**
- * Created by antonio on 2/1/16.
+ * An editable text view that shows geocoder result suggestions automatically
+ * while the user is typing. The list of suggestions is displayed in a drop
+ * down menu from which the user can choose an item and you can listen to and
+ * act upon which item they chose
+ *
+ * @see <a href="https://developer.android.com/reference/android/widget/AutoCompleteTextView.html">Android AutoCompleteTextView</a>
+ * @see <a href="https://www.mapbox.com/android-sdk/examples/geocoding/">Mapbox example</a>
+ * @since 1.0.0
  */
 public class GeocoderAutoCompleteView extends AutoCompleteTextView {
 
@@ -75,18 +82,46 @@ public class GeocoderAutoCompleteView extends AutoCompleteTextView {
      * Setters
      */
 
+    /**
+     * You'll need to have a Mapbox access token to use the geocoding API within MAS.
+     *
+     * @param accessToken Your Mapbox access token
+     * @see <a href="https://www.mapbox.com/help/define-access-token/">Mapbox access token</a>
+     * @since 1.0.0
+     */
     public void setAccessToken(String accessToken) {
         adapter.setAccessToken(accessToken);
     }
 
+    /**
+     * Configure the geocoder type, pass in one of the constants found within
+     * {@link com.mapbox.services.geocoding.v5.GeocodingCriteria}.
+     *
+     * @param type String containing "place", "poi", "neighborhood", etc.
+     * @see <a href="https://www.mapbox.com/api-documentation/#request-format">Geocoding API documentation</a>
+     * @since 1.0.0
+     */
     public void setType(String type) {
         adapter.setType(type);
     }
 
+    /**
+     * Location around which to bias geocoder results.
+     *
+     * @param position {@link Position} coordinate.
+     * @see <a href="https://www.mapbox.com/api-documentation/#request-format">Geocoding API documentation</a>
+     * @since 1.0.0
+     */
     public void setProximity(Position position) {
         adapter.setProximity(position);
     }
 
+    /**
+     * Sets the listener that will be notified when the user clicks an item in the drop down list.
+     *
+     * @param onFeatureListener the item click listener.
+     * @since 1.0.0
+     */
     public void setOnFeatureListener(OnFeatureListener onFeatureListener) {
         this.onFeatureListener = onFeatureListener;
     }

--- a/libandroid/lib/src/main/java/com/mapbox/services/android/utils/PermissionsUtils.java
+++ b/libandroid/lib/src/main/java/com/mapbox/services/android/utils/PermissionsUtils.java
@@ -9,7 +9,9 @@ import android.widget.Toast;
 
 /**
  * Utilities to handle the new permission system in 6.0. Weonly focus on ACCESS_FINE_LOCATION.
- * http://developer.android.com/training/permissions/index.html
+ *
+ * @see <a href="http://developer.android.com/training/permissions/index.html">Working with System Permissions</a>
+ * @since 1.0.0
  */
 public class PermissionsUtils {
 
@@ -25,18 +27,35 @@ public class PermissionsUtils {
 
     /**
      * We only need to check for ACCESS_FINE_LOCATION as this implies ACCESS_COARSE_LOCATION:
-     * http://developer.android.com/guide/topics/location/strategies.html#Permission
-     * https://developers.google.com/maps/documentation/android-api/location?#location_permissions
+     *
+     * @param activity The activity where this is methods being used.
+     * @return boolean true if location permission has been granted.
+     * @see <a href="http://developer.android.com/guide/topics/location/strategies.html#Permission">Requesting User Permissions</a>
+     * @see <a href="https://developers.google.com/maps/documentation/android-api/location?#location_permissions">Location permissions</a>
+     * @since 1.0.0
      */
     public static boolean isLocationGranted(Activity activity) {
         int permissionCheck = ContextCompat.checkSelfPermission(activity, permission);
         return (permissionCheck == PackageManager.PERMISSION_GRANTED);
     }
 
+    /**
+     * Request user permission
+     *
+     * @param activity The activity where this is methods being used.
+     * @since 1.0.0
+     */
     public static void startPermissionFlow(Activity activity) {
         startPermissionFlow(activity, MESSAGE_RATIONALE);
     }
 
+    /**
+     * Request user permission
+     *
+     * @param activity  The activity where this is methods being used.
+     * @param rationale Defaults "MESSAGE_RATIONALE"
+     * @since 1.0.0
+     */
     public static void startPermissionFlow(Activity activity, String rationale) {
         // Should we show an explanation?
         if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
@@ -53,10 +72,20 @@ public class PermissionsUtils {
 
     private static void requestPermissions(Activity activity) {
         ActivityCompat.requestPermissions(activity,
-                new String[]{ permission },
+                new String[]{permission},
                 LOCATION_PERMISSIONS_REQUEST);
     }
 
+    /**
+     * Use this method to check if the request was successful or not.
+     *
+     * @param requestCode  The request code passed in requestPermissions(android.app.Activity, String[], int)
+     * @param permissions  The requested permissions. Never null.
+     * @param grantResults The grant results for the corresponding permissions which is either
+     *                     PERMISSION_GRANTED or PERMISSION_DENIED. Never null.
+     * @return boolean true if permission was granted.
+     * @since 1.0.0
+     */
     public static boolean isRequestSuccessful(int requestCode, String[] permissions, int[] grantResults) {
         boolean result = false;
 
@@ -73,10 +102,23 @@ public class PermissionsUtils {
         return result;
     }
 
+    /**
+     * Display to the user when their device GPS has been disabled.
+     *
+     * @param activity The activity where the message is being used.
+     * @since 1.0.0
+     */
     public static void explainFallback(Activity activity) {
         explainFallback(activity, MESSAGE_FALLBACK);
     }
 
+    /**
+     * Display to the user when their device GPS has been disabled.
+     *
+     * @param activity The activity where the message is being used.
+     * @param message  The message, should either be MESSAGE_RATIONALE or MESSAGE_FALLBACK.
+     * @since 1.0.0
+     */
     public static void explainFallback(Activity activity, String message) {
         Toast.makeText(activity, message, Toast.LENGTH_LONG).show();
     }

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/BaseFeatureCollection.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/BaseFeatureCollection.java
@@ -8,6 +8,8 @@ import com.mapbox.services.commons.models.Position;
 
 /**
  * Shared by FeatureCollection and CarmenFeatureCollection
+ *
+ * @since 1.0.0
  */
 public class BaseFeatureCollection implements GeoJSON {
 
@@ -17,6 +19,7 @@ public class BaseFeatureCollection implements GeoJSON {
      * Should always be "FeatureCollection".
      *
      * @return String "FeatureCollection".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -28,6 +31,7 @@ public class BaseFeatureCollection implements GeoJSON {
      *
      * @param json String of JSON making up a feature collection.
      * @return {@link FeatureCollection} GeoJSON object.
+     * @since 1.0.0
      */
     public static FeatureCollection fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -40,6 +44,7 @@ public class BaseFeatureCollection implements GeoJSON {
      * Convert feature collection into JSON.
      *
      * @return String containing feature collection JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Feature.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Feature.java
@@ -12,6 +12,7 @@ import com.mapbox.services.commons.models.Position;
  * A GeoJSON object with the type "Feature" is a feature object.
  *
  * @see <a href='geojson.org/geojson-spec.html#feature-objects'>Official GeoJSON Feature Specifications</a>
+ * @since 1.0.0
  */
 public class Feature implements GeoJSON {
 
@@ -26,6 +27,7 @@ public class Feature implements GeoJSON {
      * @param geometry   {@link Geometry} object.
      * @param properties of this feature as JSON.
      * @param id         common identifier of this feature.
+     * @since 1.0.0
      */
     protected Feature(Geometry geometry, JsonObject properties, String id) {
         this.geometry = geometry;
@@ -37,6 +39,7 @@ public class Feature implements GeoJSON {
      * Should always be "Feature".
      *
      * @return String "Feature".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -47,6 +50,7 @@ public class Feature implements GeoJSON {
      * Get the features {@link Geometry}.
      *
      * @return {@link Geometry} of the feature or null if not set.
+     * @since 1.0.0
      */
     public Geometry getGeometry() {
         return geometry;
@@ -56,6 +60,7 @@ public class Feature implements GeoJSON {
      * Returns the optional properties of this feature as JSON.
      *
      * @return the properties of this feature
+     * @since 1.0.0
      */
     public JsonObject getProperties() {
         if (properties == null) properties = new JsonObject();
@@ -70,6 +75,7 @@ public class Feature implements GeoJSON {
      * The optional, common identifier of this feature.
      *
      * @return The common identifier of this feature, if set.
+     * @since 1.0.0
      */
     public String getId() {
         return id;
@@ -79,6 +85,7 @@ public class Feature implements GeoJSON {
      * Create a feature from geometry.
      *
      * @param geometry {@link Geometry} object.
+     * @since 1.0.0
      */
     public static Feature fromGeometry(Geometry geometry) {
         return new Feature(geometry, null, null);
@@ -89,6 +96,7 @@ public class Feature implements GeoJSON {
      *
      * @param geometry   {@link Geometry} object.
      * @param properties of this feature as JSON.
+     * @since 1.0.0
      */
     public static Feature fromGeometry(Geometry geometry, JsonObject properties) {
         return new Feature(geometry, properties, null);
@@ -100,6 +108,7 @@ public class Feature implements GeoJSON {
      * @param geometry   {@link Geometry} object.
      * @param properties of this feature as JSON.
      * @param id         common identifier of this feature.
+     * @since 1.0.0
      */
     public static Feature fromGeometry(Geometry geometry, JsonObject properties, String id) {
         return new Feature(geometry, properties, id);
@@ -110,6 +119,7 @@ public class Feature implements GeoJSON {
      *
      * @param json String of JSON making up a feature.
      * @return {@link Feature} GeoJSON object.
+     * @since 1.0.0
      */
     public static Feature fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -122,6 +132,7 @@ public class Feature implements GeoJSON {
      * Convert feature into JSON.
      *
      * @return String containing feature JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {
@@ -132,8 +143,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to add a String member.
-     * @param key name of the member
+     *
+     * @param key   name of the member
      * @param value the String value associated with the member
+     * @since 1.0.0
      */
     public void addStringProperty(String key, String value) {
         getProperties().addProperty(key, value);
@@ -141,8 +154,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to add a Number member.
-     * @param key name of the member
+     *
+     * @param key   name of the member
      * @param value the Number value associated with the member
+     * @since 1.0.0
      */
     public void addNumberProperty(String key, Number value) {
         getProperties().addProperty(key, value);
@@ -150,8 +165,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to add a Boolean member.
-     * @param key name of the member
+     *
+     * @param key   name of the member
      * @param value the Boolean value associated with the member
+     * @since 1.0.0
      */
     public void addBooleanProperty(String key, Boolean value) {
         getProperties().addProperty(key, value);
@@ -159,8 +176,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to add a Character member.
-     * @param key name of the member
+     *
+     * @param key   name of the member
      * @param value the Character value associated with the member
+     * @since 1.0.0
      */
     public void addCharacterProperty(String key, Character value) {
         getProperties().addProperty(key, value);
@@ -168,8 +187,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to add a JsonElement member.
-     * @param key name of the member
+     *
+     * @param key   name of the member
      * @param value the JsonElement value associated with the member
+     * @since 1.0.0
      */
     public void addProperty(String key, JsonElement value) {
         getProperties().add(key, value);
@@ -177,8 +198,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to get a String member.
+     *
      * @param key name of the member
      * @return the value of the member, null if it doesn't exist
+     * @since 1.0.0
      */
     public String getStringProperty(String key) {
         return getProperties().get(key).getAsString();
@@ -186,8 +209,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to get a Number member.
+     *
      * @param key name of the member
      * @return the value of the member, null if it doesn't exist
+     * @since 1.0.0
      */
     public Number getNumberProperty(String key) {
         return getProperties().get(key).getAsNumber();
@@ -195,8 +220,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to get a Boolean member.
+     *
      * @param key name of the member
      * @return the value of the member, null if it doesn't exist
+     * @since 1.0.0
      */
     public Boolean getBooleanProperty(String key) {
         return getProperties().get(key).getAsBoolean();
@@ -204,8 +231,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to get a Character member.
+     *
      * @param key name of the member
      * @return the value of the member, null if it doesn't exist
+     * @since 1.0.0
      */
     public Character getCharacterProperty(String key) {
         return getProperties().get(key).getAsCharacter();
@@ -213,8 +242,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to get a JsonElement member.
+     *
      * @param key name of the member
      * @return the value of the member, null if it doesn't exist
+     * @since 1.0.0
      */
     public JsonElement getProperty(String key) {
         return getProperties().get(key);
@@ -222,8 +253,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Removes the property from the object properties
+     *
      * @param key name of the member
-     * @return
+     * @return Removed {@code property} from the key string passed in through the parameter.
+     * @since 1.0.0
      */
     public JsonElement removeProperty(String key) {
         return getProperties().remove(key);
@@ -231,8 +264,10 @@ public class Feature implements GeoJSON {
 
     /**
      * Convenience method to check if a member with the specified name is present in this object.
-     * @param key
-     * @return
+     *
+     * @param key name of the member
+     * @return true if there is the member has the specified name, false otherwise.
+     * @since 1.0.0
      */
     public boolean hasProperty(String key) {
         return getProperties().has(key);

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/FeatureCollection.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/FeatureCollection.java
@@ -7,6 +7,7 @@ import java.util.List;
  * collection of feature objects.
  *
  * @see <a href='geojson.org/geojson-spec.html#feature-collection-objects'>Official GeoJSON FeatureCollection Specifications</a>
+ * @since 1.0.0
  */
 public class FeatureCollection extends BaseFeatureCollection {
 
@@ -18,6 +19,7 @@ public class FeatureCollection extends BaseFeatureCollection {
      * the deserialization of the Map Matching service response.
      *
      * @param features List of {@link Feature}.
+     * @since 1.0.0
      */
     protected FeatureCollection(List<Feature> features) {
         this.features = features;
@@ -27,6 +29,7 @@ public class FeatureCollection extends BaseFeatureCollection {
      * Get the List containing all the features within collection.
      *
      * @return List of features within collection.
+     * @since 1.0.0
      */
     public List<Feature> getFeatures() {
         return features;
@@ -37,6 +40,7 @@ public class FeatureCollection extends BaseFeatureCollection {
      *
      * @param features List of {@link Feature}
      * @return new {@link FeatureCollection}
+     * @since 1.0.0
      */
     public static FeatureCollection fromFeatures(List<Feature> features) {
         return new FeatureCollection(features);

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/GeoJSON.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/GeoJSON.java
@@ -2,10 +2,13 @@ package com.mapbox.services.commons.geojson;
 
 /**
  * Interface implemented by all GeoJSON objects, contains common fields.
+ *
+ * @since 1.0.0
  */
 public interface GeoJSON {
 
     String getType();
+
     String toJson();
 
 }

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Geometry.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Geometry.java
@@ -2,11 +2,14 @@ package com.mapbox.services.commons.geojson;
 
 /**
  * Interface implemented by all Geometry objects, contains common fields.
+ *
  * @param <T> the type of the coordinates, normally a list interface of positions.
+ * @since 1.0.0
  */
 public interface Geometry<T> extends GeoJSON {
 
     T getCoordinates();
+
     void setCoordinates(T coordinates);
 
 }

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/GeometryCollection.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/GeometryCollection.java
@@ -13,6 +13,7 @@ import java.util.List;
  * collection of geometry objects.
  *
  * @see <a href='geojson.org/geojson-spec.html#geometry-collection'>Official GeoJSON GeometryCollection Specifications</a>
+ * @since 1.0.0
  */
 public class GeometryCollection implements GeoJSON {
 
@@ -23,6 +24,7 @@ public class GeometryCollection implements GeoJSON {
      * Private constructor.
      *
      * @param geometries List of {@link Geometry}.
+     * @since 1.0.0
      */
     public GeometryCollection(List<com.mapbox.services.commons.geojson.Geometry> geometries) {
         this.geometries = geometries;
@@ -32,6 +34,7 @@ public class GeometryCollection implements GeoJSON {
      * Should always be "GeometryCollection".
      *
      * @return String "GeometryCollection".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -42,6 +45,7 @@ public class GeometryCollection implements GeoJSON {
      * Get the List containing all the geometries within collection.
      *
      * @return List of geometries within collection.
+     * @since 1.0.0
      */
     public List<com.mapbox.services.commons.geojson.Geometry> getGeometries() {
         return geometries;
@@ -52,6 +56,7 @@ public class GeometryCollection implements GeoJSON {
      *
      * @param geometries List of {@link Geometry}
      * @return new {@link GeometryCollection}
+     * @since 1.0.0
      */
     public static GeometryCollection fromGeometries(List<com.mapbox.services.commons.geojson.Geometry> geometries) {
         return new GeometryCollection(geometries);
@@ -62,6 +67,7 @@ public class GeometryCollection implements GeoJSON {
      *
      * @param json String of JSON making up a geometry collection.
      * @return {@link GeometryCollection} GeoJSON object.
+     * @since 1.0.0
      */
     public static GeometryCollection fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -74,6 +80,7 @@ public class GeometryCollection implements GeoJSON {
      * Convert geometry collection into JSON.
      *
      * @return String containing geometry collection JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/LineString.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/LineString.java
@@ -12,6 +12,7 @@ import java.util.List;
  * A LineString is a type of {@link Geometry}.
  *
  * @see <a href='geojson.org/geojson-spec.html#linestring'>Official GeoJSON LineString Specifications</a>
+ * @since 1.0.0
  */
 public class LineString implements Geometry<List<Position>> {
 
@@ -22,6 +23,7 @@ public class LineString implements Geometry<List<Position>> {
      * Private constructor.
      *
      * @param coordinates List of {@link Position} making up the LineString.
+     * @since 1.0.0
      */
     private LineString(List<Position> coordinates) {
         this.coordinates = coordinates;
@@ -31,6 +33,7 @@ public class LineString implements Geometry<List<Position>> {
      * Should always be "LineString".
      *
      * @return String "LineString".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -41,6 +44,7 @@ public class LineString implements Geometry<List<Position>> {
      * Get the list of {@link Position} making up the LineString.
      *
      * @return List of {@link Position}.
+     * @since 1.0.0
      */
     @Override
     public List<Position> getCoordinates() {
@@ -57,6 +61,7 @@ public class LineString implements Geometry<List<Position>> {
      *
      * @param coordinates List of {@link Position} coordinates.
      * @return {@link LineString}.
+     * @since 1.0.0
      */
     public static LineString fromCoordinates(List<Position> coordinates) {
         return new LineString(coordinates);
@@ -67,6 +72,7 @@ public class LineString implements Geometry<List<Position>> {
      *
      * @param json String of JSON making up a LineString.
      * @return {@link LineString} GeoJSON object.
+     * @since 1.0.0
      */
     public static LineString fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -78,6 +84,7 @@ public class LineString implements Geometry<List<Position>> {
      * Convert feature into JSON.
      *
      * @return String containing LineString JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {
@@ -89,14 +96,22 @@ public class LineString implements Geometry<List<Position>> {
     /**
      * Convert a polyline into a LineString.
      *
-     * @param polyline String describing a polyline.
+     * @param polyline  String describing a polyline.
      * @param precision The encoded precision, for example Constants.OSRM_PRECISION_V4.
-     * @return
+     * @return {@link LineString} containing the geometric structure of our polyline.
+     * @since 1.0.0
      */
     public static LineString fromPolyline(String polyline, int precision) {
         return new LineString(PolylineUtils.decode(polyline, precision));
     }
 
+    /**
+     * Convert the sequence of coordinates into an encoded path string.
+     *
+     * @param precision The encoded precision, for example Constants.OSRM_PRECISION_V4.
+     * @return a string describing the geometry of polyline.
+     * @since 1.0.0
+     */
     public String toPolyline(int precision) {
         return PolylineUtils.encode(getCoordinates(), precision);
     }

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/MultiLineString.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/MultiLineString.java
@@ -11,6 +11,7 @@ import java.util.List;
  * A MultiLineString is a type of {@link Geometry}.
  *
  * @see <a href='http://geojson.org/geojson-spec.html#multilinestringn'>Official GeoJSON MultiLineString Specifications</a>
+ * @since 1.0.0
  */
 public class MultiLineString implements Geometry<List<List<Position>>> {
 
@@ -21,6 +22,7 @@ public class MultiLineString implements Geometry<List<List<Position>>> {
      * Private constructor.
      *
      * @param coordinates List of {@link Position} making up the MultiLineString.
+     * @since 1.0.0
      */
     private MultiLineString(List<List<Position>> coordinates) {
         this.coordinates = coordinates;
@@ -30,6 +32,7 @@ public class MultiLineString implements Geometry<List<List<Position>>> {
      * Should always be "MultiLineString".
      *
      * @return String "MultiLineString".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -40,6 +43,7 @@ public class MultiLineString implements Geometry<List<List<Position>>> {
      * Get the list of {@link Position} making up the MultiLineString.
      *
      * @return List of {@link Position}.
+     * @since 1.0.0
      */
     @Override
     public List<List<Position>> getCoordinates() {
@@ -56,6 +60,7 @@ public class MultiLineString implements Geometry<List<List<Position>>> {
      *
      * @param coordinates List of {@link Position} coordinates.
      * @return {@link MultiLineString}.
+     * @since 1.0.0
      */
     public static MultiLineString fromCoordinates(List<List<Position>> coordinates) {
         return new MultiLineString(coordinates);
@@ -66,6 +71,7 @@ public class MultiLineString implements Geometry<List<List<Position>>> {
      *
      * @param json String of JSON making up a MultiLineString.
      * @return {@link MultiLineString} GeoJSON object.
+     * @since 1.0.0
      */
     public static MultiLineString fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -77,6 +83,7 @@ public class MultiLineString implements Geometry<List<List<Position>>> {
      * Convert feature into JSON.
      *
      * @return String containing MultiLineString JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/MultiPoint.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/MultiPoint.java
@@ -11,6 +11,7 @@ import java.util.List;
  * A MultiPoint is a type of {@link Geometry}.
  *
  * @see <a href='http://geojson.org/geojson-spec.html#multipoint'>Official GeoJSON MultiPoint Specifications</a>
+ * @since 1.0.0
  */
 public class MultiPoint implements Geometry<List<Position>> {
 
@@ -21,6 +22,7 @@ public class MultiPoint implements Geometry<List<Position>> {
      * Private constructor.
      *
      * @param coordinates List of {@link Position} making up the MultiPoint.
+     * @since 1.0.0
      */
     private MultiPoint(List<Position> coordinates) {
         this.coordinates = coordinates;
@@ -30,6 +32,7 @@ public class MultiPoint implements Geometry<List<Position>> {
      * Should always be "MultiPoint".
      *
      * @return String "MultiPoint".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -40,6 +43,7 @@ public class MultiPoint implements Geometry<List<Position>> {
      * Get the list of {@link Position} making up the MultiPoint.
      *
      * @return List of {@link Position}.
+     * @since 1.0.0
      */
     @Override
     public List<Position> getCoordinates() {
@@ -56,6 +60,7 @@ public class MultiPoint implements Geometry<List<Position>> {
      *
      * @param coordinates List of {@link Position} coordinates.
      * @return {@link MultiPoint}.
+     * @since 1.0.0
      */
     public static MultiPoint fromCoordinates(List<Position> coordinates) {
         return new MultiPoint(coordinates);
@@ -66,6 +71,7 @@ public class MultiPoint implements Geometry<List<Position>> {
      *
      * @param json String of JSON making up a MultiPoint.
      * @return {@link MultiPoint} GeoJSON object.
+     * @since 1.0.0
      */
     public static MultiPoint fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -77,6 +83,7 @@ public class MultiPoint implements Geometry<List<Position>> {
      * Convert feature into JSON.
      *
      * @return String containing MultiPoint JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/MultiPolygon.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/MultiPolygon.java
@@ -11,6 +11,7 @@ import java.util.List;
  * A MultiPolygon is a type of {@link Geometry}.
  *
  * @see <a href='http://geojson.org/geojson-spec.html#multipolygon'>Official GeoJSON MultiPolygon Specifications</a>
+ * @since 1.0.0
  */
 public class MultiPolygon implements Geometry<List<List<List<Position>>>> {
 
@@ -21,6 +22,7 @@ public class MultiPolygon implements Geometry<List<List<List<Position>>>> {
      * Private constructor.
      *
      * @param coordinates List of {@link Position} making up the MultiPolygon.
+     * @since 1.0.0
      */
     private MultiPolygon(List<List<List<Position>>> coordinates) {
         this.coordinates = coordinates;
@@ -30,6 +32,7 @@ public class MultiPolygon implements Geometry<List<List<List<Position>>>> {
      * Should always be "MultiPolygon".
      *
      * @return String "MultiPolygon".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -40,6 +43,7 @@ public class MultiPolygon implements Geometry<List<List<List<Position>>>> {
      * Get the list of {@link Position} making up the MultiPolygon.
      *
      * @return List of {@link Position}.
+     * @since 1.0.0
      */
     @Override
     public List<List<List<Position>>> getCoordinates() {
@@ -56,6 +60,7 @@ public class MultiPolygon implements Geometry<List<List<List<Position>>>> {
      *
      * @param coordinates List of {@link Position} coordinates.
      * @return {@link MultiPolygon}.
+     * @since 1.0.0
      */
     public static MultiPolygon fromCoordinates(List<List<List<Position>>> coordinates) {
         return new MultiPolygon(coordinates);
@@ -66,6 +71,7 @@ public class MultiPolygon implements Geometry<List<List<List<Position>>>> {
      *
      * @param json String of JSON making up a MultiPolygon.
      * @return {@link MultiPolygon} GeoJSON object.
+     * @since 1.0.0
      */
     public static MultiPolygon fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -77,6 +83,7 @@ public class MultiPolygon implements Geometry<List<List<List<Position>>>> {
      * Convert feature into JSON.
      *
      * @return String containing MultiPolygon JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Point.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Point.java
@@ -9,6 +9,7 @@ import com.mapbox.services.commons.models.Position;
  * A Point is a type of {@link Geometry}.
  *
  * @see <a href='http://geojson.org/geojson-spec.html#point'>Official GeoJSON Point Specifications</a>
+ * @since 1.0.0
  */
 public class Point implements Geometry<Position> {
 
@@ -19,6 +20,7 @@ public class Point implements Geometry<Position> {
      * Private constructor.
      *
      * @param coordinates {@link Position} making up the Point.
+     * @since 1.0.0
      */
     private Point(Position coordinates) {
         this.coordinates = coordinates;
@@ -28,6 +30,7 @@ public class Point implements Geometry<Position> {
      * Should always be "Point".
      *
      * @return String "Point".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -38,6 +41,7 @@ public class Point implements Geometry<Position> {
      * Get the {@link Position} making up the Point.
      *
      * @return {@link Position} making up the Point.
+     * @since 1.0.0
      */
     @Override
     public Position getCoordinates() {
@@ -54,6 +58,7 @@ public class Point implements Geometry<Position> {
      *
      * @param coordinates {@link Position} where point should be located.
      * @return {@link Point}.
+     * @since 1.0.0
      */
     public static Point fromCoordinates(Position coordinates) {
         return new Point(coordinates);
@@ -64,6 +69,7 @@ public class Point implements Geometry<Position> {
      *
      * @param json String of JSON making up a Point.
      * @return {@link Point} GeoJSON object.
+     * @since 1.0.0
      */
     public static Point fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -75,6 +81,7 @@ public class Point implements Geometry<Position> {
      * Convert feature into JSON.
      *
      * @return String containing Point JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Polygon.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Polygon.java
@@ -11,6 +11,7 @@ import java.util.List;
  * A Polygon is a type of {@link Geometry}.
  *
  * @see <a href='http://geojson.org/geojson-spec.html#polygon'>Official GeoJSON Polygon Specifications</a>
+ * @since 1.0.0
  */
 public class Polygon implements Geometry<List<List<Position>>> {
 
@@ -21,6 +22,7 @@ public class Polygon implements Geometry<List<List<Position>>> {
      * Private constructor.
      *
      * @param coordinates List of {@link Position} making up the Polygon.
+     * @since 1.0.0
      */
     private Polygon(List<List<Position>> coordinates) {
         this.coordinates = coordinates;
@@ -30,6 +32,7 @@ public class Polygon implements Geometry<List<List<Position>>> {
      * Should always be "Polygon".
      *
      * @return String "Polygon".
+     * @since 1.0.0
      */
     @Override
     public String getType() {
@@ -40,6 +43,7 @@ public class Polygon implements Geometry<List<List<Position>>> {
      * Get the list of {@link Position} making up the Polygon.
      *
      * @return List of {@link Position}.
+     * @since 1.0.0
      */
     @Override
     public List<List<Position>> getCoordinates() {
@@ -56,6 +60,7 @@ public class Polygon implements Geometry<List<List<Position>>> {
      *
      * @param coordinates List of {@link Position} coordinates.
      * @return {@link Polygon}.
+     * @since 1.0.0
      */
     public static Polygon fromCoordinates(List<List<Position>> coordinates) {
         return new Polygon(coordinates);
@@ -66,6 +71,7 @@ public class Polygon implements Geometry<List<List<Position>>> {
      *
      * @param json String of JSON making up a Polygon.
      * @return {@link Polygon} GeoJSON object.
+     * @since 1.0.0
      */
     public static Polygon fromJson(String json) {
         GsonBuilder gson = new GsonBuilder();
@@ -77,6 +83,7 @@ public class Polygon implements Geometry<List<List<Position>>> {
      * Convert feature into JSON.
      *
      * @return String containing Polygon JSON.
+     * @since 1.0.0
      */
     @Override
     public String toJson() {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/GeometryDeserializer.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/GeometryDeserializer.java
@@ -11,9 +11,24 @@ import java.lang.reflect.Type;
 /**
  * Required to handle the "Unable to invoke no-args constructor for interface {@link Geometry} error
  * that Gson shows when trying to deserialize a list of {@link Geometry}.
+ *
+ * @since 1.0.0
  */
 public class GeometryDeserializer implements JsonDeserializer<Geometry> {
 
+    /**
+     * Required to handle the "Unable to invoke no-args constructor for interface {@link Geometry}
+     * error that Gson shows when trying to deserialize a list of {@link Geometry}.
+     *
+     * @param json    A class representing an element of Json.
+     * @param typeOfT Common superinterface for all types in the Java.
+     * @param context Context for deserialization that is passed to a custom deserializer during
+     *                invocation of its {@link JsonDeserializer#deserialize(JsonElement, Type,
+     *                JsonDeserializationContext)} method.
+     * @return either default deserialization on the specified object or JsonParseException.
+     * @throws JsonParseException
+     * @since 1.0.0
+     */
     @Override
     public Geometry deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         // Find the actual class name from the type property in the JSON.

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/PositionDeserializer.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/PositionDeserializer.java
@@ -12,9 +12,24 @@ import java.lang.reflect.Type;
 /**
  * Required to handle the "Expected BEGIN_OBJECT but was BEGIN_ARRAY" error that Gson would show
  * otherwise.
+ *
+ * @since 1.0.0
  */
 public class PositionDeserializer implements JsonDeserializer<Position> {
 
+    /**
+     * Required to handle the "Expected BEGIN_OBJECT but was BEGIN_ARRAY" error that Gson would show
+     * otherwise.
+     *
+     * @param json    A class representing an element of Json.
+     * @param typeOfT Common superinterface for all types in the Java.
+     * @param context Context for deserialization that is passed to a custom deserializer during
+     *                invocation of its {@link JsonDeserializer#deserialize(JsonElement, Type,
+     *                JsonDeserializationContext)} method.
+     * @return Either {@link Position} with an altitude or one that doesn't.
+     * @throws JsonParseException
+     * @since 1.0.0
+     */
     @Override
     public Position deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         JsonArray rawCoordinates = json.getAsJsonArray();

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/PositionSerializer.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/PositionSerializer.java
@@ -1,6 +1,8 @@
 package com.mapbox.services.commons.geojson.custom;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
@@ -12,9 +14,24 @@ import java.lang.reflect.Type;
 /**
  * Required to handle the special case where the altitude might be a Double.NaN, which isn't a valid
  * double value as per JSON specification.
+ *
+ * @since 1.0.0
  */
 public class PositionSerializer implements JsonSerializer<Position> {
 
+    /**
+     * Required to handle the special case where the altitude might be a Double.NaN, which isn't a
+     * valid double value as per JSON specification.
+     *
+     * @param src       A {@link Position} defined by a longitude, latitude, and optionally, an
+     *                  altitude.
+     * @param typeOfSrc Common superinterface for all types in the Java.
+     * @param context   Context for deserialization that is passed to a custom deserializer during
+     *                  invocation of its {@link JsonDeserializer#deserialize(JsonElement, Type,
+     *                  JsonDeserializationContext)} method.
+     * @return a JsonArray containing the raw coordinates.
+     * @since 1.0.0
+     */
     @Override
     public JsonElement serialize(Position src, Type typeOfSrc, JsonSerializationContext context) {
         JsonArray rawCoordinates = new JsonArray();

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/models/package-info.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/models/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the Mapbox Java Services classes.
+ */
+package com.mapbox.services.commons.turf.models;

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/package-info.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the Mapbox Java Services classes.
+ */
+package com.mapbox.services.commons.turf;

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/gson/package-info.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/gson/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the Mapbox Java Services classes.
+ */
+package com.mapbox.services.geocoding.v5.gson;

--- a/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/gson/package-info.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/gson/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the Mapbox Java Services classes.
+ */
+package com.mapbox.services.mapmatching.v4.gson;

--- a/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/models/package-info.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/models/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the Mapbox Java Services classes.
+ */
+package com.mapbox.services.mapmatching.v4.models;

--- a/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/package-info.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the Mapbox Java Services classes.
+ */
+package com.mapbox.services.mapmatching.v4;


### PR DESCRIPTION
Only outputting 5 warnings now for libandroid javadoc:

```
/Users/cameron/Mapbox/mapbox-java/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/ui/GeocoderAutoCompleteView.java:12: error: cannot find symbol
import com.mapbox.services.android.R;
                                  ^
  symbol:   class R
  location: package com.mapbox.services.android
/Users/cameron/Mapbox/mapbox-java/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/AndroidGeocoder.java:68: warning: no @return
    public static boolean isPresent() {
                          ^
/Users/cameron/Mapbox/mapbox-java/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/AndroidGeocoder.java:96: warning: no @throws for com.mapbox.services.commons.ServicesException
    public List<Address> getFromLocation(double latitude, double longitude, int maxResults)
                         ^
/Users/cameron/Mapbox/mapbox-java/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/AndroidGeocoder.java:148: warning: no @throws for com.mapbox.services.commons.ServicesException
    public List<Address> getFromLocationName(String locationName, int maxResults) throws IOException, ServicesException {
                         ^
/Users/cameron/Mapbox/mapbox-java/libandroid/lib/src/main/java/com/mapbox/services/android/geocoder/AndroidGeocoder.java:204: warning: no @throws for com.mapbox.services.commons.ServicesException
    public List<Address> getFromLocationName(String locationName, int maxResults,
                         ^
:lib:javadocrelease
5 warnings

BUILD SUCCESSFUL
```

related issue: #121 
cc: @zugaldia 