### PR TITLE
Added Proguard rules

### DIFF
--- a/libandroid/app/build.gradle
+++ b/libandroid/app/build.gradle
@@ -13,7 +13,11 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -25,7 +29,7 @@ ext {
 
 dependencies {
     // Android services
-    compile project (':lib')
+    compile project(':lib')
 
     // Support libraries
     compile "com.android.support:appcompat-v7:${supportLibVersion}"
@@ -33,8 +37,9 @@ dependencies {
     compile "com.android.support:recyclerview-v7:${supportLibVersion}"
 
     // Mapbox SDK
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-beta.5@aar'){
-        transitive=true
+//    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-beta.5@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-SNAPSHOT@aar') {
+        transitive = true
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-java-services'
     }
 
@@ -44,7 +49,9 @@ dependencies {
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
 
     // LOST
-    compile 'com.mapzen.android:lost:1.0.1'
+    compile ('com.mapzen.android:lost:1.1.1') {
+        exclude group: 'com.google.guava'
+    }
 
     // Picasso (Static Image)
     compile 'com.squareup.picasso:picasso:2.5.2'

--- a/libandroid/app/proguard-rules.pro
+++ b/libandroid/app/proguard-rules.pro
@@ -1,17 +1,1 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Users/antonio/Library/Android/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-dontwarn com.squareup.okhttp.**

--- a/libandroid/lib/proguard-rules.pro
+++ b/libandroid/lib/proguard-rules.pro
@@ -21,6 +21,8 @@
 -keep class * implements com.google.gson.JsonDeserializer
 
 # MAS Data Models
+-keep class com.mapbox.services.mapmatching.v4.models.** { *; }
+-keep class com.mapbox.services.distance.v1.models.** { *; }
 -keep class com.mapbox.services.directions.v4.models.** { *; }
 -keep class com.mapbox.services.directions.v5.models.** { *; }
 -keep class com.mapbox.services.geocoding.v5.models.** { *; }

--- a/libandroid/lib/proguard-rules.pro
+++ b/libandroid/lib/proguard-rules.pro
@@ -1,36 +1,36 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Users/antonio/Library/Android/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# Add any project specific keep options here:
-
 # Retrofit 2
-# See: http://square.github.io/retrofit/#download
--dontwarn retrofit2.**
--keep class retrofit2.** { *; }
+# Platform calls Class.forName on types which do not exist on Android to determine platform.
+-dontnote retrofit2.Platform
+# Platform used when running on RoboVM on iOS. Will not be used at runtime.
+-dontnote retrofit2.Platform$IOS$MainThreadExecutor
+# Platform used when running on Java 8 VMs. Will not be used at runtime.
+-dontwarn retrofit2.Platform$Java8
+# Retain generic type information for use by reflection by converters and adapters.
 -keepattributes Signature
+# Retain declared checked exceptions for use by a Proxy instance.
 -keepattributes Exceptions
 
-# RxJava
-# See: https://github.com/ReactiveX/RxAndroid/pull/220
--keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
-    long producerIndex;
-    long consumerIndex;
-}
--keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef {
-    rx.internal.util.atomic.LinkedQueueNode producerNode;
-}
--keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
-    rx.internal.util.atomic.LinkedQueueNode consumerNode;
-}
--dontwarn sun.misc.Unsafe
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+# Gson specific classes
+-keep class sun.misc.Unsafe { *; }
+# Prevent proguard from stripping interface information from TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
 
 # MAS Data Models
 -keep class com.mapbox.services.directions.v4.models.** { *; }
 -keep class com.mapbox.services.directions.v5.models.** { *; }
 -keep class com.mapbox.services.geocoding.v5.models.** { *; }
+
+-dontwarn javax.annotation.**
+
+-keepclassmembers class rx.internal.util.unsafe.** {
+    long producerIndex;
+    long consumerIndex;
+}
+
+-keep class com.google.**
+-dontwarn com.google.**

--- a/libandroid/lib/proguard-rules.pro
+++ b/libandroid/lib/proguard-rules.pro
@@ -13,7 +13,8 @@
 # For using GSON @Expose annotation
 -keepattributes *Annotation*
 # Gson specific classes
--keep class sun.misc.Unsafe { *; }
+-dontwarn sun.misc.**
+
 # Prevent proguard from stripping interface information from TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
 -keep class * implements com.google.gson.TypeAdapterFactory

--- a/libjava/lib/build.gradle
+++ b/libjava/lib/build.gradle
@@ -8,12 +8,12 @@ dependencies {
     // Retrofit + Gson
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.3.1'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.5.0'
 
     // Testing
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.3.1'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.5.0'
 }
 
 buildConfig {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-java/issues/178

For some reason i'm running into this error when trying to build:
```
Information:Gradle tasks [:app:assembleDebug]
Warning:rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.ConcurrentCircularArrayQueue: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.ConcurrentSequencedCircularArrayQueue: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.MpmcArrayQueueConsumerField: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.MpmcArrayQueueProducerField: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.MpscLinkedQueue: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.SpmcArrayQueueConsumerField: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.SpmcArrayQueueProducerField: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.SpscArrayQueue: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.SpscUnboundedArrayQueue: can't find referenced class sun.misc.Unsafe
Warning:rx.internal.util.unsafe.UnsafeAccess: can't find referenced class sun.misc.Unsafe
Warning:there were 44 unresolved references to classes or interfaces.
Warning:Exception while processing task java.io.IOException: Please correct the above warnings first.
Error:Execution failed for task ':app:transformClassesAndResourcesWithProguardForDebug'.
> java.io.IOException: Please correct the above warnings first.
```

Any ideas @mapbox/android?