### PR TITLE
Added gradle plugin that gives dex count every build

### DIFF
--- a/libandroid/app/build.gradle
+++ b/libandroid/app/build.gradle
@@ -58,3 +58,4 @@ dependencies {
 
 apply from: 'gradle-checkstyle.gradle'
 apply from: 'gradle-config.gradle'
+apply from: 'gradle-dexcount.gradle'

--- a/libandroid/app/gradle-dexcount.gradle
+++ b/libandroid/app/gradle-dexcount.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'com.getkeepsafe.dexcount'
+
+dexcount {
+    includeTotalMethodCount = true
+    orderByMethodCount = true
+}

--- a/libandroid/build.gradle
+++ b/libandroid/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Added this [gradle plugin](https://github.com/KeepSafe/dexcount-gradle-plugin) which will output the dex method count every time you build the testapp. Output looks like this:

<img width="764" alt="screen shot 2016-08-07 at 3 46 27 pm" src="https://cloud.githubusercontent.com/assets/5652865/17464842/2cab588e-5cb6-11e6-82f1-6325801ce66c.png">

it also outputs a bunch of cool stuff here: `libandroid/app/build/outputs/dexcount` Including an interactive chart you can open in browser:

<img width="564" alt="screen shot 2016-08-07 at 3 52 26 pm" src="https://cloud.githubusercontent.com/assets/5652865/17464897/03b81678-5cb7-11e6-9d4f-e6df1eac9f51.png">

and a list with the package and method count for each:

```
methods  fields   package/class name
3        0        <unnamed>
20896    9297     android
6        0        android.accessibilityservice
41       0        android.animation
224      29       android.app
2        0        android.appwidget
267      33       android.content
24       23       android.content.pm
97       10       android.content.res
30       0        android.database
312      46       android.graphics
110      0        android.graphics.drawable
2        0        android.graphics.drawable.shapes
3        0        android.graphics.pdf
20       2        android.hardware
3        0        android.hardware.display
11       0        android.hardware.fingerprint
29       0        android.location
188      3        android.media
18       1        android.media.browse
91       0        android.media.session
46       2        android.net
3        0        android.net.http
3        0        android.net.wifi
184      11       android.os
32       3        android.print
5        0        android.print.pdf
15       1        android.provider
10       0        android.service
10       0        android.service.media
6        0        android.speech
6        0        android.speech.tts
17842    9119     android.support
23       3        android.support.annotation
1798     2341     android.support.design
187      52       android.support.design.internal
1596     625      android.support.design.widget
303      165      android.support.graphics
303      165      android.support.graphics.drawable
1        6        android.support.graphics.drawable.animated
9508     2983     android.support.v4
41       13       android.support.v4.accessibilityservice
62       17       android.support.v4.animation
1742     848      android.support.v4.app
339      114      android.support.v4.content
1        1        android.support.v4.content.pm
56       1        android.support.v4.content.res
3        0        android.support.v4.database
316      51       android.support.v4.graphics
261      42       android.support.v4.graphics.drawable
85       16       android.support.v4.hardware
19       4        android.support.v4.hardware.display
66       12       android.support.v4.hardware.fingerprint
74       9        android.support.v4.internal
74       9        android.support.v4.internal.view
1547     632      android.support.v4.media
886      295      android.support.v4.media.session
96       7        android.support.v4.net
76       19       android.support.v4.os
97       55       android.support.v4.print
96       9        android.support.v4.provider
14       5        android.support.v4.speech
14       5        android.support.v4.speech.tts
103      55       android.support.v4.text
283      74       android.support.v4.util
3084     552      android.support.v4.view
1163     113      android.support.v4.view.accessibility
29       8        android.support.v4.view.animation
1449     501      android.support.v4.widget
6210     3627     android.support.v7
981      380      android.support.v7.app
15       1340     android.support.v7.appcompat
26       8        android.support.v7.content
26       8        android.support.v7.content.res
69       18       android.support.v7.graphics
69       18       android.support.v7.graphics.drawable
7        21       android.support.v7.recyclerview
3        1        android.support.v7.text
2        2        android.support.v7.transition
140      93       android.support.v7.util
846      325      android.support.v7.view
689      248      android.support.v7.view.menu
4121     1439     android.support.v7.widget
150      89       android.support.v7.widget.helper
5        1        android.support.v7.widget.util
2        0        android.telephony
43       5        android.text
3        0        android.text.method
2        0        android.text.style
17       0        android.transition
62       10       android.util
930      20       android.view
220      0        android.view.accessibility
34       0        android.view.animation
2        1        android.view.inputmethod
3        0        android.webkit
585      13       android.widget
18148    11680    com
77       49       com.almeros
77       49       com.almeros.android
77       49       com.almeros.android.multitouch
77       49       com.almeros.android.multitouch.gesturedetectors
14693    3670     com.google
13649    3256     com.google.common
3        0        com.google.common.annotations
876      325      com.google.common.base
7        6        com.google.common.base.internal
849      282      com.google.common.cache
8231     1553     com.google.common.collect
74       29       com.google.common.escape
65       28       com.google.common.eventbus
490      120      com.google.common.hash
3        1        com.google.common.html
616      141      com.google.common.io
102      39       com.google.common.math
144      214      com.google.common.net
556      104      com.google.common.primitives
511      91       com.google.common.reflect
1125     324      com.google.common.util
1125     324      com.google.common.util.concurrent
4        5        com.google.common.xml
1027     405      com.google.gson
7        0        com.google.gson.annotations
613      263      com.google.gson.internal
3        0        com.google.gson.internal.$Gson$Preconditions
22       1        com.google.gson.internal.$Gson$Types
5        2        com.google.gson.internal.$Gson$Types$GenericArrayTypeImpl
7        4        com.google.gson.internal.$Gson$Types$ParameterizedTypeImpl
6        3        com.google.gson.internal.$Gson$Types$WildcardTypeImpl
341      146      com.google.gson.internal.bind
10       2        com.google.gson.internal.bind.util
18       3        com.google.gson.reflect
87       74       com.google.gson.stream
17       9        com.google.thirdparty
17       9        com.google.thirdparty.publicsuffix
2693     6561     com.mapbox
1615     2372     com.mapbox.mapboxsdk
317      110      com.mapbox.mapboxsdk.annotations
60       27       com.mapbox.mapboxsdk.camera
7        71       com.mapbox.mapboxsdk.constants
5        0        com.mapbox.mapboxsdk.exceptions
110      22       com.mapbox.mapboxsdk.geometry
8        9        com.mapbox.mapboxsdk.http
1        5        com.mapbox.mapboxsdk.layers
10       7        com.mapbox.mapboxsdk.location
895      272      com.mapbox.mapboxsdk.maps
149      80       com.mapbox.mapboxsdk.maps.widgets
104      67       com.mapbox.mapboxsdk.offline
50       80       com.mapbox.mapboxsdk.telemetry
26       5        com.mapbox.mapboxsdk.utils
1078     4189     com.mapbox.services
528      3950     com.mapbox.services.android
58       20       com.mapbox.services.android.geocoder
49       16       com.mapbox.services.android.geocoder.ui
446      2381     com.mapbox.services.android.testapp
52       18       com.mapbox.services.android.testapp.directions
75       34       com.mapbox.services.android.testapp.geocoding
5        8        com.mapbox.services.android.testapp.geocoding.service
25       12       com.mapbox.services.android.testapp.icons
17       12       com.mapbox.services.android.testapp.staticimage
149      49       com.mapbox.services.android.testapp.turf
79       24       com.mapbox.services.android.testapp.utils
8        4        com.mapbox.services.android.utils
220      49       com.mapbox.services.commons
112      20       com.mapbox.services.commons.geojson
9        0        com.mapbox.services.commons.geojson.custom
10       3        com.mapbox.services.commons.models
11       9        com.mapbox.services.commons.tidy
52       14       com.mapbox.services.commons.turf
9        4        com.mapbox.services.commons.turf.models
18       2        com.mapbox.services.commons.utils
185      114      com.mapbox.services.directions
103      55       com.mapbox.services.directions.v4
68       29       com.mapbox.services.directions.v4.models
82       59       com.mapbox.services.directions.v5
43       32       com.mapbox.services.directions.v5.models
74       37       com.mapbox.services.geocoding
74       37       com.mapbox.services.geocoding.v5
3        0        com.mapbox.services.geocoding.v5.gson
34       16       com.mapbox.services.geocoding.v5.models
39       11       com.mapbox.services.mapmatching
39       11       com.mapbox.services.mapmatching.v4
3        0        com.mapbox.services.mapmatching.v4.gson
6        2        com.mapbox.services.mapmatching.v4.models
30       15       com.mapbox.services.staticimage
30       15       com.mapbox.services.staticimage.v1
124      1054     com.mapzen
109      47       com.mapzen.android
109      47       com.mapzen.android.lost
38       18       com.mapzen.android.lost.api
71       29       com.mapzen.android.lost.internal
15       1007     com.mapzen.lost
561      346      com.squareup
25       1        com.squareup.okhttp
536      345      com.squareup.picasso
1688     92       java
179      2        java.io
509      57       java.lang
0        11       java.lang.annotation
3        0        java.lang.invoke
12       0        java.lang.ref
91       0        java.lang.reflect
32       10       java.math
72       4        java.net
43       3        java.nio
4        1        java.nio.channels
4        0        java.nio.charset
2        0        java.nio.file
31       0        java.security
14       0        java.security.cert
3        0        java.sql
25       0        java.text
794      16       java.util
280      7        java.util.concurrent
67       0        java.util.concurrent.atomic
39       0        java.util.concurrent.locks
9        2        java.util.jar
9        4        java.util.logging
13       0        java.util.regex
28       0        java.util.zip
37       1        javax
27       0        javax.net
25       0        javax.net.ssl
1        0        javax.security
1        0        javax.security.auth
1        0        javax.security.auth.x500
9        1        javax.xml
4        0        javax.xml.parsers
5        1        javax.xml.xpath
1724     948      okhttp3
952      509      okhttp3.internal
424      247      okhttp3.internal.framed
232      135      okhttp3.internal.http
38       14       okhttp3.internal.io
35       17       okhttp3.internal.tls
17       9        okhttp3.logging
541      88       okio
36       0        org
15       0        org.json
6        0        org.w3c
6        0        org.w3c.dom
1        0        org.xml
1        0        org.xml.sax
14       0        org.xmlpull
14       0        org.xmlpull.v1
332      147      retrofit2
12       7        retrofit2.converter
12       7        retrofit2.converter.gson
23       0        retrofit2.http
4316     2106     rx
34       17       rx.android
11       3        rx.android.plugins
15       6        rx.android.schedulers
55       20       rx.exceptions
129      37       rx.functions
2605     1616     rx.internal
1930     1120     rx.internal.operators
47       39       rx.internal.producers
67       42       rx.internal.schedulers
561      415      rx.internal.util
167      44       rx.internal.util.atomic
182      295      rx.internal.util.unsafe
216      81       rx.observables
129      36       rx.observers
32       8        rx.plugins
132      72       rx.schedulers
7        5        rx.singles
236      74       rx.subjects
64       18       rx.subscriptions
15       0        sun
15       0        sun.misc
```

This was run today August 7th on the libandroid module, Not sure if you can run for just the libjava as it depends on the android plugin.

cc: @zugaldia 
