### PR TITLE
Update test app to v5.0 of the SDK

### DIFF
--- a/mapbox/app/build.gradle
+++ b/mapbox/app/build.gradle
@@ -41,9 +41,9 @@ dependencies {
     compile "com.android.support:recyclerview-v7:25.1.0"
 
     // Mapbox SDK
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.1@aar') {
-        transitive = true
-        exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-java-services'
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.0-SNAPSHOT@aar') {
+        transitive=true
+        exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-java-geojson'
     }
 
     // Leak Canary

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/MasApplication.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/MasApplication.java
@@ -4,7 +4,7 @@ import android.app.Application;
 import android.text.TextUtils;
 import android.util.Log;
 
-import com.mapbox.mapboxsdk.MapboxAccountManager;
+import com.mapbox.mapboxsdk.Mapbox;
 import com.squareup.leakcanary.LeakCanary;
 
 public class MasApplication extends Application {
@@ -26,6 +26,6 @@ public class MasApplication extends Application {
     if (TextUtils.isEmpty(mapboxAccessToken)) {
       Log.w(LOG_TAG, "Warning: access token isn't set.");
     }
-    MapboxAccountManager.start(getApplicationContext(), mapboxAccessToken);
+    Mapbox.getInstance(getApplicationContext(), mapboxAccessToken);
   }
 }

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/Utils.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/Utils.java
@@ -1,11 +1,9 @@
 package com.mapbox.services.android.testapp;
 
 import android.content.Context;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 
-import com.mapbox.mapboxsdk.constants.MapboxConstants;
+import com.mapbox.mapboxsdk.Mapbox;
 
 public class Utils {
 
@@ -13,21 +11,17 @@ public class Utils {
    * <p>
    * Returns the Mapbox access token set in the app resources.
    * </p>
-   * It will first search the application manifest for a {@link MapboxConstants#KEY_META_DATA_MANIFEST}
-   * meta-data value. If not found it will then attempt to load the access token from the
+   * It will first search for a token in the Mapbox object. If not found it
+   * will then attempt to load the access token from the
    * {@code res/values/dev.xml} development file.
    *
    * @param context The {@link Context} of the {@link android.app.Activity} or {@link android.app.Fragment}.
    * @return The Mapbox access token or null if not found.
-   * @see MapboxConstants#KEY_META_DATA_MANIFEST
    */
   public static String getMapboxAccessToken(@NonNull Context context) {
     try {
       // Read out AndroidManifest
-      PackageManager packageManager = context.getPackageManager();
-      ApplicationInfo appInfo = packageManager
-        .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-      String token = appInfo.metaData.getString(MapboxConstants.KEY_META_DATA_MANIFEST);
+      String token = Mapbox.getAccessToken();
       if (token == null || token.isEmpty()) {
         throw new IllegalArgumentException();
       }

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/directions/DirectionsV5Activity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/directions/DirectionsV5Activity.java
@@ -159,6 +159,12 @@ public class DirectionsV5Activity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -174,6 +180,12 @@ public class DirectionsV5Activity extends AppCompatActivity {
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/directions/RouteUtilsV5Activity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/directions/RouteUtilsV5Activity.java
@@ -256,6 +256,12 @@ public class RouteUtilsV5Activity extends AppCompatActivity implements OnMapRead
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -271,6 +277,12 @@ public class RouteUtilsV5Activity extends AppCompatActivity implements OnMapRead
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/distance/DistanceActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/distance/DistanceActivity.java
@@ -234,6 +234,12 @@ public class DistanceActivity extends AppCompatActivity implements OnMapReadyCal
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -249,6 +255,12 @@ public class DistanceActivity extends AppCompatActivity implements OnMapReadyCal
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/distance/DistanceActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/distance/DistanceActivity.java
@@ -177,7 +177,7 @@ public class DistanceActivity extends AppCompatActivity implements OnMapReadyCal
   private void addMarkers() {
     for (int i = 0; i < restaurants.size(); i++) {
       CircleLayer circleLayer = new CircleLayer(
-        "circle-layer",
+              restaurants.get(i).getStringProperty("name") + "-circle-layer",
         restaurants.get(i).getStringProperty("name") + "-source"
       ).withProperties(
         circleColor(Color.parseColor("#e55e5e")),

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/geocoding/GeocodingReverseActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/geocoding/GeocodingReverseActivity.java
@@ -68,6 +68,12 @@ public class GeocodingReverseActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -83,6 +89,12 @@ public class GeocodingReverseActivity extends AppCompatActivity {
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/geocoding/GeocodingWidgetActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/geocoding/GeocodingWidgetActivity.java
@@ -105,6 +105,12 @@ public class GeocodingWidgetActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -120,6 +126,12 @@ public class GeocodingWidgetActivity extends AppCompatActivity {
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/nav/OffRouteDetectionActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/nav/OffRouteDetectionActivity.java
@@ -123,6 +123,12 @@ public class OffRouteDetectionActivity extends AppCompatActivity {
   } // End onCreate
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -142,6 +148,12 @@ public class OffRouteDetectionActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/nav/OffRouteDetectionActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/nav/OffRouteDetectionActivity.java
@@ -329,7 +329,7 @@ public class OffRouteDetectionActivity extends AppCompatActivity {
           // and starts outside the current user view. Without this, the user must
           // intentionally execute a gesture before the view marker reappears on
           // the map.
-          map.getMarkerViewManager().scheduleViewMarkerInvalidation();
+          map.getMarkerViewManager().update();
 
           // Rotate the car (marker) to the correct orientation.
           car.setRotation((float) computeHeading(car.getPosition(), routePoints.get(count)));

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/nav/SnapToRouteActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/nav/SnapToRouteActivity.java
@@ -9,7 +9,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
-import com.mapbox.mapboxsdk.MapboxAccountManager;
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.annotations.Polyline;
@@ -230,7 +230,7 @@ public class SnapToRouteActivity extends AppCompatActivity implements OnMapReady
       .setOverview(DirectionsCriteria.OVERVIEW_FULL)
       .setSteps(true)
       .setProfile(DirectionsCriteria.PROFILE_DRIVING)
-      .setAccessToken(MapboxAccountManager.getInstance().getAccessToken())
+      .setAccessToken(Mapbox.getAccessToken())
       .build();
 
     Log.i(TAG, "Request: " + client.cloneCall().request());

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/nav/SnapToRouteActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/nav/SnapToRouteActivity.java
@@ -312,6 +312,12 @@ public class SnapToRouteActivity extends AppCompatActivity implements OnMapReady
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -328,6 +334,13 @@ public class SnapToRouteActivity extends AppCompatActivity implements OnMapReady
     super.onLowMemory();
     mapView.onLowMemory();
   }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
 
   @Override
   protected void onDestroy() {

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfBearingActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfBearingActivity.java
@@ -47,6 +47,12 @@ public class TurfBearingActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -62,6 +68,12 @@ public class TurfBearingActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfDestinationActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfDestinationActivity.java
@@ -66,6 +66,12 @@ public class TurfDestinationActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -81,6 +87,12 @@ public class TurfDestinationActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfDistanceActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfDistanceActivity.java
@@ -53,6 +53,12 @@ public class TurfDistanceActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -68,6 +74,12 @@ public class TurfDistanceActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfInsideActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfInsideActivity.java
@@ -64,6 +64,12 @@ public class TurfInsideActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -79,6 +85,12 @@ public class TurfInsideActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfLineSliceActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfLineSliceActivity.java
@@ -52,6 +52,12 @@ public class TurfLineSliceActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -67,6 +73,12 @@ public class TurfLineSliceActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfMidpointActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/turf/TurfMidpointActivity.java
@@ -50,6 +50,12 @@ public class TurfMidpointActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -65,6 +71,12 @@ public class TurfMidpointActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/utils/MapMatchingActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/utils/MapMatchingActivity.java
@@ -99,6 +99,12 @@ public class MapMatchingActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -114,6 +120,12 @@ public class MapMatchingActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/utils/SimplifyPolylineActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/utils/SimplifyPolylineActivity.java
@@ -131,6 +131,12 @@ public class SimplifyPolylineActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     mapView.onResume();
@@ -146,6 +152,12 @@ public class SimplifyPolylineActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
   }
 
   @Override

--- a/mapbox/app/src/main/res/layout/activity_distance.xml
+++ b/mapbox/app/src/main/res/layout/activity_distance.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,9 +12,9 @@
         android:id="@+id/mapview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        mapbox:center_latitude="30.2686"
-        mapbox:center_longitude="-97.7444"
-        mapbox:style_url="@string/style_dark"
-        mapbox:zoom="13"/>
+        app:mapbox_cameraTargetLat="30.2686"
+        app:mapbox_cameraTargetLng="-97.7444"
+        app:mapbox_styleUrl="@string/mapbox_style_dark"
+        app:mapbox_cameraZoom="13"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_geocoding_reverse.xml
+++ b/mapbox/app/src/main/res/layout/activity_geocoding_reverse.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -14,10 +14,10 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="5"
-        mapbox:center_latitude="38.90962"
-        mapbox:center_longitude="-77.04341"
-        mapbox:style_url="@string/default_style"
-        mapbox:zoom="15"/>
+        app:mapbox_cameraTargetLat="38.90962"
+        app:mapbox_cameraTargetLng="-77.04341"
+        app:mapbox_styleUrl="@string/default_style"
+        app:mapbox_cameraZoom="15"/>
 
     <TextView
         android:id="@+id/message"

--- a/mapbox/app/src/main/res/layout/activity_off_route_detection.xml
+++ b/mapbox/app/src/main/res/layout/activity_off_route_detection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,10 +12,10 @@
         android:id="@+id/mapview"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
-        mapbox:center_latitude="48.8552"
-        mapbox:center_longitude="2.3474"
-        mapbox:rotate_enabled="false"
-        mapbox:style_url="@string/style_light"
-        mapbox:zoom="12"/>
+        app:mapbox_cameraTargetLat="48.8552"
+        app:mapbox_cameraTargetLng="2.3474"
+        app:mapbox_uiRotateGestures="false"
+        app:mapbox_styleUrl="@string/mapbox_style_light"
+        app:mapbox_cameraZoom="12"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_snap_to_route.xml
+++ b/mapbox/app/src/main/res/layout/activity_snap_to_route.xml
@@ -12,9 +12,9 @@
         android:id="@+id/mapview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:center_latitude="29.7850"
-        app:center_longitude="-95.7357"
-        app:zoom="13"/>
+        app:mapbox_cameraTargetLat="29.7850"
+        app:mapbox_cameraTargetLng="-95.7357"
+        app:mapbox_cameraZoom="13"/>
 
     <RelativeLayout
         android:layout_width="wrap_content"

--- a/mapbox/app/src/main/res/layout/activity_turf_bearing.xml
+++ b/mapbox/app/src/main/res/layout/activity_turf_bearing.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -13,9 +13,9 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        mapbox:center_latitude="33.991986"
-        mapbox:center_longitude="-118.475743"
-        mapbox:style_url="mapbox://styles/mapbox/streets-v9"
-        mapbox:zoom="14.5"/>
+        app:mapbox_cameraTargetLat="33.991986"
+        app:mapbox_cameraTargetLng="-118.475743"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
+        app:mapbox_cameraZoom="14.5"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_turf_destination.xml
+++ b/mapbox/app/src/main/res/layout/activity_turf_destination.xml
@@ -13,10 +13,10 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:center_latitude="33.991986"
-        app:center_longitude="-118.475743"
-        app:style_url="mapbox://styles/mapbox/streets-v9"
-        app:zoom="14.5"/>
+        app:mapbox_cameraTargetLat="33.991986"
+        app:mapbox_cameraTargetLng="-118.475743"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
+        app:mapbox_cameraZoom="14.5"/>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/turf_destination_fab"

--- a/mapbox/app/src/main/res/layout/activity_turf_distance.xml
+++ b/mapbox/app/src/main/res/layout/activity_turf_distance.xml
@@ -13,9 +13,9 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:center_latitude="33.991986"
-        app:center_longitude="-118.475743"
-        app:style_url="mapbox://styles/mapbox/streets-v9"
-        app:zoom="14.5"/>
+        app:mapbox_cameraTargetLat="33.991986"
+        app:mapbox_cameraTargetLng="-118.475743"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
+        app:mapbox_cameraZoom="14.5"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_turf_inside.xml
+++ b/mapbox/app/src/main/res/layout/activity_turf_inside.xml
@@ -13,9 +13,9 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:center_latitude="33.9425"
-        app:center_longitude="-118.4050"
-        app:style_url="mapbox://styles/mapbox/streets-v9"
-        app:zoom="12"/>
+        app:mapbox_cameraTargetLat="33.9425"
+        app:mapbox_cameraTargetLng="-118.4050"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
+        app:mapbox_cameraZoom="12"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_turf_line_slice.xml
+++ b/mapbox/app/src/main/res/layout/activity_turf_line_slice.xml
@@ -13,9 +13,9 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:center_latitude="33.998387"
-        app:center_longitude="-118.471271"
-        app:style_url="mapbox://styles/mapbox/streets-v9"
-        app:zoom="14"/>
+        app:mapbox_cameraTargetLat="33.998387"
+        app:mapbox_cameraTargetLng="-118.471271"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
+        app:mapbox_cameraZoom="14"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_turf_midpoint.xml
+++ b/mapbox/app/src/main/res/layout/activity_turf_midpoint.xml
@@ -13,9 +13,9 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:center_latitude="33.998387"
-        app:center_longitude="-118.471271"
-        app:style_url="mapbox://styles/mapbox/streets-v9"
-        app:zoom="14"/>
+        app:mapbox_cameraTargetLat="33.998387"
+        app:mapbox_cameraTargetLng="-118.471271"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
+        app:mapbox_cameraZoom="14"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_utils_map_matching.xml
+++ b/mapbox/app/src/main/res/layout/activity_utils_map_matching.xml
@@ -52,7 +52,7 @@
         android:layout_height="match_parent"
         app:mapbox_cameraTargetLat="34.01591350351023"
         app:mapbox_cameraTargetLng="-118.4945560781314"
-        mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
         app:mapbox_cameraZoom="14.5"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_utils_map_matching.xml
+++ b/mapbox/app/src/main/res/layout/activity_utils_map_matching.xml
@@ -2,7 +2,6 @@
 <android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -51,9 +50,9 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        mapbox:center_latitude="34.01591350351023"
-        mapbox:center_longitude="-118.4945560781314"
-        mapbox:style_url="mapbox://styles/mapbox/streets-v9"
-        mapbox:zoom="14.5"/>
+        app:mapbox_cameraTargetLat="34.01591350351023"
+        app:mapbox_cameraTargetLng="-118.4945560781314"
+        mapbox_styleUrl="mapbox://styles/mapbox/streets-v9"
+        app:mapbox_cameraZoom="14.5"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/app/src/main/res/layout/activity_utils_simplify_polyline.xml
+++ b/mapbox/app/src/main/res/layout/activity_utils_simplify_polyline.xml
@@ -79,9 +79,9 @@
         android:id="@+id/mapview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:center_latitude="37.692465"
-        app:center_longitude="-122.410413"
-        app:style_url="mapbox://styles/mapbox/light-v9"
-        app:zoom="10.5"/>
+        app:mapbox_cameraTargetLat="37.692465"
+        app:mapbox_cameraTargetLng="-122.410413"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/light-v9"
+        app:mapbox_cameraZoom="10.5"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/mapbox/build.gradle
+++ b/mapbox/build.gradle
@@ -19,6 +19,7 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }
 
     group = GROUP


### PR DESCRIPTION
Looks like upgrading to the latest 5.0 snapshot fixes https://github.com/mapbox/mapbox-java/issues/299. If you now load the reverse geocoding activity it all works as expected.

Please note this is a WIP as the migration hasn't been finished (only the reverse geocoding activity has for now the new `onStart`/`onStop` methods calls).

@cammace All changes here are great candidates for the `4.x` -> `5.x` migration guide. In particular the `map.getMarkerViewManager().scheduleViewMarkerInvalidation();` -> `map.getMarkerViewManager().update();` change needs a javadoc update to document the new name and behavior. cc: @tobrun 