### PR TITLE
Added fromjson test and method for carmen feature

### DIFF
--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeature.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeature.java
@@ -142,6 +142,9 @@ public class CarmenFeature extends Feature {
    */
   public static CarmenFeature fromJson(String json) {
     GsonBuilder gson = new GsonBuilder();
+    gson.registerTypeAdapter(Position.class, new PositionDeserializer());
+    gson.registerTypeAdapter(Geometry.class, new GeometryDeserializer());
+    gson.registerTypeAdapter(Geometry.class, new CarmenGeometryDeserializer());
     return gson.create().fromJson(json, CarmenFeature.class);
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeature.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeature.java
@@ -1,9 +1,13 @@
 package com.mapbox.services.api.geocoding.v5.models;
 
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
+import com.mapbox.services.api.geocoding.v5.gson.CarmenGeometryDeserializer;
 import com.mapbox.services.commons.geojson.Feature;
 import com.mapbox.services.commons.geojson.Geometry;
+import com.mapbox.services.commons.geojson.custom.GeometryDeserializer;
+import com.mapbox.services.commons.geojson.custom.PositionDeserializer;
 import com.mapbox.services.commons.models.Position;
 
 import java.util.List;
@@ -100,6 +104,7 @@ public class CarmenFeature extends Feature {
     return relevance;
   }
 
+
   public void setText(String text) {
     this.text = text;
   }
@@ -126,6 +131,18 @@ public class CarmenFeature extends Feature {
 
   public void setRelevance(double relevance) {
     this.relevance = relevance;
+  }
+
+  /**
+   * Create a CarmenFeature object from JSON.
+   *
+   * @param json String of JSON making up a carmen feature.
+   * @return Carmen Feature
+   * @since 2.0.0
+   */
+  public static CarmenFeature fromJson(String json) {
+    GsonBuilder gson = new GsonBuilder();
+    return gson.create().fromJson(json, CarmenFeature.class);
   }
 
   /**

--- a/mapbox/libjava-services/src/test/fixtures/geocoder_tofromjson.json
+++ b/mapbox/libjava-services/src/test/fixtures/geocoder_tofromjson.json
@@ -1,0 +1,1 @@
+{"text":"Text field 1","place_name":"Text field 2","bbox":[1.2,3.4,5.6,7.8],"address":"Text field 3","center":[1.2,3.4],"relevance":1.2,"type":"Feature","properties":{"foo1":"bar"},"id":"Text field 4"}

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/geocoding/v5/CarmenFeatureTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/geocoding/v5/CarmenFeatureTest.java
@@ -5,11 +5,17 @@ import com.mapbox.services.api.geocoding.v5.models.CarmenFeature;
 
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 import static org.junit.Assert.assertEquals;
 
 public class CarmenFeatureTest {
 
   private static final double DELTA = 1E-10;
+  private static final String GEOCODING_FIXTURE = "src/test/fixtures/geocoder_tofromjson.json";
 
   @Test
   public void testAllowStandalone() {
@@ -49,5 +55,34 @@ public class CarmenFeatureTest {
     assertEquals(feature.hasNonNullValueForProperty("foo1"), true);
     assertEquals(feature.hasNonNullValueForProperty("foo2"), false);
     assertEquals(feature.getId(), "Text field 4");
+  }
+
+  @Test
+  public void carmenFeatureFromJson() throws IOException {
+    // Build the standalone object
+    double[] bbox = new double[] {1.2, 3.4, 5.6, 7.8};
+    double[] center = new double[] {1.2, 3.4};
+    double relevance = 1.2;
+    JsonObject properties = new JsonObject();
+    properties.addProperty("foo1", "bar");
+    CarmenFeature feature = new CarmenFeature();
+
+    // Type specific
+    feature.setText("Text field 1");
+    feature.setPlaceName("Text field 2");
+    feature.setBbox(bbox);
+    feature.setAddress("Text field 3");
+    feature.setCenter(center);
+    feature.setContext(null);
+    feature.setRelevance(relevance);
+
+    // Inherited
+    feature.setGeometry(null);
+    feature.setProperties(properties);
+    feature.setId("Text field 4");
+
+    String body = new String(Files.readAllBytes(Paths.get(GEOCODING_FIXTURE)), Charset.forName("utf-8"));
+    CarmenFeature carmenFeature = CarmenFeature.fromJson(body);
+    assertEquals(carmenFeature.getText(), feature.getText());
   }
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-java/issues/278

Carmen Feature was using the `fromJson()` method found in the Feature.class. This method was returning a Feature object and not a Carmen. To get around this, I added a fromJson method to Carmen Feature.