### PR TITLE
Make RouteUtils.getClosestStep() choose furthest step in case of ties

### DIFF
--- a/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/navigation/v5/RouteUtils.java
@@ -148,7 +148,8 @@ public class RouteUtils {
   }
 
   /**
-   * Get the closest route step to the given position.
+   * Get the closest route step to the given position. Ties will go to the furthest step in the
+   * route leg.
    *
    * @param position that you want to get closest route step to.
    * @param route    a directions route.
@@ -164,7 +165,7 @@ public class RouteUtils {
     double distance;
     for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
       distance = getDistanceToStep(position, route, stepIndex);
-      if (distance < minDistance) {
+      if (distance <= minDistance) {
         minDistance = distance;
         closestIndex = stepIndex;
       }

--- a/libjava/lib/src/test/java/com/mapbox/services/navigation/v5/RouteUtilsTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/navigation/v5/RouteUtilsTest.java
@@ -107,12 +107,11 @@ public class RouteUtilsTest extends BaseTest {
   public void getClosestStepTest() throws ServicesException, TurfException {
     RouteUtils routeUtils = new RouteUtils();
 
-    // For each step, the last coordinate is closest to its step (except the last step which
-    // is one point only)
-    for (int stepIndex = 0; stepIndex < route.getSteps().size() - 1; stepIndex++) {
+    // For each step, the first coordinate is closest to its step
+    for (int stepIndex = 0; stepIndex < route.getSteps().size(); stepIndex++) {
       LegStep step = route.getSteps().get(stepIndex);
       List<Position> coords = PolylineUtils.decode(step.getGeometry(), Constants.OSRM_PRECISION_V5);
-      assertEquals(stepIndex, routeUtils.getClosestStep(coords.get(coords.size() - 1), route));
+      assertEquals(stepIndex, routeUtils.getClosestStep(coords.get(0), route));
     }
   }
 }


### PR DESCRIPTION
It seems to make more sense to choose the furthest-ahead step when a given position is equidistant to multiple steps.
