### PR TITLE
use stable version of Mapbox GL Native dependency

### DIFF
--- a/libandroid/app/build.gradle
+++ b/libandroid/app/build.gradle
@@ -37,8 +37,7 @@ dependencies {
     compile "com.android.support:recyclerview-v7:${supportLibVersion}"
 
     // Mapbox SDK
-//    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-beta.5@aar') {
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-SNAPSHOT@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0@aar') {
         transitive = true
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-java-services'
     }


### PR DESCRIPTION
Follow up on #245, where CI failed on using the Snapshot instead of the stable dependency from Mapbox GL Native. cc @cammace.