### PR TITLE
Javadoc added and fixed

### DIFF
--- a/libjava/lib/build.gradle
+++ b/libjava/lib/build.gradle
@@ -16,5 +16,11 @@ dependencies {
     testCompile 'com.squareup.okhttp3:mockwebserver:3.3.1'
 }
 
+task JavadocGeneration(type: Javadoc) {
+    source = sourceSets.main.allJava
+    failOnError = false
+    classpath = configurations.compile
+}
+
 apply from: 'gradle-checkstyle.gradle'
 apply from: 'gradle-mvn-push.gradle'

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/MapboxBuilder.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/MapboxBuilder.java
@@ -15,7 +15,7 @@ public abstract class MapboxBuilder {
      * Method to validate a Mapbox Access token.
      *
      * @param accessToken A string containing a Mapbox Access Token
-     * @throws ServicesException
+     * @throws ServicesException Generic Exception for all things Mapbox.
      * @since 1.0.0
      */
     protected void validateAccessToken(String accessToken) throws ServicesException {
@@ -29,7 +29,7 @@ public abstract class MapboxBuilder {
      * The builder.
      *
      * @return {@link MapboxBuilder}
-     * @throws ServicesException
+     * @throws ServicesException Generic Exception for all things Mapbox.
      * @since 1.0.0
      */
     public abstract Object build() throws ServicesException;

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/ServicesException.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/ServicesException.java
@@ -1,7 +1,8 @@
 package com.mapbox.services.commons;
 
 /**
- * Generic Exception for all things directions
+ * Generic Exception for all things Mapbox, this is used for geocoding, directions, and other APIs
+ * in this SDK.
  */
 public class ServicesException extends Exception {
 

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Feature.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Feature.java
@@ -85,6 +85,7 @@ public class Feature implements GeoJSON {
      * Create a feature from geometry.
      *
      * @param geometry {@link Geometry} object.
+     * @return {@link Feature}
      * @since 1.0.0
      */
     public static Feature fromGeometry(Geometry geometry) {
@@ -96,6 +97,7 @@ public class Feature implements GeoJSON {
      *
      * @param geometry   {@link Geometry} object.
      * @param properties of this feature as JSON.
+     * @return {@link Feature}
      * @since 1.0.0
      */
     public static Feature fromGeometry(Geometry geometry, JsonObject properties) {
@@ -108,6 +110,7 @@ public class Feature implements GeoJSON {
      * @param geometry   {@link Geometry} object.
      * @param properties of this feature as JSON.
      * @param id         common identifier of this feature.
+     * @return {@link Feature}
      * @since 1.0.0
      */
     public static Feature fromGeometry(Geometry geometry, JsonObject properties, String id) {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/GeometryDeserializer.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/GeometryDeserializer.java
@@ -26,7 +26,8 @@ public class GeometryDeserializer implements JsonDeserializer<Geometry> {
      *                invocation of its {@link JsonDeserializer#deserialize(JsonElement, Type,
      *                JsonDeserializationContext)} method.
      * @return either default deserialization on the specified object or JsonParseException.
-     * @throws JsonParseException
+     * @throws JsonParseException This exception is raised if there is a serious issue that occurs
+     *                            during parsing of a Json string.
      * @since 1.0.0
      */
     @Override

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/PositionDeserializer.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/custom/PositionDeserializer.java
@@ -27,7 +27,8 @@ public class PositionDeserializer implements JsonDeserializer<Position> {
      *                invocation of its {@link JsonDeserializer#deserialize(JsonElement, Type,
      *                JsonDeserializationContext)} method.
      * @return Either {@link Position} with an altitude or one that doesn't.
-     * @throws JsonParseException
+     * @throws JsonParseException This exception is raised if there is a serious issue that occurs
+     *                            during parsing of a Json string.
      * @since 1.0.0
      */
     @Override

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/models/Position.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/models/Position.java
@@ -76,6 +76,7 @@ public class Position {
      * @param longitude double longitude value.
      * @param latitude  double latitude value.
      * @param altitude  double altitude value.
+     * @return {@link Position}.
      * @since 1.0.0
      */
     public static Position fromCoordinates(double longitude, double latitude, double altitude) {
@@ -87,6 +88,7 @@ public class Position {
      *
      * @param longitude double longitude value.
      * @param latitude  double latitude value.
+     * @return {@link Position}.
      * @since 1.0.0
      */
     public static Position fromCoordinates(double longitude, double latitude) {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfGrids.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfGrids.java
@@ -23,7 +23,7 @@ public class TurfGrids {
      * @param points   input points.
      * @param polygons input polygons.
      * @return points that land within at least one polygon.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @since 2.0.0
      */
     public static FeatureCollection within(FeatureCollection points, FeatureCollection polygons) throws TurfException {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfHelpers.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfHelpers.java
@@ -35,7 +35,7 @@ public class TurfHelpers {
      *
      * @param radians Double representing a radian value.
      * @return Converted radian to distance value.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @since 1.2.0
      */
     public static double radiansToDistance(double radians) throws TurfException {
@@ -48,7 +48,7 @@ public class TurfHelpers {
      * @param radians Double representing a radian value.
      * @param units   Pass in the units you'd like to use.
      * @return Converted radian to distance value.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @since 1.2.0
      */
     public static double radiansToDistance(double radians, String units) throws TurfException {
@@ -65,7 +65,7 @@ public class TurfHelpers {
      *
      * @param distance Double representing a distance value.
      * @return Converted distance to radians value.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @since 1.2.0
      */
     public static double distanceToRadians(double distance) throws TurfException {
@@ -78,7 +78,7 @@ public class TurfHelpers {
      * @param distance Double representing a distance value.
      * @param units    Pass in the units you'd like to use.
      * @return Converted distance to radians value.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @since 1.2.0
      */
     public static double distanceToRadians(double distance, String units) throws TurfException {

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfInvariant.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfInvariant.java
@@ -22,7 +22,7 @@ public class TurfInvariant {
      *
      * @param obj any value
      * @return A coordinate
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#getcoord">Turf getCoord documentation</a>
      * @since 1.2.0
      */
@@ -46,7 +46,7 @@ public class TurfInvariant {
      * @param value Any GeoJSON object.
      * @param type  Type expected GeoJSON type.
      * @param name  Name of calling function.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#geojsontype">Turf geojsonType documentation</a>
      * @since 1.2.0
      */
@@ -68,7 +68,7 @@ public class TurfInvariant {
      * @param feature A feature with an expected geometry type.
      * @param type    Type expected GeoJSON type.
      * @param name    Name of calling function.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#featureof">Turf featureOf documentation</a>
      * @since 1.2.0
      */
@@ -94,7 +94,7 @@ public class TurfInvariant {
      * @param featurecollection A {@link FeatureCollection} for which features will be judged
      * @param type              Expected GeoJSON type.
      * @param name              Name of calling function.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#collectionof">Turf collectionOf documentation</a>
      * @since 1.2.0
      */

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfJoins.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfJoins.java
@@ -24,7 +24,7 @@ public class TurfJoins {
      * @param point   input position.
      * @param polygon input list of positions making up the polygon.
      * @return True if the Point is inside the Polygon; false if the Point is not inside the Polygon.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#inside">Turf Inside documentation</a>
      * @since 2.0.0
      */
@@ -42,7 +42,7 @@ public class TurfJoins {
      * @param point   input point.
      * @param polygon input polygon.
      * @return True if the Point is inside the Polygon; false if the Point is not inside the Polygon.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#inside">Turf Inside documentation</a>
      * @since 2.0.0
      */
@@ -61,7 +61,7 @@ public class TurfJoins {
      * @param point   input point.
      * @param polygon input multipolygon.
      * @return True if the Point is inside the MultiPolygon; false if the Point is not inside the MultiPolygon.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#inside">Turf Inside documentation</a>
      * @since 2.0.0
      */

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMeasurement.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMeasurement.java
@@ -55,7 +55,7 @@ public class TurfMeasurement {
      * @param bearing  Ranging from -180 to 180.
      * @param units    Miles, kilometers, degrees, or radians (defaults kilometers).
      * @return destination {@link Point}
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#destination">Turf Destination documetation</a>
      * @since 1.2.0
      */
@@ -86,7 +86,7 @@ public class TurfMeasurement {
      * @param point1 Origin point.
      * @param point2 Destination point.
      * @return Distance between the two points.
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#distance">Turf distance documentation</a>
      * @since 1.2.0
      */
@@ -102,7 +102,7 @@ public class TurfMeasurement {
      * @param point2 Destination point.
      * @param units  Can be degrees, radians, miles, or kilometers (defaults kilometers).
      * @return Distance between the two points.
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#distance">Turf distance documentation</a>
      * @since 1.2.0
      */
@@ -127,7 +127,7 @@ public class TurfMeasurement {
      * @param line  Line to measure.
      * @param units Can be degrees, radians, miles, or kilometers (defaults kilometers).
      * @return Length of the input line.
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#linedistance">Turf Line Distance documentation</a>
      * @since 1.2.0
      */
@@ -145,7 +145,7 @@ public class TurfMeasurement {
      * @param line  Line to measure.
      * @param units Can be degrees, radians, miles, or kilometers (defaults kilometers).
      * @return Length of the input line.
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#linedistance">Turf Line Distance documentation</a>
      * @since 1.2.0
      */
@@ -159,7 +159,7 @@ public class TurfMeasurement {
      * @param line  Line to measure.
      * @param units Can be degrees, radians, miles, or kilometers (defaults kilometers).
      * @return Length of the input line.
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#linedistance">Turf Line Distance documentation</a>
      * @since 1.2.0
      */
@@ -214,7 +214,7 @@ public class TurfMeasurement {
      * @param from First point.
      * @param to   Second point.
      * @return A {@link Position} midway between pt1 and pt2.
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#midpoint">Turf Midpoint documentation</a>
      * @since 2.0.0
      */
@@ -231,7 +231,7 @@ public class TurfMeasurement {
      * @param from First point.
      * @param to   Second point.
      * @return A {@link Point} midway between pt1 and pt2.
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#midpoint">Turf Midpoint documentation</a>
      * @since 2.0.0
      */

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMisc.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMisc.java
@@ -25,7 +25,7 @@ public class TurfMisc {
      * @param stopPt  Stopping point.
      * @param line    Line to slice.
      * @return Sliced line.
-     * @throws TurfException
+     * @throws TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#lineslice">Turf Line slice documentation</a>
      * @since 1.2.0
      */
@@ -45,7 +45,7 @@ public class TurfMisc {
      * @param stopPt  Stopping point.
      * @param line    Line to slice.
      * @return Sliced line.
-     * @throws TurfException
+     * @throws TurfException TurfException Signals that a Turf exception of some sort has occurred.
      * @see <a href="http://turfjs.org/docs/#lineslice">Turf Line slice documentation</a>
      * @since 1.2.0
      */

--- a/libjava/lib/src/main/java/com/mapbox/services/directions/v4/DirectionsService.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/directions/v4/DirectionsService.java
@@ -45,13 +45,14 @@ public interface DirectionsService {
     /**
      * RxJava-based interface
      *
-     * @param profile      The profile directions should use.
-     * @param waypoints    The waypoints the route should follow.
-     * @param accessToken  Mapbox access token.
+     * @param userAgent The user.
+     * @param profile The profile directions should use.
+     * @param waypoints The waypoints the route should follow.
+     * @param accessToken Mapbox access token.
      * @param alternatives Define whether you want to recieve more then one route.
      * @param instructions Define if you'd like to recieve route instructions.
-     * @param geometry     Route geometry.
-     * @param steps        Define if you'd like the route steps.
+     * @param geometry Route geometry.
+     * @param steps Define if you'd like the route steps.
      * @return A RxJava Observable object
      * @since 1.0.0
      */

--- a/libjava/lib/src/main/java/com/mapbox/services/directions/v4/MapboxDirections.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/directions/v4/MapboxDirections.java
@@ -104,7 +104,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * Execute the call
      *
      * @return The Directions v4 response
-     * @throws IOException
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
      * @since 1.0.0
      */
     @Override
@@ -203,6 +203,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          *
          * @param profile {@link DirectionsCriteria#PROFILE_DRIVING},
          *                {@link DirectionsCriteria#PROFILE_CYCLING}, or {@link DirectionsCriteria#PROFILE_WALKING}
+         * @return Builder
          * @since 1.0.0
          */
         public Builder setProfile(String profile) {
@@ -215,6 +216,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          * waypoints including origin and final destination.
          *
          * @param waypoints List including all {@link Waypoint} you'd line to include in route.
+         * @return Builder
          * @since 1.0.0
          */
         public Builder setWaypoints(List<Waypoint> waypoints) {
@@ -226,6 +228,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          * Origin of the destination.
          *
          * @param origin {@link Waypoint} of origin.
+         * @return Builder
          * @since 1.0.0
          */
         public Builder setOrigin(Waypoint origin) {
@@ -238,6 +241,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          * use {@link #setWaypoints(List)}
          *
          * @param destination {@link Waypoint} of destination.
+         * @return Builder
          * @since 1.0.0
          */
         public Builder setDestination(Waypoint destination) {
@@ -249,6 +253,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          * Optionally, call if you'd like to receive alternative routes besides just one.
          *
          * @param alternatives true if you'd like alternative routes, else false.
+         * @return Builder
          * @since 1.0.0
          */
         public Builder setAlternatives(Boolean alternatives) {
@@ -261,6 +266,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          *
          * @param instructions {@link DirectionsCriteria#INSTRUCTIONS_TEXT} or
          *                     {@link DirectionsCriteria#INSTRUCTIONS_HTML}
+         * @return Builder
          * @since 1.0.0
          */
         public Builder setInstructions(String instructions) {
@@ -273,6 +279,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          *
          * @param geometry {@link DirectionsCriteria#GEOMETRY_GEOJSON},
          *                 {@link DirectionsCriteria#GEOMETRY_POLYLINE}, or {@link DirectionsCriteria#GEOMETRY_FALSE}
+         * @return Builder
          * @since 1.0.0
          */
         public Builder setGeometry(String geometry) {
@@ -284,6 +291,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          * Optionally, call if you'd like to include step information within route.
          *
          * @param steps true if you'd like step information.
+         * @return Builder
          * @since 1.0.0
          */
         public Builder setSteps(Boolean steps) {
@@ -393,7 +401,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          * Build the MapboxDirections
          *
          * @return {@link MapboxDirections}
-         * @throws ServicesException
+         * @throws ServicesException Generic Exception for all things directions.
          * @since 1.0.0
          */
         @Override

--- a/libjava/lib/src/main/java/com/mapbox/services/directions/v5/MapboxDirections.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/directions/v5/MapboxDirections.java
@@ -94,7 +94,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * Execute the call
      *
      * @return The Directions v5 response
-     * @throws IOException
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
      * @since 1.0.0
      */
     @Override
@@ -375,23 +375,12 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
             return profile;
         }
 
-        /*
-         * The coordinates parameter denotes between which points routing happens. The coordinates
-         * must be in the format:
-         *
-         *    {longitude},{latitude};{longitude},{latitude}[;{longitude},{latitude} ...]
-         *
-         * - Each coordinate is a pair of a longitude float and latitude float, which are separated by a ,
-         * - Coordinates are separated by a ; from each other
-         * - A query must at minimum have 2 coordinates and may at maximum have 25 coordinates
-         */
-
         /**
          * The coordinates parameter denotes between which points routing happens. The coordinates
          * must be in the format:
-         * <p/>
+         * <p>
          * {longitude},{latitude};{longitude},{latitude}[;{longitude},{latitude} ...]
-         * <p/>
+         * <p>
          * - Each coordinate is a pair of a longitude float and latitude float, which are separated by a ,
          * - Coordinates are separated by a ; from each other
          * - A query must at minimum have 2 coordinates and may at maximum have 25 coordinates
@@ -447,12 +436,12 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
         /**
          * Radiuses indicate how far from a coordinate a routeable way is searched. They
          * are indicated like this:
-         * <p/>
+         * <p>
          * ?radiuses={radius};{radius}}[;{radius} ...].
-         * <p/>
+         * <p>
          * If no routeble way can be found within the serach radius, a NoRoute error will be returned.
          * - Radiuses are separated by a ,
-         * - Each radius must be of a value float >= 0 in meters or unlimited (default)
+         * - Each radius must be of a value {@code float >= 0} in meters or unlimited (default)
          * - There must be as many radiuses as there are coordinates
          * - It is possible to not specify radiuses via ;;, which result in the same behaviour as setting unlimited
          *
@@ -492,7 +481,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
          * Build method
          *
          * @return MapboxDirections
-         * @throws ServicesException
+         * @throws ServicesException Generic Exception for all things directions.
          * @since 1.0.0
          */
         @Override

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/GeocodingCriteria.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/GeocodingCriteria.java
@@ -1,49 +1,72 @@
 package com.mapbox.services.geocoding.v5;
 
+/**
+ * Constants that should be used when requesting geocoding.
+ *
+ * @since 1.0.0
+ */
 public final class GeocodingCriteria {
 
     /**
-     * Default geocoding mode
+     * Default geocoding mode.
+     *
+     * @since 1.0.0
      */
     public static final String MODE_PLACES = "mapbox.places";
 
     /**
-     * Geocoding mode for for enterprise/batch geocoding
+     * Geocoding mode for for enterprise/batch geocoding.
+     *
+     * @since 1.0.0
      */
     public static final String MODE_PLACES_PERMANENT = "mapbox.places-permanent";
 
     /**
-     * Filter results by country
+     * Filter results by country.
+     *
+     * @since 1.0.0
      */
     public static final String TYPE_COUNTRY = "country";
 
     /**
-     * Filter results by region
+     * Filter results by region.
+     *
+     * @since 1.0.0
      */
     public static final String TYPE_REGION = "region";
 
     /**
-     * Filter results by postcode
+     * Filter results by postcode.
+     *
+     * @since 1.0.0
      */
     public static final String TYPE_POSTCODE = "postcode";
 
     /**
-     * Filter results by place
+     * Filter results by place.
+     *
+     * @since 1.0.0
      */
     public static final String TYPE_PLACE = "place";
 
     /**
-     * Filter results by neighborhood
+     * Filter results by neighborhood.
+     *
+     * @since 1.0.0
      */
     public static final String TYPE_NEIGHBORHOOD = "neighborhood";
 
     /**
-     * Filter results by address
+     * Filter results by address.
+     *
+     * @since 1.0.0
      */
     public static final String TYPE_ADDRESS = "address";
 
     /**
-     * Filter results by POI
+     * Filter results by POI.
+     *
+     * @since 1.0.0
      */
     public static final String TYPE_POI = "poi";
 

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/GeocodingService.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/GeocodingService.java
@@ -11,21 +11,26 @@ import rx.Observable;
 
 /**
  * Interface that defines the geocoding service.
+ *
+ * @since 1.0.0
  */
 public interface GeocodingService {
 
     /**
      * Call-based interface
      *
-     * @param mode
-     * @param query
-     * @param accessToken
-     * @param country
-     * @param proximity
-     * @param types
-     * @param autocomplete
-     * @param bbox
+     * @param userAgent    The user
+     * @param mode         mapbox.places or mapbox.places-permanent for enterprise/batch geocoding.
+     * @param query        a location; a place name for forward geocoding or a coordinate pair
+     *                     (longitude, latitude location) for reverse geocoding
+     * @param accessToken  Mapbox access token.
+     * @param country      ISO 3166 alpha 2 country codes, separated by commas.
+     * @param proximity    Location around which to bias results.
+     * @param types        Filter results by one or more type.
+     * @param autocomplete True if you want auto complete.
+     * @param bbox         Optionally pass in a bounding box to limit results in.
      * @return A retrofit Call object
+     * @since 1.0.0
      */
     @GET("/geocoding/v5/{mode}/{query}.json")
     Call<GeocodingResponse> getCall(
@@ -42,15 +47,18 @@ public interface GeocodingService {
     /**
      * RxJava-based interface
      *
-     * @param mode
-     * @param query
-     * @param accessToken
-     * @param country
-     * @param proximity
-     * @param types
-     * @param autocomplete
-     * @param bbox
+     * @param userAgent    The user
+     * @param mode         mapbox.places or mapbox.places-permanent for enterprise/batch geocoding.
+     * @param query        a location; a place name for forward geocoding or a coordinate pair
+     *                     (longitude, latitude location) for reverse geocoding
+     * @param accessToken  Mapbox access token.
+     * @param country      ISO 3166 alpha 2 country codes, separated by commas.
+     * @param proximity    Location around which to bias results.
+     * @param types        Filter results by one or more type.
+     * @param autocomplete True if you want auto complete.
+     * @param bbox         Optionally pass in a bounding box to limit results in.
      * @return A RxJava Observable object
+     * @since 1.0.0
      */
     @GET("/geocoding/v5/{mode}/{query}.json")
     Observable<GeocodingResponse> getObservable(
@@ -63,5 +71,4 @@ public interface GeocodingService {
             @Query("types") String types,
             @Query("autocomplete") Boolean autocomplete,
             @Query("bbox") String bbox);
-
 }

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/MapboxGeocoding.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/MapboxGeocoding.java
@@ -25,6 +25,8 @@ import rx.Observable;
 
 /**
  * The Mapbox geocoding client (v5).
+ *
+ * @since 1.0.0
  */
 public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
 
@@ -36,14 +38,32 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
     // Allows testing
     private String baseUrl = Constants.BASE_API_URL;
 
+    /**
+     * Public constructor.
+     *
+     * @param builder {@link Builder} object.
+     * @since 1.0.0
+     */
     public MapboxGeocoding(Builder builder) {
         this.builder = builder;
     }
 
+    /**
+     * Used internally.
+     *
+     * @param baseUrl the baseURL.
+     * @since 1.0.0
+     */
     public void setBaseUrl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
 
+    /**
+     * Used internally.
+     *
+     * @return Geocoding service.
+     * @since 1.0.0
+     */
     public GeocodingService getService() {
         // No need to recreate it
         if (service != null) return service;
@@ -64,6 +84,12 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
         return service;
     }
 
+    /**
+     * Used internally.
+     *
+     * @return call
+     * @since 1.0.0
+     */
     public Call<GeocodingResponse> getCall() {
         // No need to recreate it
         if (call != null) return call;
@@ -82,26 +108,56 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
         return call;
     }
 
+    /**
+     * Execute the call
+     *
+     * @return The Geocoding v5 response
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @since 1.0.0
+     */
     @Override
     public Response<GeocodingResponse> executeCall() throws IOException {
         return getCall().execute();
     }
 
+    /**
+     * Execute the call
+     *
+     * @param callback A Retrofit callback.
+     * @since 1.0.0
+     */
     @Override
     public void enqueueCall(Callback<GeocodingResponse> callback) {
         getCall().enqueue(callback);
     }
 
+    /**
+     * Cancel the call
+     *
+     * @since 1.0.0
+     */
     @Override
     public void cancelCall() {
         getCall().cancel();
     }
 
+    /**
+     * clone the call
+     *
+     * @return cloned call
+     * @since 1.0.0
+     */
     @Override
     public Call<GeocodingResponse> cloneCall() {
         return getCall().clone();
     }
 
+    /**
+     * Get observable
+     *
+     * @return Observable
+     * @since 1.0.0
+     */
     @Override
     public Observable<GeocodingResponse> getObservable() {
         // No need to recreate it
@@ -123,6 +179,8 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
 
     /**
      * Builds your geocoder query by adding parameters.
+     *
+     * @since 1.0.0
      */
     public static class Builder extends MapboxBuilder {
 
@@ -138,6 +196,11 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
         private Boolean autocomplete = null;
         private String bbox = null;
 
+        /**
+         * Constructor
+         *
+         * @since 1.0.0
+         */
         public Builder() {
             // Defaults
             mode = GeocodingCriteria.MODE_PLACES;
@@ -146,8 +209,10 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
         /**
          * Required to call when building {@link MapboxGeocoding.Builder}
          *
-         * @param accessToken Mapbox access token, you must have a Mapbox account
-         *                    in order to use this library.
+         * @param accessToken Mapbox access token, you must have a Mapbox account in order to use
+         *                    this library.
+         * @return Builder
+         * @since 1.0.0
          */
         @Override
         public Builder setAccessToken(String accessToken) {
@@ -155,11 +220,23 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
             return this;
         }
 
+        /**
+         * The location equals the query.
+         *
+         * @param location query
+         * @return Builder
+         * @since 1.0.0
+         */
         public Builder setLocation(String location) {
             query = location;
             return this;
         }
 
+        /**
+         * @param position {@link Position}
+         * @return Builder
+         * @since 1.0.0
+         */
         public Builder setCoordinates(Position position) {
             if (position == null) return this;
             query = String.format(Locale.US, "%f,%f",
@@ -168,16 +245,37 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
             return this;
         }
 
+        /**
+         * mapbox.places or mapbox.places-permanent for enterprise/batch geocoding.
+         *
+         * @param mode mapbox.places or mapbox.places-permanent for enterprise/batch geocoding.
+         * @return Builder
+         * @since 1.0.0
+         */
         public Builder setMode(String mode) {
             this.mode = mode;
             return this;
         }
 
+        /**
+         * Country which you want the results to show up in.
+         *
+         * @param country ISO 3166 alpha 2 country code
+         * @return Builder
+         * @since 1.0.0
+         */
         public Builder setCountry(String country) {
             this.country = country;
             return this;
         }
 
+        /**
+         * Countries which you want the results to show up in.
+         *
+         * @param countries ISO 3166 alpha 2 country codes, separated by commas.
+         * @return Builder
+         * @since 1.0.0
+         */
         public Builder setCountries(String[] countries) {
             this.country = TextUtils.join(",", countries);
             return this;
@@ -187,6 +285,8 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
          * Location around which to bias results.
          *
          * @param position A {@link Position}.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setProximity(Position position) {
             if (position == null) return this;
@@ -201,28 +301,65 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
          * locality, neighborhood, address, poi. Multiple options can be comma-separated.
          *
          * @param geocodingType String filtering the geocoder result types.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setGeocodingType(String geocodingType) {
             this.geocodingTypes = geocodingType;
             return this;
         }
 
+        /**
+         * Filter results by one or more type. Options are country, region, postcode, place,
+         * locality, neighborhood, address, poi. Multiple options can be comma-separated.
+         *
+         * @param geocodingType String array filtering the geocoder result types.
+         * @return Builder
+         * @since 1.0.0
+         */
         public Builder setGeocodingTypes(String[] geocodingType) {
             this.geocodingTypes = TextUtils.join(",", geocodingType);
             return this;
         }
 
+        /**
+         * Whether or not to return autocomplete results.
+         *
+         * @param autocomplete true, if you want autocomplete results, else false. (Defaults true)
+         * @return Builder
+         * @since 1.0.0
+         */
         public Builder setAutocomplete(boolean autocomplete) {
             this.autocomplete = autocomplete;
             return this;
         }
 
+        /**
+         * Bounding box within which to limit results.
+         *
+         * @param northeast The northeast corner of the bounding box as {@link Position}.
+         * @param southwest The southwest corner of the bounding box as {@link Position}.
+         * @return Builder
+         * @throws ServicesException Generic Exception for all things geocoding.
+         * @since 1.0.0
+         */
         public Builder setBbox(Position northeast, Position southwest) throws ServicesException {
             return setBbox(southwest.getLongitude(), southwest.getLatitude(),
                     northeast.getLongitude(), northeast.getLatitude());
         }
 
-        public Builder setBbox(double minX, double minY, double  maxX, double  maxY) throws ServicesException {
+        /**
+         * Bounding box within which to limit results.
+         *
+         * @param minX The minX of bounding box when maps facing north.
+         * @param minY The minY of bounding box when maps facing north.
+         * @param maxX The maxX of bounding box when maps facing north.
+         * @param maxY The maxY of bounding box when maps facing north.
+         * @return Builder
+         * @throws ServicesException Generic Exception for all things geocoding.
+         * @since 1.0.0
+         */
+        public Builder setBbox(double minX, double minY, double maxX, double maxY) throws ServicesException {
             if (minX == 0 && minY == 0 && maxX == 0 && maxY == 0) {
                 throw new ServicesException("You provided an empty bounding box");
             }
@@ -233,6 +370,7 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
 
         /**
          * @return your Mapbox access token.
+         * @since 1.0.0
          */
         @Override
         public String getAccessToken() {
@@ -241,15 +379,24 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
 
         /**
          * @return your geocoder query.
+         * @since 1.0.0
          */
         public String getQuery() {
             return query;
         }
 
+        /**
+         * @return mapbox.places or  mapbox.places-permanent for enterprise/batch geocoding.
+         * @since 1.0.0
+         */
         public String getMode() {
             return mode;
         }
 
+        /**
+         * @return ISO 3166 alpha 2 country codes, separated by commas
+         * @since 1.0.0
+         */
         public String getCountry() {
             return country;
         }
@@ -258,6 +405,7 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
          * Location around which you biased the results.
          *
          * @return String with the format longitude, latitude.
+         * @since 1.0.0
          */
         public String getProximity() {
             return proximity;
@@ -268,19 +416,35 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
          * using this method.
          *
          * @return String with list of filters you used.
+         * @since 1.0.0
          */
         public String getGeocodingTypes() {
             return geocodingTypes;
         }
 
+        /**
+         * @return true if autocomplete results, else false.
+         * @since 1.0.0
+         */
         public Boolean getAutocomplete() {
             return autocomplete;
         }
 
+        /**
+         * @return Bounding box within which the results are limited
+         * @since 1.0.0
+         */
         public String getBbox() {
             return bbox;
         }
 
+        /**
+         * Build method
+         *
+         * @return MapboxGeocoding
+         * @throws ServicesException Generic Exception for all things geocoding.
+         * @since 1.0.0
+         */
         @Override
         public MapboxGeocoding build() throws ServicesException {
             validateAccessToken(accessToken);

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/gson/CarmenGeometryDeserializer.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/gson/CarmenGeometryDeserializer.java
@@ -13,10 +13,23 @@ import com.mapbox.services.commons.models.Position;
 import java.lang.reflect.Type;
 
 /**
- * Created by antonio on 6/30/16.
+ * A custom deserializer for Gson, used for the Geocoder.
+ *
+ * @since 1.0.0
  */
 public class CarmenGeometryDeserializer implements JsonDeserializer<Geometry> {
 
+    /**
+     * A custom deserializer for Gson, used for the Geocoder.
+     *
+     * @param json    The Json data being deserialized.
+     * @param typeOfT The type of the Object to deserialize to.
+     * @param context Context for deserialization.
+     * @return Deserialized Geometry.
+     * @throws JsonParseException This exception is raised if there is a serious issue that occurs
+     *                            during parsing of a Json string.
+     * @since 1.0.0
+     */
     @Override
     public Geometry deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         JsonObject jsonObject = (JsonObject) json;

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/models/CarmenContext.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/models/CarmenContext.java
@@ -3,42 +3,62 @@ package com.mapbox.services.geocoding.v5.models;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Created by antonio on 6/30/16.
+ * Array representing a hierarchy of parents. Each parent includes id, text keys along with
+ * (if avaliable) a wikidata, short_code, and Maki key.
+ *
+ * @see <a href="https://github.com/mapbox/carmen/blob/master/carmen-geojson.md">Carmen Geojson information</a>
+ * @see <a href="https://www.mapbox.com/api-documentation/#geocoding">Mapbox geocoder documentation</a>
+ * @since 1.0.0
  */
 public class CarmenContext {
 
     private String id;
     private String text;
 
-    @SerializedName("short_code") private String shortCode;
+    @SerializedName("short_code")
+    private String shortCode;
     private String wikidata;
     private String category;
     private String maki;
 
+    /**
+     * ID of the feature of the form {index}.{id} where index is the id/handle of the datasource
+     * that contributed the result.
+     *
+     * @return String containing the ID.
+     * @since 1.0.0
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * @return Text representing the feature (e.g. "Austin").
+     * @since 1.0.0
+     */
     public String getText() {
         return text;
     }
 
     /**
-     * ISO 3166-1 country and ISO 3166-2 region codes
+     * @return String containing ISO 3166-1 country and ISO 3166-2 region codes
+     * @since 1.0.0
      */
     public String getShortCode() {
         return shortCode;
     }
 
     /**
-     * The Wikidata identifier for a country, region or place
+     * @return The Wikidata identifier for a country, region or place
+     * @since 1.2.0
      */
     public String getWikidata() {
         return wikidata;
     }
 
     /**
-     * Comma-separated list of categories applicable to a poi
+     * @return Comma-separated list of categories applicable to a poi
+     * @since 1.0.0
      */
     public String getCategory() {
         return category;
@@ -46,7 +66,10 @@ public class CarmenContext {
 
     /**
      * Suggested icon mapping from the most current version of the Maki project for a poi feature,
-     * based on its  category
+     * based on its category
+     *
+     * @return String containing recommendation
+     * @since 1.2.0
      */
     public String getMaki() {
         return maki;

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/models/CarmenFeature.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/models/CarmenFeature.java
@@ -9,12 +9,19 @@ import com.mapbox.services.commons.models.Position;
 import java.util.List;
 
 /**
- * Created by antonio on 6/30/16.
+ * The Features key in the geocoding API response contains the majority of information you'll want
+ * to use.
+ *
+ * @see <a href="https://github.com/mapbox/carmen/blob/master/carmen-geojson.md">Carmen Geojson information</a>
+ * @see <a href="https://www.mapbox.com/api-documentation/#geocoding">Mapbox geocoder documentation</a>
+ * @see <a href='geojson.org/geojson-spec.html#feature-objects'>Official GeoJSON Feature Specifications</a>
+ * @since 1.0.0
  */
 public class CarmenFeature extends Feature {
 
     private String text;
-    @SerializedName("place_name") private String placeName;
+    @SerializedName("place_name")
+    private String placeName;
     private double[] bbox;
     private String address;
     private double[] center;
@@ -30,55 +37,70 @@ public class CarmenFeature extends Feature {
     }
 
     /**
-     * Text representing the feature (e.g. "Austin").
+     * @return Text representing the feature (e.g. "Austin").
+     * @since 1.0.0
      */
     public String getText() {
         return text;
     }
 
     /**
-     * Human-readable text representing the full result hierarchy (e.g. "Austin, Texas, United States").
+     * @return Human-readable text representing the full result hierarchy (e.g. "Austin, Texas, United States").
+     * @since 1.0.0
      */
     public String getPlaceName() {
         return placeName;
     }
 
     /**
-     * Array bounding box of the form [minx, miny, maxx, maxy].
+     * @return Array bounding box of the form [minx, miny, maxx, maxy].
+     * @since 1.0.0
      */
     public double[] getBbox() {
         return bbox;
     }
 
     /**
-     * Where applicable. Contains the housenumber for the returned feature
+     * @return Where applicable. Contains the housenumber for the returned feature
+     * @since 1.0.0
      */
     public String getAddress() {
         return address;
     }
 
     /**
-     * Array of the form [lon, lat].
+     * @return Array of the form [lon, lat].
+     * @since 1.0.0
      */
     public double[] getCenter() {
         return center;
     }
 
     /**
-     * Array representing a hierarchy of parents. Each parent includes id, text keys.
+     * @return Array representing a hierarchy of parents. Each parent includes id, text keys.
+     * @since 1.0.0
      */
     public List<CarmenContext> getContext() {
         return context;
     }
 
+    /**
+     * You can use the relevance property to remove rough results if you require a response that
+     * matches your whole query.
+     *
+     * @return double value between 0 and 1.
+     * @since 1.0.0
+     */
     public double getRelevance() {
         return relevance;
     }
 
     /**
      * Util to transform center into a Position object
+     *
+     * @return a {@link Position} representing the center.
+     * @since 1.0.0
      */
-
     public Position asPosition() {
         return Position.fromCoordinates(center[0], center[1]);
     }
@@ -88,6 +110,7 @@ public class CarmenFeature extends Feature {
      * (e.g. "Austin, Texas, United States").
      *
      * @return String with human-readable text.
+     * @since 1.0.0
      */
     @Override
     public String toString() {

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/models/CarmenFeatureCollection.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/models/CarmenFeatureCollection.java
@@ -7,7 +7,9 @@ import com.mapbox.services.commons.geojson.FeatureCollection;
 import java.util.List;
 
 /**
- * Created by antonio on 6/30/16.
+ * The Geocoding API hierarchy starts with this class.
+ *
+ * @since 1.0.0
  */
 public class CarmenFeatureCollection extends BaseFeatureCollection {
 
@@ -21,6 +23,7 @@ public class CarmenFeatureCollection extends BaseFeatureCollection {
      * of the Geocoding service responses.
      *
      * @param features List of {@link Feature}.
+     * @since 1.0.0
      */
     protected CarmenFeatureCollection(List<CarmenFeature> features) {
         this.features = features;
@@ -31,11 +34,19 @@ public class CarmenFeatureCollection extends BaseFeatureCollection {
      * reverse geocoding.
      *
      * @return a List containing your search query.
+     * @since 1.0.0
      */
     public List<String> getQuery() {
         return this.query;
     }
 
+    /**
+     * A place name for forward geocoding or a coordinate pair (longitude, latitude location)
+     * for reverse geocoding.
+     *
+     * @param query The search terms used.
+     * @since 1.0.0
+     */
     public void setQuery(List<String> query) {
         this.query = query;
     }
@@ -44,11 +55,16 @@ public class CarmenFeatureCollection extends BaseFeatureCollection {
      * Mapbox attribution.
      *
      * @return String with Mapbox attribution.
+     * @since 1.0.0
      */
     public String getAttribution() {
         return this.attribution;
     }
 
+    /**
+     * @param attribution String with Mapbox attribution.
+     * @since 1.0.0
+     */
     public void setAttribution(String attribution) {
         this.attribution = attribution;
     }
@@ -57,6 +73,7 @@ public class CarmenFeatureCollection extends BaseFeatureCollection {
      * Get the List containing all the features within collection.
      *
      * @return List of features within collection.
+     * @since 1.0.0
      */
     public List<CarmenFeature> getFeatures() {
         return features;
@@ -67,6 +84,7 @@ public class CarmenFeatureCollection extends BaseFeatureCollection {
      *
      * @param features List of {@link Feature}
      * @return new {@link FeatureCollection}
+     * @since 1.0.0
      */
     public static CarmenFeatureCollection fromFeatures(List<CarmenFeature> features) {
         return new CarmenFeatureCollection(features);

--- a/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/models/GeocodingResponse.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/geocoding/v5/models/GeocodingResponse.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 /**
  * The response object for a geocoder query.
+ *
+ * @since 1.0.0
  */
 public class GeocodingResponse extends CarmenFeatureCollection {
 

--- a/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/MapMatchingService.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/MapMatchingService.java
@@ -12,17 +12,23 @@ import retrofit2.http.Query;
 import rx.Observable;
 
 /**
- * Created by ivo on 17/05/16.
+ * Interface that defines the map matching service.
+ *
+ * @since 1.2.0
  */
 public interface MapMatchingService {
 
     /**
      * Call based interface
      *
+     * @param userAgent    user
      * @param profile      directions profile id
+     * @param accessToken  Mapbox access token
      * @param geometry     format for the returned geometry (optional)
      * @param gpsPrecision assumed precission in meters of the used tracking device
+     * @param trace        The trace wanting to be matched
      * @return The MapMatchingResponse in a Call wrapper
+     * @since 1.2.0
      */
     @POST("matching/v4/{profile}.json")
     Call<MapMatchingResponse> getCall(
@@ -36,10 +42,14 @@ public interface MapMatchingService {
     /**
      * RxJava-based interface
      *
+     * @param userAgent    user
      * @param profile      directions profile id
+     * @param accessToken  Mapbox access token
      * @param geometry     format for the returned geometry (optional)
      * @param gpsPrecision assumed precision in meters of the used tracking device
+     * @param trace        The trace wanting to be matched
      * @return The MapMatchingResponse in an RX Java Observable
+     * @since 1.2.0
      */
     @POST("matching/v4/{profile}.json")
     Observable<MapMatchingResponse> getObservable(

--- a/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/MapboxMapMatching.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/MapboxMapMatching.java
@@ -27,6 +27,13 @@ import rx.Observable;
 
 /**
  * The Mapbox map matching interface (v4)
+ * <p>
+ * The Mapbox Map Matching API snaps fuzzy, inaccurate traces from a GPS unit or a phone to the
+ * OpenStreetMap? road and path network using the Directions API. This produces clean paths that can
+ * be displayed on a map or used for other analysis.
+ *
+ * @see <a href="https://www.mapbox.com/api-documentation/#map-matching">Map matching API documentation</a>
+ * @since 1.2.0
  */
 public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
 
@@ -42,9 +49,16 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
         this.builder = builder;
     }
 
+    /**
+     * Used internally.
+     *
+     * @param baseUrl the baseURL.
+     * @since 1.2.0
+     */
     public void setBaseUrl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
+
 
     private MapMatchingService getService() {
         // No need to recreate it
@@ -70,6 +84,12 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
         return service;
     }
 
+    /**
+     * Used internally.
+     *
+     * @return call
+     * @since 1.2.0
+     */
     public Call<MapMatchingResponse> getCall() {
         // No need to recreate it
         if (call != null) return call;
@@ -86,26 +106,56 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
         return call;
     }
 
+    /**
+     * Execute the call
+     *
+     * @return The map matching v4 response
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @since 1.2.0
+     */
     @Override
     public Response<MapMatchingResponse> executeCall() throws IOException {
         return getCall().execute();
     }
 
+    /**
+     * Execute the call
+     *
+     * @param callback A Retrofit callback.
+     * @since 1.2.0
+     */
     @Override
     public void enqueueCall(Callback<MapMatchingResponse> callback) {
         getCall().enqueue(callback);
     }
 
+    /**
+     * Cancel the call
+     *
+     * @since 1.2.0
+     */
     @Override
     public void cancelCall() {
         getCall().cancel();
     }
 
+    /**
+     * clone the call
+     *
+     * @return cloned call
+     * @since 1.2.0
+     */
     @Override
     public Call<MapMatchingResponse> cloneCall() {
         return getCall().clone();
     }
 
+    /**
+     * Get observable
+     *
+     * @return Observable
+     * @since 1.2.0
+     */
     @Override
     public Observable<MapMatchingResponse> getObservable() {
         // No need to recreate it
@@ -123,6 +173,11 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
         return observable;
     }
 
+    /**
+     * Builds your map matching query by adding parameters.
+     *
+     * @since 1.2.0
+     */
     public static class Builder extends MapboxBuilder {
 
         private String accessToken;
@@ -132,17 +187,34 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
 
         private LineString trace;
 
+        /**
+         * Constructor
+         *
+         * @since 1.2.0
+         */
         public Builder() {
             // Use polyline by default as the return format
             this.geometry = DirectionsCriteria.GEOMETRY_POLYLINE;
         }
 
+        /**
+         * Required to call when building {@link Builder}
+         *
+         * @param accessToken Mapbox access token, you must have a Mapbox account in order to use
+         *                    this API.
+         * @return Builder
+         * @since 1.2.0
+         */
         @Override
         public Builder setAccessToken(String accessToken) {
             this.accessToken = accessToken;
             return this;
         }
 
+        /**
+         * @return Mapbox access token
+         * @since 1.2.0
+         */
         @Override
         public String getAccessToken() {
             return this.accessToken;
@@ -152,30 +224,66 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
          * Set a map matching profile. You should use one of the constants in Directions v4
          * com.mapbox.services.directions.v4.DirectionsCriteria
          *
-         * @param profile on of DirectionsCriteria#PROFILE_*
+         * @param profile String containg A directions profile ID; either {@code mapbox.driving},
+         *                {@code mapbox.walking}, or {@code mapbox.cycling}. Use one of the
+         *                {@link DirectionsCriteria} constants.
+         * @return Builder
+         * @since 1.2.0
          */
         public Builder setProfile(String profile) {
             this.profile = profile;
             return this;
         }
 
+        /**
+         * @return String containg A directions profile ID; either {@code mapbox.driving},
+         * {@code mapbox.walking}, or {@code mapbox.cycling}.
+         * @since 1.2.0
+         */
         public String getProfile() {
             return profile;
         }
 
+        /**
+         * Format of the returned geometry. Allowed values are: {@code geojson} (default, as
+         * LineString), {@code polyline} (documentation) with precision 6, {@code false} (no
+         * geometry, but matched points).
+         *
+         * @return String containing one of the values allowed.
+         * @since 1.2.0
+         */
         public String getGeometry() {
             return geometry;
         }
 
+        /**
+         * Set the geometry to {@code false}.
+         *
+         * @return Builder
+         * @since 1.2.0
+         */
         public Builder setNoGeometry() {
             this.geometry = DirectionsCriteria.GEOMETRY_FALSE;
             return this;
         }
 
+        /**
+         * An integer in meters indicating the assumed precision of the used tracking device. Use
+         * higher numbers (5-10) for noisy traces and lower numbers (1-3) for clean traces. The
+         * default value is 4.
+         *
+         * @return integer value representing the GPS precision.
+         * @since 1.2.0
+         */
         public Integer getGpsPrecison() {
             return gpsPrecison;
         }
 
+        /**
+         * @return Returns a new request body that transmits {@code content}. If {@code contentType}
+         * is non-null and lacks a charset, this will use UTF-8.
+         * @since 1.2.0
+         */
         public RequestBody getTrace() {
             return RequestBody.create(
                     MediaType.parse("application/json"),
@@ -183,13 +291,21 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
         }
 
         /**
-         * @param gpsPrecison Assumed accuracy of the tracking device in meters (1-10 inclusive, default 4)
+         * @param gpsPrecison Assumed accuracy of the tracking device in meters
+         *                    (1-10 inclusive, default 4)
+         * @return Builder
+         * @since 1.2.0
          */
         public Builder setGpsPrecison(Integer gpsPrecison) {
             this.gpsPrecison = gpsPrecison;
             return this;
         }
 
+        /**
+         * @param trace A {@link LineString} representing the route geometry you want to match.
+         * @return Builder
+         * @since 1.2.0
+         */
         public Builder setTrace(LineString trace) {
             this.trace = trace;
             return this;
@@ -224,6 +340,14 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
             }
         }
 
+        /**
+         * Builder method
+         *
+         * @return MapboxMapMatching
+         * @throws ServicesException Generic Exception occuring when something with map matching
+         *                           goes wrong.
+         * @since 1.2.0
+         */
         @Override
         public MapboxMapMatching build() throws ServicesException {
             validateAccessToken(accessToken);

--- a/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/gson/MapMatchingGeometryDeserializer.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/gson/MapMatchingGeometryDeserializer.java
@@ -11,15 +11,29 @@ import com.mapbox.services.commons.geojson.LineString;
 import java.lang.reflect.Type;
 
 /**
- * Custom deserializer that assumes a Polyline string.
- *
- * In case of a json object, null is returned to support the geometry=false option
+ * A custom deserializer that assumes a Polyline string.
+ * <p>
+ * In case of a json object, null is returned to support the {@code geometry=false} option
  * (empty object is returned instead of null)
  *
- * @see com.mapbox.services.mapmatching.v4.MapboxMapMatching.Builder
+ * @since 1.2.0
  */
 public class MapMatchingGeometryDeserializer implements JsonDeserializer<Geometry> {
 
+    /**
+     * A custom deserializer that assumes a Polyline string.
+     * <p>
+     * In case of a json object, null is returned to support the {@code geometry=false} option
+     * (empty object is returned instead of null)
+     *
+     * @param json    The Json data being deserialized.
+     * @param typeOfT The type of the Object to deserialize to.
+     * @param context Context for deserialization.
+     * @return Deserialized Geometry.
+     * @throws JsonParseException This exception is raised if there is a serious issue that occurs
+     *                            during parsing of a Json string.
+     * @since 1.2.0
+     */
     @Override
     public Geometry deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         if (json.isJsonObject()) {
@@ -28,5 +42,4 @@ public class MapMatchingGeometryDeserializer implements JsonDeserializer<Geometr
             return LineString.fromPolyline(json.getAsString(), Constants.OSRM_PRECISION_V4);
         }
     }
-
 }

--- a/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/models/MapMatchingResponse.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/mapmatching/v4/models/MapMatchingResponse.java
@@ -9,7 +9,9 @@ import com.mapbox.services.commons.models.Position;
 import java.util.List;
 
 /**
- * Created by ivo on 17/05/16.
+ * Mapbox map matching API response
+ *
+ * @since 1.2.0
  */
 public class MapMatchingResponse extends FeatureCollection {
 
@@ -21,16 +23,36 @@ public class MapMatchingResponse extends FeatureCollection {
         super(features);
     }
 
+    /**
+     * A string depicting the state of the response.
+     * <ul>
+     * <li>"Ok" - Normal case</li>
+     * <li>"NoMatch" - The input did not produce any matches. {@link Feature} will be an empty array.</li>
+     * <li>"TooManyCoordinates" - There are more than 100 points in the request.</li>
+     * <li>"InvalidInput" - message will hold an explanation of the invalid input.</li>
+     * <li>"ProfileNotFound" - Profile should be {@code mapbox.driving} , {@code mapbox.walking} , or {@code mapbox.cycling}.</li>
+     * </ul>
+     *
+     * @return String containing the code.
+     * @since 1.2.0
+     */
     public String getCode() {
         return code;
     }
 
+    /**
+     * @param code String containing the code.
+     * @since 1.2.0
+     */
     public void setCode(String code) {
         this.code = code;
     }
 
     /**
      * Convenience method to obtain the list of matched points.
+     *
+     * @return Array of {@link Position} that have been map matched.
+     * @since 1.2.0
      */
     public Position[] getMatchedPoints() {
         return getMatchedPoints(0);
@@ -41,6 +63,10 @@ public class MapMatchingResponse extends FeatureCollection {
      * algorithm cannot decide the correct match between two points, it will omit that line and
      * create several sub-matches, each as a feature. The higher the number of features, the more
      * likely that the input traces are poorly aligned to the road network.
+     *
+     * @param submatch Which sub-match you want to get the position for.
+     * @return Array of {@link Position} that have been map matched.
+     * @since 1.2.0
      */
     public Position[] getMatchedPoints(int submatch) {
         JsonObject properties = getFeatures().get(submatch).getProperties();
@@ -52,7 +78,6 @@ public class MapMatchingResponse extends FeatureCollection {
                     points.get(i).getAsJsonArray().get(0).getAsDouble(),
                     points.get(i).getAsJsonArray().get(1).getAsDouble());
         }
-
         return positions;
     }
 

--- a/libjava/lib/src/main/java/com/mapbox/services/staticimage/v1/MapboxStaticImage.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/staticimage/v1/MapboxStaticImage.java
@@ -17,6 +17,7 @@ import okhttp3.HttpUrl;
  * or controls.
  *
  * @see <a href=https://www.mapbox.com/developers/api/styles/#Request.static.images.from.a.style>API Documentation</a>
+ * @since 1.0.0
  */
 public class MapboxStaticImage {
 
@@ -26,6 +27,7 @@ public class MapboxStaticImage {
      * Build the static image API URL using the builder.
      *
      * @param builder The MapboxStaticImage builder.
+     * @since 1.0.0
      */
     public MapboxStaticImage(Builder builder) {
         HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
@@ -57,6 +59,7 @@ public class MapboxStaticImage {
      * If you need the API URL you can request it with this method.
      *
      * @return the built API URL.
+     * @since 1.0.0
      */
     public HttpUrl getUrl() {
         return url;
@@ -65,6 +68,8 @@ public class MapboxStaticImage {
     /**
      * Static image builder used to customize the image, including location, image width/height,
      * and camera position.
+     *
+     * @since 1.0.0
      */
     public static class Builder extends MapboxBuilder {
 
@@ -91,6 +96,8 @@ public class MapboxStaticImage {
          *
          * @param accessToken Mapbox access token, you must have a Mapbox account in order to use
          *                    this library.
+         * @return Builder
+         * @since 1.0.0
          */
         @Override
         public Builder setAccessToken(String accessToken) {
@@ -104,6 +111,8 @@ public class MapboxStaticImage {
          * styles, the username will be "mapbox".
          *
          * @param username You will need to pass in your Mapbox username.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setUsername(String username) {
             this.username = username;
@@ -114,6 +123,8 @@ public class MapboxStaticImage {
          * You'll need to set what map style you'd like the static image to display.
          *
          * @param styleId can be one of the <a href=https://mapbox.com/api-documentation/#styles>defaults</a> or your own.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setStyleId(String styleId) {
             this.styleId = styleId;
@@ -124,6 +135,8 @@ public class MapboxStaticImage {
          * Longitude for the center point of the static map.
          *
          * @param lon double number between -180 and 180.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setLon(double lon) {
             this.lon = lon;
@@ -134,6 +147,8 @@ public class MapboxStaticImage {
          * Latitude for the center point of the static map.
          *
          * @param lat double number between -90 and 90.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setLat(double lat) {
             this.lat = lat;
@@ -144,6 +159,8 @@ public class MapboxStaticImage {
          * Location for the center point of the static map.
          *
          * @param position Position object with valid latitude and longitude values
+         * @return Builder
+         * @since 1.2.0
          */
         public Builder setLocation(Position position) {
             this.lat = position.getLatitude();
@@ -155,6 +172,8 @@ public class MapboxStaticImage {
          * static map zoom level. Fractional zoom levels will be rounded to two decimal places.
          *
          * @param zoom double number between 0 and 22.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setZoom(double zoom) {
             this.zoom = zoom;
@@ -166,6 +185,8 @@ public class MapboxStaticImage {
          * to the left. 180 flips the map. Defaults is 0.
          *
          * @param bearing double number between 0 and 360, interpreted as decimal degrees.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setBearing(double bearing) {
             this.bearing = bearing;
@@ -176,6 +197,8 @@ public class MapboxStaticImage {
          * Optionally, pitch tilts the map, producing a perspective effect. Defaults is 0.
          *
          * @param pitch double number between 0 and 60.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setPitch(double pitch) {
             this.pitch = pitch;
@@ -186,6 +209,8 @@ public class MapboxStaticImage {
          * width of the image.
          *
          * @param width int number between 1 and 1280.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setWidth(int width) {
             this.width = width;
@@ -193,9 +218,11 @@ public class MapboxStaticImage {
         }
 
         /**
-         * height of the image.
+         * Height of the image.
          *
          * @param height int number between 1 and 1280.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setHeight(int height) {
             this.height = height;
@@ -206,6 +233,8 @@ public class MapboxStaticImage {
          * Optionally, use to request a retina 2x image that will be returned.
          *
          * @param retina true if you'd like a retina image.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setRetina(boolean retina) {
             this.retina = retina;
@@ -216,6 +245,8 @@ public class MapboxStaticImage {
          * Optionally, control whether there is attribution on the image. Default is true.
          *
          * @param attribution true places attribution on image.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setAttribution(boolean attribution) {
             this.attribution = attribution;
@@ -226,6 +257,8 @@ public class MapboxStaticImage {
          * Optionally, control whether there is a Mapbox logo on the image. Default is true.
          *
          * @param logo true places Mapbox logo on image.
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setLogo(boolean logo) {
             this.logo = logo;
@@ -236,7 +269,9 @@ public class MapboxStaticImage {
          * In order to make the returned images better cacheable on the client, you can set the
          * precision in decimals instead of manually rounding the parameters.
          *
-         * @param precision int number representing the precision for the formater
+         * @param precision int number representing the precision for the formatter
+         * @return Builder
+         * @since 1.0.0
          */
         public Builder setPrecision(int precision) {
             this.precision = precision;
@@ -247,6 +282,7 @@ public class MapboxStaticImage {
          * Get the access token
          *
          * @return String with the access token
+         * @since 1.0.0
          */
         @Override
         public String getAccessToken() {
@@ -258,6 +294,7 @@ public class MapboxStaticImage {
          * used a <a href=https://mapbox.com/api-documentation/#styles>defaults</a> Mapbox style, it will be "mapbox".
          *
          * @return String with the username.
+         * @since 1.0.0
          */
         public String getUsername() {
             return username;
@@ -267,6 +304,7 @@ public class MapboxStaticImage {
          * Get what map style your static image will display.
          *
          * @return String containing static map id.
+         * @since 1.0.0
          */
         public String getStyleId() {
             return styleId;
@@ -277,6 +315,7 @@ public class MapboxStaticImage {
          * bearing, and pitch.
          *
          * @return String value with static image location information.
+         * @since 1.0.0
          */
         public String getLocationPathSegment() {
             if (precision > 0) {
@@ -296,6 +335,7 @@ public class MapboxStaticImage {
          * Gives the height and width of the static image.
          *
          * @return String giving width, height and retina.
+         * @since 1.0.0
          */
         public String getSizePathSegment() {
             String retinaPath = retina ? "@2x" : "";
@@ -306,6 +346,7 @@ public class MapboxStaticImage {
          * Determine if the static image will contain attribution.
          *
          * @return true if attribution will be on static image.
+         * @since 1.0.0
          */
         public boolean isAttribution() {
             return attribution;
@@ -315,17 +356,25 @@ public class MapboxStaticImage {
          * Determine if the static image will contain Mapbox logo.
          *
          * @return true if Mapbox logo will be on static image.
+         * @since 1.0.0
          */
         public boolean isLogo() {
             return logo;
         }
 
+        /**
+         * @return int number representing the precision for the formatter
+         * @since 1.0.0
+         */
         public int getPrecision() {
             return precision;
         }
 
         /**
          * Build the client when all user parameters have been set.
+         *
+         * @return MapboxStaticImage
+         * @since 1.0.0
          */
         @Override
         public MapboxStaticImage build() throws ServicesException {


### PR DESCRIPTION
libjava now produces 0 errors or warnings. The problem was missing tags and tag descriptions among other things. Every public method now has javadoc.

I've also added a task in gradle to build the java doc:

```groovy
task JavadocGeneration(type: Javadoc) {
    source = sourceSets.main.allJava
    failOnError = false
    classpath = configurations.compile
}
```

cc: @zugaldia 