### PR TITLE
[android] - upgrade to a bitrise compatible buildtools version

### DIFF
--- a/mapbox/dependencies.gradle
+++ b/mapbox/dependencies.gradle
@@ -6,7 +6,7 @@ ext {
     minSdkVersion = 15
     targetSdkVersion = 25
     compileSdkVersion = 25
-    buildToolsVersion = "25.0.1"
+    buildToolsVersion = "25.0.2"
 
     dep = [
         gson: 'com.google.code.gson:gson:2.8.0',


### PR DESCRIPTION
The CI bots on this repo were having the same issues as the one on gl-native in mapbox/mapbox-gl-native#7729. This PR upgrades the build tools to a bitrise supported version. After merging we need to publish a new snapshot to allow projects using this dependency to be build on CI.

Review @cammace