### PR TITLE
fixed progaurd issue

### DIFF
--- a/libandroid/lib/build.gradle
+++ b/libandroid/lib/build.gradle
@@ -23,6 +23,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
 }


### PR DESCRIPTION
We were missing `consumerProguardFiles 'proguard-rules.pro'` and the lib build gradle file. This should use the libraries progaurd-rules.pro file which includes:

```pro 
#MAS Data Models
-keep class com.mapbox.services.directions.v4.models.** { *; }
-keep class com.mapbox.services.directions.v5.models.** { *; }
-keep class com.mapbox.services.geocoding.v5.models.** { *; }
```

Closes #178 

cc: @zugaldia @tobrun 