### PR TITLE
Turf Point On Line fixed and test added

### DIFF
--- a/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMisc.java
+++ b/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMisc.java
@@ -103,38 +103,30 @@ public class TurfMisc {
       //stop
       stop.addNumberProperty("dist", TurfMeasurement.distance(pt, (Point) stop.getGeometry(), units));
       //perpendicular
+      double heightDistance = Math.max(
+        start.getProperties().get("dist").getAsDouble(),
+        stop.getProperties().get("dist").getAsDouble()
+      );
       double direction = TurfMeasurement.bearing((Point) start.getGeometry(), (Point) stop.getGeometry());
-      Feature perpendicularPt = Feature.fromGeometry(
-        TurfMeasurement.destination(pt, 1000, direction + 90, units)); // 1000 = gross
+      Feature perpendicularPt1 = Feature.fromGeometry(
+        TurfMeasurement.destination(pt, heightDistance, direction + 90, units));
+      Feature perpendicularPt2 = Feature.fromGeometry(
+        TurfMeasurement.destination(pt, heightDistance, direction - 90, units));
       LineIntersectsResult intersect = lineIntersects(
-        pt.getCoordinates().getLongitude(),
-        pt.getCoordinates().getLatitude(),
-        ((Point) perpendicularPt.getGeometry()).getCoordinates().getLongitude(),
-        ((Point) perpendicularPt.getGeometry()).getCoordinates().getLatitude(),
+        ((Point) perpendicularPt1.getGeometry()).getCoordinates().getLongitude(),
+        ((Point) perpendicularPt1.getGeometry()).getCoordinates().getLatitude(),
+        ((Point) perpendicularPt2.getGeometry()).getCoordinates().getLongitude(),
+        ((Point) perpendicularPt2.getGeometry()).getCoordinates().getLatitude(),
         ((Point) start.getGeometry()).getCoordinates().getLongitude(),
         ((Point) start.getGeometry()).getCoordinates().getLatitude(),
         ((Point) stop.getGeometry()).getCoordinates().getLongitude(),
         ((Point) stop.getGeometry()).getCoordinates().getLatitude()
       );
-      if (intersect == null) {
-        perpendicularPt = Feature.fromGeometry(
-          TurfMeasurement.destination(pt, 1000, direction - 90, units)); // 1000 = gross
-        intersect = lineIntersects(
-          pt.getCoordinates().getLongitude(),
-          pt.getCoordinates().getLatitude(),
-          ((Point) perpendicularPt.getGeometry()).getCoordinates().getLongitude(),
-          ((Point) perpendicularPt.getGeometry()).getCoordinates().getLatitude(),
-          ((Point) start.getGeometry()).getCoordinates().getLongitude(),
-          ((Point) start.getGeometry()).getCoordinates().getLatitude(),
-          ((Point) stop.getGeometry()).getCoordinates().getLongitude(),
-          ((Point) stop.getGeometry()).getCoordinates().getLatitude()
-        );
-      }
-      perpendicularPt.addNumberProperty("dist", Double.POSITIVE_INFINITY);
+
       Feature intersectPt = null;
       if (intersect != null) {
         intersectPt = Feature.fromGeometry(
-          Point.fromCoordinates(Position.fromCoordinates(intersect.getY(), intersect.getX())));
+          Point.fromCoordinates(Position.fromCoordinates(intersect.getX(), intersect.getY())));
         intersectPt.addNumberProperty("dist", TurfMeasurement.distance(pt, (Point) intersectPt.getGeometry(), units));
       }
 

--- a/libjava/lib/src/test/java/com/mapbox/services/turf/TurfMiscTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/turf/TurfMiscTest.java
@@ -1,20 +1,27 @@
 package com.mapbox.services.turf;
 
 import com.mapbox.services.commons.geojson.Feature;
+import com.mapbox.services.commons.geojson.FeatureCollection;
+import com.mapbox.services.commons.geojson.Geometry;
 import com.mapbox.services.commons.geojson.LineString;
 import com.mapbox.services.commons.geojson.Point;
 import com.mapbox.services.commons.models.Position;
+import com.mapbox.services.commons.turf.TurfConstants;
 import com.mapbox.services.commons.turf.TurfException;
+import com.mapbox.services.commons.turf.TurfMeasurement;
 import com.mapbox.services.commons.turf.TurfMisc;
+import com.mapbox.services.directions.v4.models.FeatureGeometry;
 
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TurfMiscTest extends BaseTurf {
 
@@ -93,5 +100,239 @@ public class TurfMiscTest extends BaseTurf {
     assertNotEquals(
       sliced.getCoordinates().get(0).getCoordinates(),
       sliced.getCoordinates().get(1).getCoordinates());
+  }
+
+  /*
+   * Point on line test
+   */
+
+  @Test
+  public void testTurfPointOnLineFirstPoint() throws TurfException {
+    List<Position> line = new ArrayList<>();
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.72003306385638));
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.718242366859215));
+
+    Point pt = Point.fromCoordinates(Position.fromCoordinates(-122.45717525482178, 37.72003306385638));
+
+    Feature snappedFeature = TurfMisc.pointOnLine(pt, line);
+    Point snapped = (Point) snappedFeature.getGeometry();
+    // pt on start does not move
+    assertEquals(pt.getCoordinates(), snapped.getCoordinates());
+  }
+
+  @Test
+  public void testTurfPointOnLinePointsBehindFirstPoint() throws TurfException {
+    List<Position> line = new ArrayList<>();
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.72003306385638));
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.718242366859215));
+
+    Point first = Point.fromCoordinates(line.get(0));
+
+    List<Point> pts = new ArrayList<>();
+    pts.add(Point.fromCoordinates(new double[] {-122.45717525482178, 37.72009306385638}));
+    pts.add(Point.fromCoordinates(new double[] {-122.45717525482178, 37.82009306385638}));
+    pts.add(Point.fromCoordinates(new double[] {-122.45716525482178, 37.72009306385638}));
+    pts.add(Point.fromCoordinates(new double[] {-122.45516525482178, 37.72009306385638}));
+
+    for (Point pt : pts) {
+      Feature snappedFeature = TurfMisc.pointOnLine(pt, line);
+      Point snapped = (Point) snappedFeature.getGeometry();
+      // pt behind start moves to first vertex
+      assertEquals(first.getCoordinates(), snapped.getCoordinates());
+    }
+  }
+
+  @Test
+  public void testTurfPointOnLinePointsInFrontOfLastPoint() throws TurfException {
+    List<Position> line = new ArrayList<>();
+    line.add(Position.fromCoordinates(-122.45616137981413, 37.72125936929241));
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.72003306385638));
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.718242366859215));
+
+    Point last = Point.fromCoordinates(line.get(2));
+
+    List<Point> pts = new ArrayList<>();
+    pts.add(Point.fromCoordinates(new double[] {-122.45696067810057, 37.7181405249708}));
+    pts.add(Point.fromCoordinates(new double[] {-122.4573630094528,37.71813203814049}));
+    pts.add(Point.fromCoordinates(new double[] {-122.45730936527252,37.71797927502795}));
+    pts.add(Point.fromCoordinates(new double[] {-122.45718061923981,37.71704571582896}));
+
+    for(Point pt : pts) {
+      Feature snappedFeature = TurfMisc.pointOnLine(pt, line);
+      Point snapped = (Point) snappedFeature.getGeometry();
+      // pt behind start moves to last vertex
+      assertEquals(last.getCoordinates(), snapped.getCoordinates());
+    }
+  }
+
+  @Test
+  public void testTurfPointOnLinePointsOnJoints() throws TurfException {
+    List<Point> line1 = new ArrayList<>();
+    line1.add(Point.fromCoordinates(new double[]{-122.45616137981413,37.72125936929241}));
+    line1.add(Point.fromCoordinates(new double[]{-122.45717525482178,37.72003306385638}));
+    line1.add(Point.fromCoordinates(new double[]{-122.45717525482178,37.718242366859215}));
+
+    List<Point> line2 = new ArrayList<>();
+    line2.add(Point.fromCoordinates(new double[]{26.279296875,31.728167146023935}));
+    line2.add(Point.fromCoordinates(new double[]{21.796875,32.69486597787505}));
+    line2.add(Point.fromCoordinates(new double[]{18.80859375,29.99300228455108}));
+    line2.add(Point.fromCoordinates(new double[]{12.919921874999998,33.137551192346145}));
+    line2.add(Point.fromCoordinates(new double[]{10.1953125,35.60371874069731}));
+    line2.add(Point.fromCoordinates(new double[]{4.921875,36.527294814546245}));
+    line2.add(Point.fromCoordinates(new double[]{-1.669921875,36.527294814546245}));
+    line2.add(Point.fromCoordinates(new double[]{-5.44921875,34.74161249883172}));
+    line2.add(Point.fromCoordinates(new double[]{-8.7890625,32.99023555965106}));
+
+    List<Point> line3 = new ArrayList<>();
+    line3.add(Point.fromCoordinates(new double[]{-0.10919809341430663,51.52204224896724}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10923027992248535,51.521942114455435}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10916590690612793,51.52186200668747}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10904788970947266,51.52177522311313}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10886549949645996,51.521601655468345}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10874748229980469,51.52138135712038}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10855436325073242,51.5206870765674}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10843634605407713,51.52027984939518}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10839343070983887,51.519952729849024}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10817885398864746,51.51957887606202}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10814666748046874,51.51928513164789}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10789990425109863,51.518624199789016}));
+    line3.add(Point.fromCoordinates(new double[]{-0.10759949684143065,51.51778299991493}));
+
+    List<List<Point>> lines = new ArrayList<>();
+    lines.add(line1);
+    lines.add(line2);
+    lines.add(line3);
+
+    for (List<Point> line : lines) {
+      List<Position> linePosition = new ArrayList<>();
+      for(Point pt : line) {
+        linePosition.add(Position.fromCoordinates(pt.getCoordinates().getLongitude(), pt.getCoordinates().getLatitude()));
+      }
+      for(Point pt : line) {
+        Feature snappedFeature = TurfMisc.pointOnLine(pt, linePosition);
+        Point snapped = (Point) snappedFeature.getGeometry();
+        // pt on joint stayed in place
+        assertEquals(pt.getCoordinates(), snapped.getCoordinates());
+      }
+    }
+  }
+
+  @Test
+  public void testTurfPointOnLinePointsOnTopOfLine() throws TurfException {
+    List<Position> line = new ArrayList<>();
+    line.add(Position.fromCoordinates(-0.10919809341430663,51.52204224896724));
+    line.add(Position.fromCoordinates(-0.10923027992248535,51.521942114455435));
+    line.add(Position.fromCoordinates(-0.10916590690612793,51.52186200668747));
+    line.add(Position.fromCoordinates(-0.10904788970947266,51.52177522311313));
+    line.add(Position.fromCoordinates(-0.10886549949645996,51.521601655468345));
+    line.add(Position.fromCoordinates(-0.10874748229980469,51.52138135712038));
+    line.add(Position.fromCoordinates(-0.10855436325073242,51.5206870765674));
+    line.add(Position.fromCoordinates(-0.10843634605407713,51.52027984939518));
+    line.add(Position.fromCoordinates(-0.10839343070983887,51.519952729849024));
+    line.add(Position.fromCoordinates(-0.10817885398864746,51.51957887606202));
+    line.add(Position.fromCoordinates(-0.10814666748046874,51.51928513164789));
+    line.add(Position.fromCoordinates(-0.10789990425109863,51.518624199789016));
+    line.add(Position.fromCoordinates(-0.10759949684143065,51.51778299991493));
+
+    double dist = TurfMeasurement.lineDistance(LineString.fromCoordinates(line), TurfConstants.UNIT_MILES);
+    double increment = dist / 10;
+
+    for (int i = 0; i < 10; i++) {
+      Point pt = TurfMeasurement.along(LineString.fromCoordinates(line), increment * i, TurfConstants.UNIT_MILES);
+      Feature snappedFeature = TurfMisc.pointOnLine(pt, line);
+      Point snapped = (Point) snappedFeature.getGeometry();
+
+      double shift = TurfMeasurement.distance(pt, snapped, TurfConstants.UNIT_MILES);
+
+      // pt did not shift far
+      assertTrue(shift < 0.000001);
+    }
+
+//    test('turf-point-on-line - points on top of line', function (t) {
+//      var line = linestring([[-0.10919809341430663,51.52204224896724],[-0.10923027992248535,51.521942114455435],[-0.10916590690612793,51.52186200668747],[-0.10904788970947266,51.52177522311313],[-0.10886549949645996,51.521601655468345],[-0.10874748229980469,51.52138135712038],[-0.10855436325073242,51.5206870765674],[-0.10843634605407713,51.52027984939518],[-0.10839343070983887,51.519952729849024],[-0.10817885398864746,51.51957887606202],[-0.10814666748046874,51.51928513164789],[-0.10789990425109863,51.518624199789016],[-0.10759949684143065,51.51778299991493]]);
+//
+//      var dist = lineDistance(line, 'miles');
+//      var increment = dist / 10;
+//
+//      for (var i = 0; i < 10; i++) {
+//        var pt = along(line, increment * i, 'miles');
+//        var snapped = pointOnLine(line, pt);
+//        var shift = distance(pt, snapped, 'miles');
+//        t.true(shift < 0.000001, 'pt did not shift far');
+//      }
+//
+//      t.end();
+//    });
+  }
+
+  @Test
+  public void testTurfPointOnLinePointAlongLine() throws TurfException {
+    List<Position> line = new ArrayList<>();
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.7200330638563));
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.718242366859215));
+
+    Point pt = TurfMeasurement.along(LineString.fromCoordinates(line), 0.019, TurfConstants.UNIT_MILES);
+    Feature snappedFeature = TurfMisc.pointOnLine(pt, line);
+    Point snapped = (Point) snappedFeature.getGeometry();
+    double shift = TurfMeasurement.distance(pt, snapped, TurfConstants.UNIT_MILES);
+
+    // pt did not shift far
+    assertTrue(shift < 0.000001);
+
+//    test('turf-point-on-line - point along line', function (t) {
+//      var line = linestring([[-122.45717525482178,37.72003306385638],[-122.45717525482178,37.718242366859215]]);
+//
+//      var pt = along(line, 0.019, 'miles');
+//      var snapped = pointOnLine(line, pt);
+//      var shift = distance(pt, snapped, 'miles');
+//
+//      t.true(shift < 0.00001, 'pt did not shift far');
+//
+//      t.end();
+//    });
+  }
+
+  @Test
+  public void testTurfPointOnLinePointsOnSidesOfLines() throws TurfException {
+    List<Position> line = new ArrayList<>();
+    line.add(Position.fromCoordinates(-122.45616137981413, 37.72125936929241));
+    line.add(Position.fromCoordinates(-122.45717525482178, 37.718242366859215));
+    Position first = line.get(0);
+    Position last = line.get(1);
+
+    List<Point> pts = new ArrayList<>();
+    pts.add(Point.fromCoordinates(new double[]{-122.45702505111694,37.71881098149625}));
+    pts.add(Point.fromCoordinates(new double[]{-122.45733618736267,37.719235317933844}));
+    pts.add(Point.fromCoordinates(new double[]{-122.45686411857605,37.72027068864082}));
+    pts.add(Point.fromCoordinates(new double[]{-122.45652079582213,37.72063561093274}));
+
+    for (Point pt : pts) {
+      Feature snappedFeature = TurfMisc.pointOnLine(pt, line);
+      Point snapped = (Point) snappedFeature.getGeometry();
+      // pt did not snap to first vertex
+      assertNotEquals(snapped.getCoordinates(), first);
+      // pt did not snap to last vertex
+      assertNotEquals(snapped.getCoordinates(), last);
+    }
+
+
+//    test('turf-point-on-line - points on sides of lines', function (t) {
+//      var line = linestring([[-122.45616137981413,37.72125936929241],[-122.45717525482178,37.718242366859215]]);
+//      var first = line.geometry.coordinates[0];
+//      var last = line.geometry.coordinates[line.geometry.coordinates.length - 1];
+//      var pts = [
+//      point([-122.45702505111694,37.71881098149625]),
+//      point([-122.45733618736267,37.719235317933844]),
+//      point([-122.45686411857605,37.72027068864082]),
+//      point([-122.45652079582213,37.72063561093274])
+//      ];
+//
+//      pts.forEach(function(pt){
+//        var snapped = pointOnLine(line, pt);
+//        t.notDeepEqual(snapped.geometry.coordinates, first, 'pt did not snap to first vertex');
+//        t.notDeepEqual(snapped.geometry.coordinates, last, 'pt did not snap to last vertex');
+//      });
+//
+//      t.end();
   }
 }

--- a/libjava/lib/src/test/java/com/mapbox/services/turf/TurfMiscTest.java
+++ b/libjava/lib/src/test/java/com/mapbox/services/turf/TurfMiscTest.java
@@ -247,22 +247,6 @@ public class TurfMiscTest extends BaseTurf {
       // pt did not shift far
       assertTrue(shift < 0.000001);
     }
-
-//    test('turf-point-on-line - points on top of line', function (t) {
-//      var line = linestring([[-0.10919809341430663,51.52204224896724],[-0.10923027992248535,51.521942114455435],[-0.10916590690612793,51.52186200668747],[-0.10904788970947266,51.52177522311313],[-0.10886549949645996,51.521601655468345],[-0.10874748229980469,51.52138135712038],[-0.10855436325073242,51.5206870765674],[-0.10843634605407713,51.52027984939518],[-0.10839343070983887,51.519952729849024],[-0.10817885398864746,51.51957887606202],[-0.10814666748046874,51.51928513164789],[-0.10789990425109863,51.518624199789016],[-0.10759949684143065,51.51778299991493]]);
-//
-//      var dist = lineDistance(line, 'miles');
-//      var increment = dist / 10;
-//
-//      for (var i = 0; i < 10; i++) {
-//        var pt = along(line, increment * i, 'miles');
-//        var snapped = pointOnLine(line, pt);
-//        var shift = distance(pt, snapped, 'miles');
-//        t.true(shift < 0.000001, 'pt did not shift far');
-//      }
-//
-//      t.end();
-//    });
   }
 
   @Test
@@ -277,19 +261,7 @@ public class TurfMiscTest extends BaseTurf {
     double shift = TurfMeasurement.distance(pt, snapped, TurfConstants.UNIT_MILES);
 
     // pt did not shift far
-    assertTrue(shift < 0.000001);
-
-//    test('turf-point-on-line - point along line', function (t) {
-//      var line = linestring([[-122.45717525482178,37.72003306385638],[-122.45717525482178,37.718242366859215]]);
-//
-//      var pt = along(line, 0.019, 'miles');
-//      var snapped = pointOnLine(line, pt);
-//      var shift = distance(pt, snapped, 'miles');
-//
-//      t.true(shift < 0.00001, 'pt did not shift far');
-//
-//      t.end();
-//    });
+    assertTrue(shift < 0.00001);
   }
 
   @Test
@@ -314,25 +286,5 @@ public class TurfMiscTest extends BaseTurf {
       // pt did not snap to last vertex
       assertNotEquals(snapped.getCoordinates(), last);
     }
-
-
-//    test('turf-point-on-line - points on sides of lines', function (t) {
-//      var line = linestring([[-122.45616137981413,37.72125936929241],[-122.45717525482178,37.718242366859215]]);
-//      var first = line.geometry.coordinates[0];
-//      var last = line.geometry.coordinates[line.geometry.coordinates.length - 1];
-//      var pts = [
-//      point([-122.45702505111694,37.71881098149625]),
-//      point([-122.45733618736267,37.719235317933844]),
-//      point([-122.45686411857605,37.72027068864082]),
-//      point([-122.45652079582213,37.72063561093274])
-//      ];
-//
-//      pts.forEach(function(pt){
-//        var snapped = pointOnLine(line, pt);
-//        t.notDeepEqual(snapped.geometry.coordinates, first, 'pt did not snap to first vertex');
-//        t.notDeepEqual(snapped.geometry.coordinates, last, 'pt did not snap to last vertex');
-//      });
-//
-//      t.end();
   }
 }


### PR DESCRIPTION
We were missing test for  [`Turf.Misc#pointOnLine()`](https://github.com/mapbox/mapbox-java/blob/master/libjava/lib/src/main/java/com/mapbox/services/commons/turf/TurfMisc.java#L90).

cc: @ivovandongen @zugaldia 