### PR TITLE
Release v1.3.0

### DIFF
--- a/libandroid/CHANGELOG.md
+++ b/libandroid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### v1.3.0
+
+* Geocoding widget now supports the `bbox` parameter
+
 ### v1.2.1
 
 * Fixes regresion in `GeocoderAutoCompleteView`

--- a/libandroid/lib/build.gradle
+++ b/libandroid/lib/build.gradle
@@ -34,12 +34,12 @@ dependencies {
     compile 'com.android.support:design:23.3.0'
 
     // Mapbox Java Services (development)
-    compile project(':libjava')
+//    compile project(':libjava')
 
     // Mapbox Java Services (release)
-//    compile ('com.mapbox.mapboxsdk:mapbox-java-services:2.0.0-SNAPSHOT@jar') {
-//        transitive=true
-//    }
+    compile ('com.mapbox.mapboxsdk:mapbox-java-services:2.0.0-SNAPSHOT@jar') {
+        transitive=true
+    }
 
     // Testing
     testCompile 'junit:junit:4.12'
@@ -48,3 +48,12 @@ dependencies {
 apply from: 'gradle-javadoc.gradle'
 apply from: 'gradle-checkstyle.gradle'
 apply from: 'gradle-mvn-push.gradle'
+
+// See: https://github.com/chrisbanes/gradle-mvn-push/issues/43#issuecomment-84140513
+afterEvaluate { project ->
+    android.libraryVariants.all { variant ->
+        tasks.androidJavadocs.doFirst {
+            classpath += files(variant.javaCompile.classpath.files)
+        }
+    }
+}

--- a/libjava/CHANGELOG.md
+++ b/libjava/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### v1.3.0
+
+* `RouteUtils` class to simplify work with `RouteLeg` objects
+* `geojson-tidy` integrated with Map Matching client
+* Added Turf's `midpoint`, `along`, and `within` methods
+* Added an example to showcase Turf's `lineslice`
+
 ### v1.2.1
 
 * Bring back `toString()` method in `CarmenFeature`


### PR DESCRIPTION
This PR fixes an issue with Javadoc generation as described in https://github.com/chrisbanes/gradle-mvn-push/issues/43#issuecomment-84140513.

It also brings a dependency in `libandroid` back to `mapbox-java-services:2.0.0-SNAPSHOT` instead of `compile project(':libjava')`. This was inadvertingly introduced by https://github.com/mapbox/mapbox-java/pull/180.

/cc: @cammace 