### PR TITLE
Make sure feature properties are properly serialized

### DIFF
--- a/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Feature.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/geojson/Feature.java
@@ -99,7 +99,7 @@ public class Feature implements GeoJSON {
    * @since 1.0.0
    */
   public static Feature fromGeometry(Geometry geometry) {
-    return new Feature(geometry, null, null);
+    return new Feature(geometry, new JsonObject(), null);
   }
 
   /**

--- a/libjava/lib/src/test/java/com/mapbox/services/geojson/FeatureTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/geojson/FeatureTest.java
@@ -1,10 +1,17 @@
 package com.mapbox.services.geojson;
 
+import com.google.gson.JsonObject;
 import com.mapbox.services.commons.geojson.Feature;
+import com.mapbox.services.commons.geojson.LineString;
+import com.mapbox.services.commons.models.Position;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class FeatureTest extends BaseGeoJSON {
 
@@ -20,6 +27,24 @@ public class FeatureTest extends BaseGeoJSON {
   public void toJson() {
     Feature geo = Feature.fromJson(BaseGeoJSON.SAMPLE_FEATURE);
     compareJson(BaseGeoJSON.SAMPLE_FEATURE, geo.toJson());
+  }
+
+  @Test
+  public void testNullProperties() {
+    List<Position> coordinates = Arrays.asList(Position.fromCoordinates(0.1, 2.3), Position.fromCoordinates(4.5, 6.7));
+    LineString line = LineString.fromCoordinates(coordinates);
+    Feature feature = Feature.fromGeometry(line);
+    assertTrue(feature.toJson().contains("\"properties\":{}"));
+  }
+
+  @Test
+  public void testNonNullProperties() {
+    List<Position> coordinates = Arrays.asList(Position.fromCoordinates(0.1, 2.3), Position.fromCoordinates(4.5, 6.7));
+    LineString line = LineString.fromCoordinates(coordinates);
+    JsonObject properties = new JsonObject();
+    properties.addProperty("key", "value");
+    Feature feature = Feature.fromGeometry(line, properties);
+    assertTrue(feature.toJson().contains("\"properties\":{\"key\":\"value\"}"));
   }
 
 }


### PR DESCRIPTION
GSON ignores fields with `null` values during serialization. Setting empty `properties` as a `new JsonObject ()` makes sure the serialized JSON includes the `"properties":{}` string.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/6240.

/cc: @cammace 