### PR TITLE
Bring RouteUtils class to simplify work with RouteLeg objects

### DIFF
--- a/libandroid/app/src/main/AndroidManifest.xml
+++ b/libandroid/app/src/main/AndroidManifest.xml
@@ -36,6 +36,11 @@
             android:parentActivityName=".MainActivity"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
+            android:name=".directions.RouteUtilsV5Activity"
+            android:label="Route Utils v5"
+            android:parentActivityName=".MainActivity"
+            android:theme="@style/AppTheme.NoActionBar" />
+        <activity
             android:name=".icons.DirectionsIconsActivity"
             android:label="Directions icons"
             android:parentActivityName=".MainActivity"
@@ -100,7 +105,6 @@
             android:label="Turf inside"
             android:parentActivityName=".MainActivity"
             android:theme="@style/AppTheme.NoActionBar" />
-
         <activity
             android:name=".turf.TurfMidpointActivity"
             android:label="Turf midpoint"

--- a/libandroid/app/src/main/java/com/mapbox/services/android/testapp/MainActivity.java
+++ b/libandroid/app/src/main/java/com/mapbox/services/android/testapp/MainActivity.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 import com.mapbox.services.android.BuildConfig;
 import com.mapbox.services.android.testapp.directions.DirectionsV4Activity;
 import com.mapbox.services.android.testapp.directions.DirectionsV5Activity;
+import com.mapbox.services.android.testapp.directions.RouteUtilsV5Activity;
 import com.mapbox.services.android.testapp.geocoding.GeocodingReverseActivity;
 import com.mapbox.services.android.testapp.geocoding.GeocodingServiceActivity;
 import com.mapbox.services.android.testapp.geocoding.GeocodingWidgetActivity;
@@ -49,6 +50,7 @@ public class MainActivity extends AppCompatActivity {
 
     private final static List<SampleItem> samples = new ArrayList<>(Arrays.asList(
             new SampleItem("Directions v5", "", DirectionsV5Activity.class),
+            new SampleItem("Route Utils v5", "", RouteUtilsV5Activity.class),
             new SampleItem("Directions v4", "", DirectionsV4Activity.class),
             new SampleItem("Directions icons", "", DirectionsIconsActivity.class),
             new SampleItem("Reverse geocoding", "", GeocodingReverseActivity.class),

--- a/libandroid/app/src/main/java/com/mapbox/services/android/testapp/directions/DirectionsV5Activity.java
+++ b/libandroid/app/src/main/java/com/mapbox/services/android/testapp/directions/DirectionsV5Activity.java
@@ -29,6 +29,7 @@ import com.mapbox.services.directions.v5.models.DirectionsRoute;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -127,7 +128,7 @@ public class DirectionsV5Activity extends AppCompatActivity {
                 // Print some info about the route
                 currentRoute = response.body().getRoutes().get(0);
                 Log.d(LOG_TAG, "Distance: " + currentRoute.getDistance());
-                showMessage(String.format("Route is %f meters long.", currentRoute.getDistance()));
+                showMessage(String.format(Locale.US, "Route is %.1f meters long.", currentRoute.getDistance()));
 
                 // Draw the route on the map
                 drawRoute(currentRoute);

--- a/libandroid/app/src/main/java/com/mapbox/services/android/testapp/directions/RouteUtilsV5Activity.java
+++ b/libandroid/app/src/main/java/com/mapbox/services/android/testapp/directions/RouteUtilsV5Activity.java
@@ -2,9 +2,13 @@ package com.mapbox.services.android.testapp.directions;
 
 import android.graphics.Color;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.FloatingActionButton;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
+import android.view.View;
 import android.widget.Toast;
 
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
@@ -22,83 +26,122 @@ import com.mapbox.services.android.testapp.Utils;
 import com.mapbox.services.commons.ServicesException;
 import com.mapbox.services.commons.geojson.LineString;
 import com.mapbox.services.commons.models.Position;
+import com.mapbox.services.commons.turf.TurfException;
 import com.mapbox.services.directions.v5.DirectionsCriteria;
 import com.mapbox.services.directions.v5.MapboxDirections;
 import com.mapbox.services.directions.v5.models.DirectionsResponse;
 import com.mapbox.services.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.directions.v5.models.RouteLeg;
+import com.mapbox.services.navigation.v5.RouteUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-public class DirectionsV5Activity extends AppCompatActivity {
+public class RouteUtilsV5Activity extends AppCompatActivity implements OnMapReadyCallback {
 
-    private final static String LOG_TAG = "DirectionsV5Activity";
+    private final static String LOG_TAG = "RouteUtilsV5Activity";
 
     private MapView mapView = null;
     private MapboxMap mapboxMap = null;
 
+    private LatLng from = null;
+    private LatLng to = null;
     private DirectionsRoute currentRoute = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_directions_v5);
+        setContentView(R.layout.activity_route_utils_v5);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        // San Francisco
-        final Position origin = Position.fromCoordinates(-122.416667, 37.783333);
-
-        // San Jose
-        final Position destination = Position.fromCoordinates(-121.9, 37.333333);
-
-        // Centroid
-        final LatLng centroid = new LatLng(
-                (origin.getLatitude() + destination.getLatitude()) / 2,
-                (origin.getLongitude() + destination.getLongitude()) / 2);
-
         // Set up a standard Mapbox map
         mapView = (MapView) findViewById(R.id.mapview);
         mapView.onCreate(savedInstanceState);
-        mapView.getMapAsync(new OnMapReadyCallback() {
+        mapView.getMapAsync(this);
+    }
+
+    @Override
+    public void onMapReady(MapboxMap mapboxMap) {
+        this.mapboxMap = mapboxMap;
+
+        mapboxMap.setStyleUrl(Style.MAPBOX_STREETS);
+
+        // Dupont Circle
+        LatLng target = new LatLng(38.90962, -77.04341);
+
+        // Move map
+        CameraPosition cameraPosition = new CameraPosition.Builder()
+                .target(target)
+                .zoom(14)
+                .build();
+        mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
+
+        mapboxMap.setOnMapClickListener(new MapboxMap.OnMapClickListener() {
             @Override
-            public void onMapReady(MapboxMap mapboxMapReady) {
-                mapboxMap = mapboxMapReady;
-
-                mapboxMap.setStyleUrl(Style.MAPBOX_STREETS);
-
-                // Move map
-                CameraPosition cameraPosition = new CameraPosition.Builder()
-                        .target(centroid)
-                        .zoom(8)
-                        .build();
-                mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
-
-                // Add origin and destination to the map
-                mapboxMap.addMarker(new MarkerOptions()
-                        .position(new LatLng(origin.getLatitude(), origin.getLongitude()))
-                        .title("Origin")
-                        .snippet("San Francisco"));
-                mapboxMap.addMarker(new MarkerOptions()
-                        .position(new LatLng(destination.getLatitude(), destination.getLongitude()))
-                        .title("Destination")
-                        .snippet("San Jose"));
-
-                // Get route from API
-                try {
-                    getRoute(origin, destination);
-                } catch (ServicesException e) {
-                    e.printStackTrace();
+            public void onMapClick(@NonNull LatLng point) {
+                if (from == null) {
+                    setFrom(point);
+                } else if (to == null) {
+                    setTo(point);
+                } else {
+                    try {
+                        doUtils(point);
+                    } catch (ServicesException e) {
+                        Log.e(LOG_TAG, "Services exception: " + e.getMessage());
+                        e.printStackTrace();
+                    } catch (TurfException e) {
+                        Log.e(LOG_TAG, "Turf exception: " + e.getMessage());
+                        e.printStackTrace();
+                    }
                 }
             }
         });
+    }
+
+    private void setFrom(LatLng point) {
+        from = point;
+        mapboxMap.addMarker(new MarkerOptions()
+                .position(point)
+                .title("From"));
+    }
+
+    private void setTo(LatLng point) {
+        to = point;
+        mapboxMap.addMarker(new MarkerOptions()
+                .position(point)
+                .title("To"));
+
+        try {
+            getRoute(Position.fromCoordinates(from.getLongitude(), from.getLatitude()), Position.fromCoordinates(to.getLongitude(), to.getLatitude()));
+        } catch (ServicesException e) {
+            showMessage(e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private void doUtils(LatLng point) throws ServicesException, TurfException {
+        RouteUtils routeUtils = new RouteUtils();
+        RouteLeg route = currentRoute.getLegs().get(0);
+        Position position = Position.fromCoordinates(point.getLongitude(), point.getLatitude());
+
+        Log.d(LOG_TAG, String.format(Locale.US, "- isOffRoute = %b", routeUtils.isOffRoute(position, route)));
+        Log.d(LOG_TAG, String.format(Locale.US, "- getClosestStep = %d", routeUtils.getClosestStep(position, route)));
+
+        for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
+            Log.d(LOG_TAG, String.format("- Step index: %d", stepIndex));
+            Log.d(LOG_TAG, String.format(Locale.US, "  - isInStep = %b", routeUtils.isInStep(position, route, stepIndex)));
+            Log.d(LOG_TAG, String.format(Locale.US, "  - getDistanceToStep = %f", routeUtils.getDistanceToStep(position, route, stepIndex)));
+            Log.d(LOG_TAG, String.format(Locale.US, "  - getSnapToRoute = %s", routeUtils.getSnapToRoute(position, route, stepIndex).toString()));
+        }
     }
 
     private void getRoute(Position origin, Position destination) throws ServicesException {
@@ -127,7 +170,7 @@ public class DirectionsV5Activity extends AppCompatActivity {
                 // Print some info about the route
                 currentRoute = response.body().getRoutes().get(0);
                 Log.d(LOG_TAG, "Distance: " + currentRoute.getDistance());
-                showMessage(String.format("Route is %f meters long.", currentRoute.getDistance()));
+                showMessage(String.format(Locale.US, "Route is %f meters long.", currentRoute.getDistance()));
 
                 // Draw the route on the map
                 drawRoute(currentRoute);
@@ -192,5 +235,4 @@ public class DirectionsV5Activity extends AppCompatActivity {
         super.onLowMemory();
         mapView.onLowMemory();
     }
-
 }

--- a/libandroid/app/src/main/java/com/mapbox/services/android/testapp/directions/RouteUtilsV5Activity.java
+++ b/libandroid/app/src/main/java/com/mapbox/services/android/testapp/directions/RouteUtilsV5Activity.java
@@ -1,17 +1,24 @@
 package com.mapbox.services.android.testapp.directions;
 
 import android.graphics.Color;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
+import com.mapbox.mapboxsdk.annotations.Icon;
+import com.mapbox.mapboxsdk.annotations.IconFactory;
+import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
+import com.mapbox.mapboxsdk.annotations.MarkerViewOptions;
+import com.mapbox.mapboxsdk.annotations.Polyline;
 import com.mapbox.mapboxsdk.annotations.PolylineOptions;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -21,16 +28,19 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.services.Constants;
+import com.mapbox.services.android.testapp.MainActivity;
 import com.mapbox.services.android.testapp.R;
 import com.mapbox.services.android.testapp.Utils;
 import com.mapbox.services.commons.ServicesException;
 import com.mapbox.services.commons.geojson.LineString;
 import com.mapbox.services.commons.models.Position;
 import com.mapbox.services.commons.turf.TurfException;
+import com.mapbox.services.commons.utils.PolylineUtils;
 import com.mapbox.services.directions.v5.DirectionsCriteria;
 import com.mapbox.services.directions.v5.MapboxDirections;
 import com.mapbox.services.directions.v5.models.DirectionsResponse;
 import com.mapbox.services.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.directions.v5.models.LegStep;
 import com.mapbox.services.directions.v5.models.RouteLeg;
 import com.mapbox.services.navigation.v5.RouteUtils;
 
@@ -53,6 +63,10 @@ public class RouteUtilsV5Activity extends AppCompatActivity implements OnMapRead
     private LatLng to = null;
     private DirectionsRoute currentRoute = null;
 
+    private Icon tapIcon;
+    private Marker userTap = null;
+    private List<Polyline> snapLines = null;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -62,6 +76,11 @@ public class RouteUtilsV5Activity extends AppCompatActivity implements OnMapRead
         setSupportActionBar(toolbar);
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        // Create an Icon object for the marker to use
+        IconFactory iconFactory = IconFactory.getInstance(this);
+        Drawable iconDrawable = ContextCompat.getDrawable(this, R.drawable.ic_my_location_black_24dp);
+        tapIcon = iconFactory.fromDrawable(iconDrawable);
 
         // Set up a standard Mapbox map
         mapView = (MapView) findViewById(R.id.mapview);
@@ -129,18 +148,50 @@ public class RouteUtilsV5Activity extends AppCompatActivity implements OnMapRead
     }
 
     private void doUtils(LatLng point) throws ServicesException, TurfException {
+        // Remove previous
+        if (userTap != null) {
+            mapboxMap.removeMarker(userTap);
+        }
+
+        userTap = mapboxMap.addMarker(new MarkerOptions().position(point).setIcon(tapIcon));
+
         RouteUtils routeUtils = new RouteUtils();
         RouteLeg route = currentRoute.getLegs().get(0);
         Position position = Position.fromCoordinates(point.getLongitude(), point.getLatitude());
 
-        Log.d(LOG_TAG, String.format(Locale.US, "- isOffRoute = %b", routeUtils.isOffRoute(position, route)));
-        Log.d(LOG_TAG, String.format(Locale.US, "- getClosestStep = %d", routeUtils.getClosestStep(position, route)));
+        // General situational message
+        String message = String.format(Locale.US, "You're closest to step %d/%d (%s)",
+                routeUtils.getClosestStep(position, route) + 1,
+                route.getSteps().size(),
+                routeUtils.isOffRoute(position, route) ? "off-route" : "not off-route");
+        showMessage(message);
 
+        // Remove previous lines
+        if (snapLines != null && snapLines.size() > 0) {
+            for (Polyline snapLine: snapLines) {
+                mapboxMap.removePolyline(snapLine);
+            }
+        }
+
+        // Draw snap to route lines
+        snapLines = new ArrayList<>();
         for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
-            Log.d(LOG_TAG, String.format("- Step index: %d", stepIndex));
-            Log.d(LOG_TAG, String.format(Locale.US, "  - isInStep = %b", routeUtils.isInStep(position, route, stepIndex)));
-            Log.d(LOG_TAG, String.format(Locale.US, "  - getDistanceToStep = %f", routeUtils.getDistanceToStep(position, route, stepIndex)));
-            Log.d(LOG_TAG, String.format(Locale.US, "  - getSnapToRoute = %s", routeUtils.getSnapToRoute(position, route, stepIndex).toString()));
+            Position snapPoint = routeUtils.getSnapToRoute(position, route, stepIndex);
+            LatLng[] points = new LatLng[] {
+                    point,
+                    new LatLng(snapPoint.getLatitude(), snapPoint.getLongitude())};
+            snapLines.add(mapboxMap.addPolyline(new PolylineOptions()
+                    .add(points)
+                    .color(Color.parseColor("#f9886c"))
+                    .width(2)));
+        }
+
+        // Log some extra info
+        for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
+            Log.d(LOG_TAG, String.format("Step %d: in step = %b, distance = %.1fkm",
+                    stepIndex + 1,
+                    routeUtils.isInStep(position, route, stepIndex),
+                    routeUtils.getDistanceToStep(position, route, stepIndex)));
         }
     }
 
@@ -170,7 +221,9 @@ public class RouteUtilsV5Activity extends AppCompatActivity implements OnMapRead
                 // Print some info about the route
                 currentRoute = response.body().getRoutes().get(0);
                 Log.d(LOG_TAG, "Distance: " + currentRoute.getDistance());
-                showMessage(String.format(Locale.US, "Route is %f meters long.", currentRoute.getDistance()));
+                showMessage(String.format(Locale.US, "Route has %d steps and it's %.1f meters long.",
+                        currentRoute.getLegs().get(0).getSteps().size(),
+                        currentRoute.getDistance()));
 
                 // Draw the route on the map
                 drawRoute(currentRoute);
@@ -185,21 +238,28 @@ public class RouteUtilsV5Activity extends AppCompatActivity implements OnMapRead
     }
 
     private void drawRoute(DirectionsRoute route) {
-        // Convert LineString coordinates into LatLng[]
-        LineString lineString = LineString.fromPolyline(route.getGeometry(), Constants.OSRM_PRECISION_V5);
-        List<Position> coordinates = lineString.getCoordinates();
-        LatLng[] points = new LatLng[coordinates.size()];
-        for (int i = 0; i < coordinates.size(); i++) {
-            points[i] = new LatLng(
-                    coordinates.get(i).getLatitude(),
-                    coordinates.get(i).getLongitude());
-        }
+        // We're gonna draw each step in an alternating color
+        String[] colors = new String[] {"#3887be", "#56b881"}; // Blue, green
 
-        // Draw Points on MapView
-        mapboxMap.addPolyline(new PolylineOptions()
-                .add(points)
-                .color(Color.parseColor("#3887be"))
-                .width(5));
+        List<Position> coordinates;
+        LatLng[] points;
+        int colorIndex = 0;
+        for (int i = 0; i < route.getLegs().get(0).getSteps().size(); i++) {
+            LegStep step = route.getLegs().get(0).getSteps().get(i);
+            coordinates = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
+            points = new LatLng[coordinates.size()];
+            for (int j = 0; j < coordinates.size(); j++) {
+                points[j] = new LatLng(
+                        coordinates.get(j).getLatitude(),
+                        coordinates.get(j).getLongitude());
+            }
+
+            colorIndex ^= 1;
+            mapboxMap.addPolyline(new PolylineOptions()
+                    .add(points)
+                    .color(Color.parseColor(colors[colorIndex]))
+                    .width(5));
+        }
     }
 
     private void showMessage(String message) {

--- a/libandroid/app/src/main/res/drawable/ic_my_location_black_24dp.xml
+++ b/libandroid/app/src/main/res/drawable/ic_my_location_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,8c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4zM20.94,11c-0.46,-4.17 -3.77,-7.48 -7.94,-7.94L13,1h-2v2.06C6.83,3.52 3.52,6.83 3.06,11L1,11v2h2.06c0.46,4.17 3.77,7.48 7.94,7.94L11,23h2v-2.06c4.17,-0.46 7.48,-3.77 7.94,-7.94L23,13v-2h-2.06zM12,19c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/libandroid/app/src/main/res/layout/activity_route_utils_v5.xml
+++ b/libandroid/app/src/main/res/layout/activity_route_utils_v5.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.mapbox.services.android.testapp.directions.RouteUtilsV5Activity">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <include layout="@layout/content_route_utils_v5" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/libandroid/app/src/main/res/layout/content_route_utils_v5.xml
+++ b/libandroid/app/src/main/res/layout/content_route_utils_v5.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:context="com.mapbox.services.android.testapp.directions.DirectionsV5Activity"
+    tools:showIn="@layout/activity_directions_v5">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapview"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"/>
+
+</RelativeLayout>

--- a/libandroid/app/src/main/res/values/strings.xml
+++ b/libandroid/app/src/main/res/values/strings.xml
@@ -40,7 +40,6 @@
         <item>inches</item>
         <item>yards</item>
         <item>meters</item>
-
     </string-array>
 
 </resources>

--- a/libandroid/lib/build.gradle
+++ b/libandroid/lib/build.gradle
@@ -34,12 +34,12 @@ dependencies {
     compile 'com.android.support:design:23.3.0'
 
     // Mapbox Java Services (development)
-    //compile project(':libjava')
+    compile project(':libjava')
 
     // Mapbox Java Services (release)
-    compile ('com.mapbox.mapboxsdk:mapbox-java-services:2.0.0-SNAPSHOT@jar') {
-        transitive=true
-    }
+//    compile ('com.mapbox.mapboxsdk:mapbox-java-services:2.0.0-SNAPSHOT@jar') {
+//        transitive=true
+//    }
 
     // Testing
     testCompile 'junit:junit:4.12'

--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMisc.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMisc.java
@@ -76,7 +76,7 @@ public class TurfMisc {
         return clipLine;
     }
 
-    private static Feature pointOnLine(Point pt, List<Position> coords) throws TurfException {
+    public static Feature pointOnLine(Point pt, List<Position> coords) throws TurfException {
         String units = TurfConstants.UNIT_MILES;
 
         Feature closestPt = Feature.fromGeometry(

--- a/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
@@ -54,6 +54,11 @@ public class RouteUtils {
         // Decode the geometry
         List<Position> coords = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
 
+        // No need to do the math if the step has one coordinate only
+        if (coords.size() == 1) {
+            return coords.get(0);
+        }
+
         // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
         // Point on the LineString.
         Feature point = TurfMisc.pointOnLine(Point.fromCoordinates(position), coords);

--- a/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
@@ -1,0 +1,99 @@
+package com.mapbox.services.navigation.v5;
+
+import com.mapbox.services.Constants;
+import com.mapbox.services.commons.ServicesException;
+import com.mapbox.services.commons.geojson.Feature;
+import com.mapbox.services.commons.geojson.LineString;
+import com.mapbox.services.commons.geojson.Point;
+import com.mapbox.services.commons.models.Position;
+import com.mapbox.services.commons.turf.TurfConstants;
+import com.mapbox.services.commons.turf.TurfException;
+import com.mapbox.services.commons.turf.TurfMeasurement;
+import com.mapbox.services.commons.turf.TurfMisc;
+import com.mapbox.services.directions.v5.models.LegStep;
+import com.mapbox.services.directions.v5.models.RouteLeg;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * A few utilities to work with RouteLeg objects.
+ */
+public class RouteUtils {
+
+    // Default threshold for the user to be considered to be off-route (100 meters)
+    public static final double DEFAULT_OFF_ROUTE_THRESHOLD_KM = 0.1;
+
+    private double offRouteThresholdKm;
+
+    public RouteUtils() {
+        this.offRouteThresholdKm = DEFAULT_OFF_ROUTE_THRESHOLD_KM;
+    }
+
+    public RouteUtils(double offRouteThresholdKm) {
+        this.offRouteThresholdKm = offRouteThresholdKm;
+    }
+
+    public boolean isInStep(Position position, RouteLeg route, int stepIndex) throws ServicesException, TurfException {
+        // Compute the distance between the position and the step line (the closest point), and
+        // checks if it's within the off-route threshold
+        double distance = getDistanceToStep(position, route, stepIndex);
+        return (distance <= offRouteThresholdKm);
+    }
+
+    public double getDistanceToStep(Position position, RouteLeg route, int stepIndex) throws ServicesException, TurfException {
+        // Compute the distance between the position and the step line (the closest point).
+        Position closestPoint = getSnapToRoute(position, route, stepIndex);
+        return TurfMeasurement.distance(Point.fromCoordinates(position), Point.fromCoordinates(closestPoint), TurfConstants.UNIT_DEFAULT);
+    }
+
+    public Position getSnapToRoute(Position position, RouteLeg route, int stepIndex) throws ServicesException, TurfException {
+        LegStep step = validateStep(route, stepIndex);
+
+        // Decode the geometry
+        List<Position> coords = LineString.fromPolyline(step.getGeometry(), Constants.OSRM_PRECISION_V5).getCoordinates();
+
+        // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
+        // Point on the LineString.
+        Feature point = TurfMisc.pointOnLine(Point.fromCoordinates(position), coords);
+        return ((Point) point.getGeometry()).getCoordinates();
+    }
+
+    public boolean isOffRoute(Position position, RouteLeg route) throws ServicesException, TurfException {
+        for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
+            if (isInStep(position, route, stepIndex)) {
+                // We aren't off-route if we're close to at least one route step
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public int getClosestStep(Position position, RouteLeg route) throws ServicesException, TurfException {
+        double minDistance = Double.MAX_VALUE;
+        int closestIndex = 0;
+
+        for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
+            double distance = getDistanceToStep(position, route, stepIndex);
+            if (distance < minDistance) {
+                minDistance = distance;
+                closestIndex = stepIndex;
+            }
+        }
+
+        return closestIndex;
+    }
+
+    private LegStep validateStep(RouteLeg route, int stepIndex) throws ServicesException {
+        if (route == null) {
+            throw new ServicesException("The provided route is empty.");
+        } else if (route.getSteps() == null || route.getSteps().size() == 0) {
+            throw new ServicesException("The provided route has an empty set of steps.");
+        } else if (stepIndex >= route.getSteps().size()) {
+            throw new ServicesException(String.format(Locale.US, "The provided route doesn't have so many steps (%d).", stepIndex));
+        }
+
+        return route.getSteps().get(stepIndex);
+    }
+}

--- a/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
@@ -3,7 +3,6 @@ package com.mapbox.services.navigation.v5;
 import com.mapbox.services.Constants;
 import com.mapbox.services.commons.ServicesException;
 import com.mapbox.services.commons.geojson.Feature;
-import com.mapbox.services.commons.geojson.LineString;
 import com.mapbox.services.commons.geojson.Point;
 import com.mapbox.services.commons.models.Position;
 import com.mapbox.services.commons.turf.TurfConstants;
@@ -33,6 +32,10 @@ public class RouteUtils {
 
     public RouteUtils(double offRouteThresholdKm) {
         this.offRouteThresholdKm = offRouteThresholdKm;
+    }
+
+    public double getOffRouteThresholdKm() {
+        return offRouteThresholdKm;
     }
 
     public boolean isInStep(Position position, RouteLeg route, int stepIndex) throws ServicesException, TurfException {

--- a/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
@@ -10,6 +10,7 @@ import com.mapbox.services.commons.turf.TurfConstants;
 import com.mapbox.services.commons.turf.TurfException;
 import com.mapbox.services.commons.turf.TurfMeasurement;
 import com.mapbox.services.commons.turf.TurfMisc;
+import com.mapbox.services.commons.utils.PolylineUtils;
 import com.mapbox.services.directions.v5.models.LegStep;
 import com.mapbox.services.directions.v5.models.RouteLeg;
 
@@ -51,7 +52,7 @@ public class RouteUtils {
         LegStep step = validateStep(route, stepIndex);
 
         // Decode the geometry
-        List<Position> coords = LineString.fromPolyline(step.getGeometry(), Constants.OSRM_PRECISION_V5).getCoordinates();
+        List<Position> coords = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
 
         // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
         // Point on the LineString.
@@ -74,8 +75,9 @@ public class RouteUtils {
         double minDistance = Double.MAX_VALUE;
         int closestIndex = 0;
 
+        double distance;
         for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
-            double distance = getDistanceToStep(position, route, stepIndex);
+            distance = getDistanceToStep(position, route, stepIndex);
             if (distance < minDistance) {
                 minDistance = distance;
                 closestIndex = stepIndex;

--- a/libjava/lib/src/test/java/com/mapbox/services/navigation/v5/RouteUtilsTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/navigation/v5/RouteUtilsTest.java
@@ -1,0 +1,61 @@
+package com.mapbox.services.navigation.v5;
+
+import com.google.gson.Gson;
+import com.mapbox.services.directions.v5.models.DirectionsResponse;
+import com.mapbox.services.directions.v5.models.RouteLeg;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Created by antonio on 8/23/16.
+ */
+public class RouteUtilsTest {
+
+    private DirectionsResponse response;
+    private RouteLeg route;
+
+    @Before
+    public void setUp() throws IOException {
+        Gson gson = new Gson();
+        byte[] content = Files.readAllBytes(Paths.get("src/test/fixtures/directions_v5.json"));
+        String body = new String(content, StandardCharsets.UTF_8);
+        response = gson.fromJson(body, DirectionsResponse.class);
+        route = response.getRoutes().get(0).getLegs().get(0);
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+
+    @Test
+    public void isInStepTest() {
+    }
+
+    @Test
+    public void getDistanceToStepTest() {
+
+    }
+
+    @Test
+    public void getSnapToRouteTest() {
+
+    }
+
+    @Test
+    public void isOffRouteTest() {
+
+    }
+
+    @Test
+    public void getClosestStepTest() {
+
+    }
+}

--- a/libjava/lib/src/test/java/com/mapbox/services/navigation/v5/RouteUtilsTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/navigation/v5/RouteUtilsTest.java
@@ -1,7 +1,16 @@
 package com.mapbox.services.navigation.v5;
 
 import com.google.gson.Gson;
+import com.mapbox.services.BaseTest;
+import com.mapbox.services.Constants;
+import com.mapbox.services.commons.ServicesException;
+import com.mapbox.services.commons.models.Position;
+import com.mapbox.services.commons.turf.TurfConstants;
+import com.mapbox.services.commons.turf.TurfException;
+import com.mapbox.services.commons.turf.TurfMeasurement;
+import com.mapbox.services.commons.utils.PolylineUtils;
 import com.mapbox.services.directions.v5.models.DirectionsResponse;
+import com.mapbox.services.directions.v5.models.LegStep;
 import com.mapbox.services.directions.v5.models.RouteLeg;
 
 import org.junit.Before;
@@ -13,11 +22,16 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by antonio on 8/23/16.
  */
-public class RouteUtilsTest {
+public class RouteUtilsTest extends BaseTest {
 
     private DirectionsResponse response;
     private RouteLeg route;
@@ -36,26 +50,72 @@ public class RouteUtilsTest {
 
 
     @Test
-    public void isInStepTest() {
+    public void isInStepTest() throws ServicesException, TurfException {
+        RouteUtils routeUtils = new RouteUtils();
+
+        // For each step, the first coordinate is in the step
+        for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
+            LegStep step = route.getSteps().get(stepIndex);
+            List<Position> coords = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
+            assertTrue(routeUtils.isInStep(coords.get(0), route, stepIndex));
+        }
     }
 
     @Test
-    public void getDistanceToStepTest() {
+    public void getDistanceToStepTest() throws ServicesException, TurfException {
+        RouteUtils routeUtils = new RouteUtils();
 
+        // For each step, the distance to the first coordinate is zero
+        for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
+            LegStep step = route.getSteps().get(stepIndex);
+            List<Position> coords = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
+            assertEquals(0.0, routeUtils.getDistanceToStep(coords.get(0), route, stepIndex), DELTA);
+        }
     }
 
     @Test
-    public void getSnapToRouteTest() {
+    public void getSnapToRouteTest() throws ServicesException, TurfException {
+        RouteUtils routeUtils = new RouteUtils();
 
+        // For each step, the first coordinate snap point is the same point
+        for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
+            LegStep step = route.getSteps().get(stepIndex);
+            List<Position> coords = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
+            Position snapPoint = routeUtils.getSnapToRoute(coords.get(0), route, stepIndex);
+            assertEquals(coords.get(0).getLatitude(), snapPoint.getLatitude(), DELTA);
+            assertEquals(coords.get(0).getLongitude(), snapPoint.getLongitude(), DELTA);
+        }
     }
 
     @Test
-    public void isOffRouteTest() {
+    public void isOffRouteTest() throws ServicesException, TurfException {
+        RouteUtils routeUtils = new RouteUtils();
 
+        // For each step, the first coordinate is not off-route
+        for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
+            LegStep step = route.getSteps().get(stepIndex);
+            List<Position> coords = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
+            assertFalse(routeUtils.isOffRoute(coords.get(0), route));
+        }
+
+        // The route goes from SF (N) to San Jose (S). So 0.1 km south of the last point should
+        // be off-route
+        LegStep lastStep = route.getSteps().get(route.getSteps().size() - 1);
+        List<Position> lastCoords = PolylineUtils.decode(lastStep.getGeometry(), Constants.OSRM_PRECISION_V5);
+        Position offRoutePoint = TurfMeasurement.destination(lastCoords.get(0), routeUtils.getOffRouteThresholdKm(), 180, TurfConstants.UNIT_DEFAULT);
+        assertTrue(routeUtils.isOffRoute(offRoutePoint, route));
     }
 
     @Test
-    public void getClosestStepTest() {
+    public void getClosestStepTest() throws ServicesException, TurfException {
+        RouteUtils routeUtils = new RouteUtils();
 
+        // For each step, the last coordinate is closest to its step (except the last step which
+        // is one point only)
+        for (int stepIndex = 0; stepIndex < route.getSteps().size() - 1; stepIndex++) {
+            LegStep step = route.getSteps().get(stepIndex);
+            List<Position> coords = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
+            assertEquals(stepIndex, routeUtils.getClosestStep(coords.get(coords.size() - 1), route));
+        }
     }
 }


### PR DESCRIPTION
This PR brings a new `RouteUtils` class that brings some Turf-powered methods to obtain situational information from a `RouteLeg` object. To some extend, this a partial refactor and port to Java of @bsudekum 's work on [`navigation.js`](https://github.com/mapbox/navigation.js).

Particularly, this PR includes the following methods:

- `isInStep`: Given a position, a route, and a step index, determines if the position is close to the given step (within a customizable threshold).
- `getDistanceToStep`: Given a position, a route, and a step index, determines the distance between the position and the closest point in the given step.
- `getSnapToRoute`: Given a position, a route, and a step index, determines the closest point in the given step
- `isOffRoute`: Given a position and a route, determines if the position is off-route (within a customizable threshold).
- `getClosestStep`: Given a position and a route, determines the closest step in the route.

It also has a basic Activity to showcase its functionality. It currently only outputs information via `Log`, we should think how to better show this in the UI.

#### Next

- [x] Improve TestApp's Activity UI
- [x] Include tests

/cc: @cammace 