### PR TITLE
RxJava support

### DIFF
--- a/mapbox/app/build.gradle
+++ b/mapbox/app/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     // The Test App depends in Mapbox Android UI, which includes all modules
     compile project(':libandroid-ui')
 
+    // Rx extensions
+    compile project(':libjava-services-rx')
+
     // Android Support libraries
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.support:design:25.1.0'

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/directions/DirectionsV5Activity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/directions/DirectionsV5Activity.java
@@ -113,13 +113,13 @@ public class DirectionsV5Activity extends AppCompatActivity {
       .setOverview(DirectionsCriteria.OVERVIEW_FULL)
       .build();
 
-    MapboxDirectionsRx.Builder builder = new MapboxDirectionsRx.Builder()
+    MapboxDirectionsRx clientRx = new MapboxDirectionsRx.Builder()
       .setAccessToken(Utils.getMapboxAccessToken(this))
       .setCoordinates(positions)
       .setProfile(DirectionsCriteria.PROFILE_DRIVING)
       .setSteps(true)
-      .setOverview(DirectionsCriteria.OVERVIEW_FULL);
-    MapboxDirectionsRx clientRx = new MapboxDirectionsRx(builder);
+      .setOverview(DirectionsCriteria.OVERVIEW_FULL)
+      .build();
     clientRx.getObservable()
       .subscribeOn(Schedulers.newThread())
       .observeOn(AndroidSchedulers.mainThread())

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/directions/DirectionsV5Activity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/directions/DirectionsV5Activity.java
@@ -23,6 +23,7 @@ import com.mapbox.services.api.directions.v5.DirectionsCriteria;
 import com.mapbox.services.api.directions.v5.MapboxDirections;
 import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.services.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.api.rx.directions.v5.MapboxDirectionsRx;
 import com.mapbox.services.commons.geojson.LineString;
 import com.mapbox.services.commons.models.Position;
 
@@ -33,6 +34,9 @@ import java.util.Locale;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Action1;
+import rx.schedulers.Schedulers;
 
 public class DirectionsV5Activity extends AppCompatActivity {
 
@@ -108,6 +112,25 @@ public class DirectionsV5Activity extends AppCompatActivity {
       .setSteps(true)
       .setOverview(DirectionsCriteria.OVERVIEW_FULL)
       .build();
+
+    MapboxDirectionsRx.Builder builder = new MapboxDirectionsRx.Builder()
+      .setAccessToken(Utils.getMapboxAccessToken(this))
+      .setCoordinates(positions)
+      .setProfile(DirectionsCriteria.PROFILE_DRIVING)
+      .setSteps(true)
+      .setOverview(DirectionsCriteria.OVERVIEW_FULL);
+    MapboxDirectionsRx clientRx = new MapboxDirectionsRx(builder);
+    clientRx.getObservable()
+      .subscribeOn(Schedulers.newThread())
+      .observeOn(AndroidSchedulers.mainThread())
+      .subscribe(new Action1<DirectionsResponse>() {
+        @Override
+        public void call(DirectionsResponse response) {
+          DirectionsRoute currentRoute = response.getRoutes().get(0);
+          Log.d(LOG_TAG, "Response code: " + response.getCode());
+          Log.d(LOG_TAG, "Distance: " + currentRoute.getDistance());
+        }
+      });
 
     client.enqueueCall(new Callback<DirectionsResponse>() {
       @Override

--- a/mapbox/dependencies.gradle
+++ b/mapbox/dependencies.gradle
@@ -12,6 +12,7 @@ ext {
         gson: 'com.google.code.gson:gson:2.8.0',
         retrofit2Main: 'com.squareup.retrofit2:retrofit:2.1.0',
         retrofit2Gson: 'com.squareup.retrofit2:converter-gson:2.1.0',
+        retrofit2Rx: 'com.squareup.retrofit2:adapter-rxjava:2.1.0',
         okhttp3Logging: 'com.squareup.okhttp3:logging-interceptor:3.5.0',
         okhttp3Mockwebserver: 'com.squareup.okhttp3:mockwebserver:3.5.0',
         junit: 'junit:junit:4.12',

--- a/mapbox/libjava-services-rx/build.gradle
+++ b/mapbox/libjava-services-rx/build.gradle
@@ -9,6 +9,11 @@ dependencies {
 
     // Rx extensions
     compile rootProject.ext.dep.retrofit2Rx
+
+    // Testing
+    testCompile rootProject.ext.dep.okhttp3Mockwebserver
+    testCompile rootProject.ext.dep.junit
+    testCompile rootProject.ext.dep.hamcrestJunit
 }
 
 apply from: 'gradle-javadoc.gradle'

--- a/mapbox/libjava-services-rx/build.gradle
+++ b/mapbox/libjava-services-rx/build.gradle
@@ -6,6 +6,9 @@ targetCompatibility = "1.7"
 dependencies {
     // Rx support depends on non-Rx services
     compile project(':libjava-services')
+
+    // Rx extensions
+    compile rootProject.ext.dep.retrofit2Rx
 }
 
 apply from: 'gradle-javadoc.gradle'

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/DirectionsServiceRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/DirectionsServiceRx.java
@@ -16,7 +16,7 @@ import rx.Observable;
 public interface DirectionsServiceRx {
 
   /**
-   * Call-based interface
+   * Observable-based interface
    *
    * @param userAgent        The user.
    * @param user             The user.
@@ -30,7 +30,7 @@ public interface DirectionsServiceRx {
    * @param steps            Define if you'd like the route steps.
    * @param continueStraight Define whether the route should continue straight even if the route
    *                         will be slower.
-   * @return A retrofit Call object
+   * @return A retrofit Observable object
    * @since 2.0.0
    */
   @GET("directions/v5/{user}/{profile}/{coordinates}")

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/DirectionsServiceRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/DirectionsServiceRx.java
@@ -1,19 +1,19 @@
-package com.mapbox.services.api.directions.v5;
+package com.mapbox.services.api.rx.directions.v5;
 
 import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
 
-import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
+import rx.Observable;
 
 /**
  * Interface that defines the directions service (v5).
  *
- * @since 1.0.0
+ * @since 2.0.0
  */
-public interface DirectionsService {
+public interface DirectionsServiceRx {
 
   /**
    * Call-based interface
@@ -31,11 +31,10 @@ public interface DirectionsService {
    * @param continueStraight Define whether the route should continue straight even if the route
    *                         will be slower.
    * @return A retrofit Call object
-   * @since 1.0.0
+   * @since 2.0.0
    */
   @GET("directions/v5/{user}/{profile}/{coordinates}")
-  Call<DirectionsResponse> getCall(
-    // NOTE: DirectionsServiceRx should be updated as well
+  Observable<DirectionsResponse> getObservable(
     @Header("User-Agent") String userAgent,
     @Path("user") String user,
     @Path("profile") String profile,

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/MapboxDirectionsRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/MapboxDirectionsRx.java
@@ -1,0 +1,68 @@
+package com.mapbox.services.api.rx.directions.v5;
+
+import com.mapbox.services.api.directions.v5.MapboxDirections;
+import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
+
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+import rx.Observable;
+
+/**
+ * The Directions API allows the calculation of routes between coordinates. The fastest route
+ * is returned with geometries, and turn-by-turn instructions. The Mapbox Directions API supports
+ * routing for driving cars, riding bicycles and walking.
+ *
+ * This class has support for Rx Observables.
+ *
+ * @since 2.0.0
+ */
+public class MapboxDirectionsRx extends MapboxDirections {
+
+  private DirectionsServiceRx serviceRx = null;
+  private Observable<DirectionsResponse> observable = null;
+
+  public MapboxDirectionsRx(Builder builder) {
+    super(builder);
+  }
+
+  private DirectionsServiceRx getServiceRx() {
+    // No need to recreate it
+    if (serviceRx != null) {
+      return serviceRx;
+    }
+
+    // Retrofit instance
+    Retrofit retrofit = new Retrofit.Builder()
+      .client(getOkHttpClient())
+      .baseUrl(builder.getBaseUrl())
+      .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+      .build();
+
+    // Directions service
+    serviceRx = retrofit.create(DirectionsServiceRx.class);
+    return serviceRx;
+  }
+
+  public Observable<DirectionsResponse> getObservable() {
+    // No need to recreate it
+    if (observable != null) {
+      return observable;
+    }
+
+    observable = getServiceRx().getObservable(
+      getHeaderUserAgent(builder.getClientAppName()),
+      builder.getUser(),
+      builder.getProfile(),
+      builder.getCoordinates(),
+      builder.getAccessToken(),
+      builder.isAlternatives(),
+      builder.getGeometries(),
+      builder.getOverview(),
+      builder.getRadiuses(),
+      builder.isSteps(),
+      builder.isContinueStraight());
+
+    // Done
+    return observable;
+  }
+}

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/MapboxDirectionsRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/MapboxDirectionsRx.java
@@ -6,6 +6,7 @@ import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
 
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+import retrofit2.converter.gson.GsonConverterFactory;
 import rx.Observable;
 
 /**
@@ -37,6 +38,7 @@ public class MapboxDirectionsRx extends MapboxDirections {
       .client(getOkHttpClient())
       .baseUrl(builder.getBaseUrl())
       .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+      .addConverterFactory(GsonConverterFactory.create())
       .build();
 
     // Directions service

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/MapboxDirectionsRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/directions/v5/MapboxDirectionsRx.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.api.rx.directions.v5;
 
+import com.mapbox.services.api.ServicesException;
 import com.mapbox.services.api.directions.v5.MapboxDirections;
 import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
 
@@ -64,5 +65,13 @@ public class MapboxDirectionsRx extends MapboxDirections {
 
     // Done
     return observable;
+  }
+
+  public static class Builder extends MapboxDirections.Builder<Builder> {
+    @Override
+    public MapboxDirectionsRx build() throws ServicesException {
+      super.build();
+      return new MapboxDirectionsRx(this);
+    }
   }
 }

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/distance/v1/DistanceServiceRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/distance/v1/DistanceServiceRx.java
@@ -1,0 +1,38 @@
+package com.mapbox.services.api.rx.distance.v1;
+
+import com.mapbox.services.api.distance.v1.models.DistanceResponse;
+import com.mapbox.services.commons.geojson.MultiPoint;
+
+import okhttp3.RequestBody;
+import retrofit2.http.Body;
+import retrofit2.http.Header;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import rx.Observable;
+
+/**
+ * Interface that defines the distance service.
+ *
+ * @since 2.0.0
+ */
+public interface DistanceServiceRx {
+  /**
+   * Observable-based interface
+   *
+   * @param userAgent   The User.
+   * @param user        The user.
+   * @param profile     Directions profile id.
+   * @param accessToken Mapbox access token.
+   * @param coordinates converted to a {@link MultiPoint#toJson()}.
+   * @return The {@link DistanceResponse} in a Observable wrapper
+   * @since 2.0.0
+   */
+  @POST("distances/v1/{user}/{profile}")
+  Observable<DistanceResponse> getObservable(
+    @Header("User-Agent") String userAgent,
+    @Path("user") String user,
+    @Path("profile") String profile,
+    @Query("access_token") String accessToken,
+    @Body RequestBody coordinates);
+}

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/distance/v1/MapboxDistanceRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/distance/v1/MapboxDistanceRx.java
@@ -1,0 +1,84 @@
+package com.mapbox.services.api.rx.distance.v1;
+
+import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.distance.v1.MapboxDistance;
+import com.mapbox.services.api.distance.v1.models.DistanceResponse;
+
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+import retrofit2.converter.gson.GsonConverterFactory;
+import rx.Observable;
+
+/**
+ * Note this API is still in preview.
+ * <p>
+ * The Mapbox Distance API returns all travel times between many points. For example, given 3
+ * locations A, B, C, the Distance API will return a matrix of travel times in seconds between each
+ * location. This API allows you to build tools that efficiently check the reachability of
+ * coordinates from each other, filter points by travel time, or run algorithms for solving
+ * optimization problems.
+ * </p>
+ * <p>
+ * Limits placed on this API include a maximum 100 coordinate pairs per request and a maximum 60
+ * requests per minute.
+ * </p>
+ * This class has support for Rx Observables.
+ *
+ * @see <a href="https://www.mapbox.com/api-documentation/?language=Java#distance">Mapbox Distance API documentation</a>
+ * @since 2.0.0
+ */
+public class MapboxDistanceRx extends MapboxDistance {
+
+  private DistanceServiceRx serviceRx = null;
+  private Observable<DistanceResponse> observable = null;
+
+  public MapboxDistanceRx(Builder builder) {
+    super(builder);
+  }
+
+  private DistanceServiceRx getServiceRx() {
+    // No need to recreate it
+    if (serviceRx != null) {
+      return serviceRx;
+    }
+
+    // Retrofit instance
+    Retrofit retrofit = new Retrofit.Builder()
+      .client(getOkHttpClient())
+      .baseUrl(builder.getBaseUrl())
+      .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+      .addConverterFactory(GsonConverterFactory.create(getGson()))
+      .build();
+
+    // Distance service
+    serviceRx = retrofit.create(DistanceServiceRx.class);
+    return serviceRx;
+  }
+
+  public Observable<DistanceResponse> getObservable() {
+    // No need to recreate it
+    if (observable != null) {
+      return observable;
+    }
+
+    observable = getServiceRx().getObservable(
+      getHeaderUserAgent(builder.getClientAppName()),
+      builder.getUser(),
+      builder.getProfile(),
+      builder.getAccessToken(),
+      builder.getCoordinates()
+    );
+
+    // Done
+    return observable;
+  }
+
+  public static class Builder extends MapboxDistance.Builder<Builder> {
+    @Override
+    public MapboxDistanceRx build() throws ServicesException {
+      super.build();
+      return new MapboxDistanceRx(this);
+    }
+  }
+
+}

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/geocoding/v5/GeocodingServiceRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/geocoding/v5/GeocodingServiceRx.java
@@ -1,0 +1,78 @@
+package com.mapbox.services.api.rx.geocoding.v5;
+
+import com.mapbox.services.api.geocoding.v5.models.GeocodingResponse;
+
+import java.util.List;
+
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import rx.Observable;
+
+/**
+ * Created by antonio on 2/6/17.
+ */
+
+public interface GeocodingServiceRx {
+
+  /**
+   * Observable-based interface
+   *
+   * @param userAgent    The user
+   * @param mode         mapbox.places or mapbox.places-permanent for enterprise geocoding.
+   * @param query        a location; a place name for forward geocoding or a coordinate pair
+   *                     (longitude, latitude location) for reverse geocoding
+   * @param accessToken  Mapbox access token.
+   * @param country      ISO 3166 alpha 2 country codes, separated by commas.
+   * @param proximity    Location around which to bias results.
+   * @param types        Filter results by one or more type.
+   * @param autocomplete True if you want auto complete.
+   * @param bbox         Optionally pass in a bounding box to limit results in.
+   * @param limit        Optionally pass in a limit the amount of returning results.
+   * @return A retrofit Observable object
+   * @since 1.0.0
+   */
+  @GET("/geocoding/v5/{mode}/{query}.json")
+  Observable<GeocodingResponse> getObservable(
+    @Header("User-Agent") String userAgent,
+    @Path("mode") String mode,
+    @Path("query") String query,
+    @Query("access_token") String accessToken,
+    @Query("country") String country,
+    @Query("proximity") String proximity,
+    @Query("types") String types,
+    @Query("autocomplete") Boolean autocomplete,
+    @Query("bbox") String bbox,
+    @Query("limit") String limit);
+
+  /**
+   * Observable-based interface
+   *
+   * @param userAgent    The user
+   * @param mode         mapbox.places-permanent for batch geocoding.
+   * @param query        a location; a place name for forward geocoding or a coordinate pair
+   *                     (longitude, latitude location) for reverse geocoding
+   * @param accessToken  Mapbox access token.
+   * @param country      ISO 3166 alpha 2 country codes, separated by commas.
+   * @param proximity    Location around which to bias results.
+   * @param types        Filter results by one or more type.
+   * @param autocomplete True if you want auto complete.
+   * @param bbox         Optionally pass in a bounding box to limit results in.
+   * @param limit        Optionally pass in a limit the amount of returning results.
+   * @return A retrofit Observable object
+   * @since 1.0.0
+   */
+  @GET("/geocoding/v5/{mode}/{query}.json")
+  Observable<List<GeocodingResponse>> getBatchObservable(
+    @Header("User-Agent") String userAgent,
+    @Path("mode") String mode,
+    @Path("query") String query,
+    @Query("access_token") String accessToken,
+    @Query("country") String country,
+    @Query("proximity") String proximity,
+    @Query("types") String types,
+    @Query("autocomplete") Boolean autocomplete,
+    @Query("bbox") String bbox,
+    @Query("limit") String limit);
+}

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/geocoding/v5/GeocodingServiceRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/geocoding/v5/GeocodingServiceRx.java
@@ -11,9 +11,10 @@ import retrofit2.http.Query;
 import rx.Observable;
 
 /**
- * Created by antonio on 2/6/17.
+ * Interface that defines the geocoding service.
+ *
+ * @since 2.0.0
  */
-
 public interface GeocodingServiceRx {
 
   /**

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/geocoding/v5/MapboxGeocodingRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/geocoding/v5/MapboxGeocodingRx.java
@@ -1,0 +1,109 @@
+package com.mapbox.services.api.rx.geocoding.v5;
+
+import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.geocoding.v5.MapboxGeocoding;
+import com.mapbox.services.api.geocoding.v5.models.GeocodingResponse;
+
+import java.util.List;
+
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+import retrofit2.converter.gson.GsonConverterFactory;
+import rx.Observable;
+
+/**
+ * The Mapbox geocoding client (v5).
+ *
+ * This class has support for Rx Observables.
+ *
+ * @since 2.0.0
+ */
+public class MapboxGeocodingRx extends MapboxGeocoding {
+
+  private GeocodingServiceRx serviceRx = null;
+  private Observable<GeocodingResponse> observable = null;
+  private Observable<List<GeocodingResponse>> batchObservable = null;
+
+  public MapboxGeocodingRx(Builder builder) {
+    super(builder);
+  }
+
+  private GeocodingServiceRx getServiceRx() {
+    // No need to recreate it
+    if (serviceRx != null) {
+      return serviceRx;
+    }
+
+    // Retrofit instance
+    Retrofit retrofit = new Retrofit.Builder()
+      .client(getOkHttpClient())
+      .baseUrl(builder.getBaseUrl())
+      .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+      .addConverterFactory(GsonConverterFactory.create(getGson()))
+      .build();
+
+    // Geocoding service
+    serviceRx = retrofit.create(GeocodingServiceRx.class);
+    return serviceRx;
+  }
+
+  public Observable<GeocodingResponse> getObservable() {
+    // No need to recreate it
+    if (observable != null) {
+      return observable;
+    }
+
+    if (builder.getQuery().contains(";")) {
+      throw new IllegalArgumentException("Use getBatchObservable() for batch calls.");
+    }
+
+    observable = getServiceRx().getObservable(
+      getHeaderUserAgent(builder.getClientAppName()),
+      builder.getMode(),
+      builder.getQuery(),
+      builder.getAccessToken(),
+      builder.getCountry(),
+      builder.getProximity(),
+      builder.getGeocodingTypes(),
+      builder.getAutocomplete(),
+      builder.getBbox(),
+      builder.getLimit());
+
+    // Done
+    return observable;
+  }
+
+  public Observable<List<GeocodingResponse>> getBatchObservable() {
+    // No need to recreate it
+    if (batchObservable != null) {
+      return batchObservable;
+    }
+
+    if (!builder.getQuery().contains(";")) {
+      throw new IllegalArgumentException("Use getObservable() for non-batch calls.");
+    }
+
+    batchObservable = getServiceRx().getBatchObservable(
+      getHeaderUserAgent(builder.getClientAppName()),
+      builder.getMode(),
+      builder.getQuery(),
+      builder.getAccessToken(),
+      builder.getCountry(),
+      builder.getProximity(),
+      builder.getGeocodingTypes(),
+      builder.getAutocomplete(),
+      builder.getBbox(),
+      builder.getLimit());
+
+    // Done
+    return batchObservable;
+  }
+
+  public static class Builder extends MapboxGeocoding.Builder<Builder> {
+    @Override
+    public MapboxGeocodingRx build() throws ServicesException {
+      super.build();
+      return new MapboxGeocodingRx(this);
+    }
+  }
+}

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/mapmatching/v4/MapMatchingServiceRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/mapmatching/v4/MapMatchingServiceRx.java
@@ -1,0 +1,39 @@
+package com.mapbox.services.api.rx.mapmatching.v4;
+
+import com.mapbox.services.api.mapmatching.v4.models.MapMatchingResponse;
+
+import okhttp3.RequestBody;
+import retrofit2.http.Body;
+import retrofit2.http.Header;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import rx.Observable;
+
+/**
+ * Interface that defines the map matching service.
+ *
+ * @since 2.0.0
+ */
+public interface MapMatchingServiceRx {
+  /**
+   * Observable-based interface
+   *
+   * @param userAgent    user
+   * @param profile      map matching profile id
+   * @param accessToken  Mapbox access token
+   * @param geometry     format for the returned geometry (optional)
+   * @param gpsPrecision assumed precision in meters of the used tracking device
+   * @param trace        The trace wanting to be matched
+   * @return The MapMatchingResponse in a Observable wrapper
+   * @since 1.2.0
+   */
+  @POST("matching/v4/{profile}.json")
+  Observable<MapMatchingResponse> getObservable(
+    @Header("User-Agent") String userAgent,
+    @Path("profile") String profile,
+    @Query("access_token") String accessToken,
+    @Query("geometry") String geometry,
+    @Query("gps_precision") Integer gpsPrecision,
+    @Body RequestBody trace);
+}

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/mapmatching/v4/MapboxMapMatchingRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/mapmatching/v4/MapboxMapMatchingRx.java
@@ -1,0 +1,78 @@
+package com.mapbox.services.api.rx.mapmatching.v4;
+
+import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.mapmatching.v4.MapboxMapMatching;
+import com.mapbox.services.api.mapmatching.v4.models.MapMatchingResponse;
+
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+import retrofit2.converter.gson.GsonConverterFactory;
+import rx.Observable;
+
+/**
+ * The Mapbox map matching interface (v4)
+ * <p>
+ * The Mapbox Map Matching API snaps fuzzy, inaccurate traces from a GPS unit or a phone to the
+ * OpenStreetMap road and path network using the Directions API. This produces clean paths that can
+ * be displayed on a map or used for other analysis.
+ *
+ * This class has support for Rx Observables.
+ *
+ * @see <a href="https://www.mapbox.com/api-documentation/#map-matching">Map matching API documentation</a>
+ * @since 2.0.0
+ */
+public class MapboxMapMatchingRx extends MapboxMapMatching {
+
+  private MapMatchingServiceRx serviceRx = null;
+  private Observable<MapMatchingResponse> observable = null;
+
+  public MapboxMapMatchingRx(Builder builder) {
+    super(builder);
+  }
+
+  private MapMatchingServiceRx getServiceRx() {
+    // No need to recreate it
+    if (serviceRx != null) {
+      return serviceRx;
+    }
+
+    // Retrofit instance
+    Retrofit retrofit = new Retrofit.Builder()
+      .client(getOkHttpClient())
+      .baseUrl(builder.getBaseUrl())
+      .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+      .addConverterFactory(GsonConverterFactory.create(getGson()))
+      .build();
+
+    // MapMatching service
+    serviceRx = retrofit.create(MapMatchingServiceRx.class);
+    return serviceRx;
+  }
+
+  public Observable<MapMatchingResponse> getObservable() {
+    // No need to recreate it
+    if (observable != null) {
+      return observable;
+    }
+
+    observable = getServiceRx().getObservable(
+      getHeaderUserAgent(builder.getClientAppName()),
+      builder.getProfile(),
+      builder.getAccessToken(),
+      builder.getGeometry(),
+      builder.getGpsPrecison(),
+      builder.getTrace()
+    );
+
+    // Done
+    return observable;
+  }
+
+  public static class Builder extends MapboxMapMatching.Builder<Builder> {
+    @Override
+    public MapboxMapMatchingRx build() throws ServicesException {
+      super.build();
+      return new MapboxMapMatchingRx(this);
+    }
+  }
+}

--- a/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/directions/v5/MapboxDirectionsRxTest.java
+++ b/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/directions/v5/MapboxDirectionsRxTest.java
@@ -1,0 +1,101 @@
+package com.mapbox.services.api.rx.directions.v5;
+
+import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.directions.v5.DirectionsCriteria;
+import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.services.commons.models.Position;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import rx.observers.TestSubscriber;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test Rx support on the Mapbox Directions API
+ */
+
+public class MapboxDirectionsRxTest {
+
+  private static final double DELTA = 1E-10;
+
+  public static final String DIRECTIONS_FIXTURE = "../libjava-services/src/test/fixtures/directions_v5.json";
+
+  private MockWebServer server;
+  private HttpUrl mockUrl;
+
+  private ArrayList<Position> positions;
+
+  @Before
+  public void setUp() throws IOException {
+    server = new MockWebServer();
+
+    server.setDispatcher(new okhttp3.mockwebserver.Dispatcher() {
+      @Override
+      public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+        try {
+          String body = new String(Files.readAllBytes(Paths.get(DIRECTIONS_FIXTURE)), Charset.forName("utf-8"));
+          return new MockResponse().setBody(body);
+        } catch (IOException ioException) {
+          throw new RuntimeException(ioException);
+        }
+
+      }
+    });
+
+    server.start();
+
+    mockUrl = server.url("");
+
+    positions = new ArrayList<>();
+    positions.add(Position.fromCoordinates(-122.416667, 37.783333)); // SF
+    positions.add(Position.fromCoordinates(-121.9, 37.333333)); // SJ
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testSanityRX() throws ServicesException {
+    MapboxDirectionsRx client = new MapboxDirectionsRx.Builder()
+      .setAccessToken("pk.XXX")
+      .setCoordinates(positions)
+      .setProfile(DirectionsCriteria.PROFILE_DRIVING)
+      .setBaseUrl(mockUrl.toString())
+      .build();
+
+    TestSubscriber<DirectionsResponse> testSubscriber = new TestSubscriber<>();
+    client.getObservable().subscribe(testSubscriber);
+
+    testSubscriber.assertCompleted();
+    testSubscriber.assertNoErrors();
+    testSubscriber.assertValueCount(1);
+
+    List<DirectionsResponse> events = testSubscriber.getOnNextEvents();
+    assertEquals(1, events.size());
+
+    DirectionsResponse response = events.get(0);
+    assertEquals(response.getCode(), DirectionsCriteria.RESPONSE_OK);
+  }
+
+}

--- a/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/distance/v1/MapboxDistanceRxTest.java
+++ b/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/distance/v1/MapboxDistanceRxTest.java
@@ -1,0 +1,105 @@
+package com.mapbox.services.api.rx.distance.v1;
+
+import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.directions.v5.DirectionsCriteria;
+import com.mapbox.services.api.distance.v1.models.DistanceResponse;
+import com.mapbox.services.commons.models.Position;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import rx.observers.TestSubscriber;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test Rx support on the Mapbox Distance API
+ */
+
+public class MapboxDistanceRxTest {
+
+  private static final String DISTANCE_FIXTURE = "../libjava-services/src/test/fixtures/distance_v1.json";
+
+  private static final String ACCESS_TOKEN = "pk.XXX";
+
+  private MockWebServer server;
+  private HttpUrl mockUrl;
+
+  private List<Position> coordinates;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() throws IOException {
+    server = new MockWebServer();
+
+    server.setDispatcher(new Dispatcher() {
+
+      @Override
+      public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+        try {
+          String body = new String(Files.readAllBytes(Paths.get(DISTANCE_FIXTURE)), Charset.forName("utf-8"));
+          return new MockResponse().setBody(body);
+        } catch (IOException ioException) {
+          throw new RuntimeException(ioException);
+        }
+      }
+    });
+
+    server.start();
+    mockUrl = server.url("");
+
+    coordinates = new ArrayList<>();
+    coordinates.add(Position.fromCoordinates(13.41894, 52.50055));
+    coordinates.add(Position.fromCoordinates(14.10293, 52.50055));
+    coordinates.add(Position.fromCoordinates(13.50116, 53.10293));
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  public void testSanityRX() throws ServicesException {
+    MapboxDistanceRx client = new MapboxDistanceRx.Builder()
+      .setAccessToken(ACCESS_TOKEN)
+      .setProfile(DirectionsCriteria.PROFILE_WALKING)
+      .setCoordinates(coordinates)
+      .setBaseUrl(mockUrl.toString())
+      .build();
+
+    TestSubscriber<DistanceResponse> testSubscriber = new TestSubscriber<>();
+    client.getObservable().subscribe(testSubscriber);
+
+    testSubscriber.assertCompleted();
+    testSubscriber.assertNoErrors();
+    testSubscriber.assertValueCount(1);
+
+    List<DistanceResponse> events = testSubscriber.getOnNextEvents();
+    assertEquals(1, events.size());
+
+    DistanceResponse response = events.get(0);
+    assertNotNull(response);
+    assertEquals(3, response.getDurations().length);
+    assertNotNull(response.getDurations()[0][0]);
+  }
+
+}

--- a/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/geocoding/v5/MapboxGeocodingRxTest.java
+++ b/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/geocoding/v5/MapboxGeocodingRxTest.java
@@ -1,0 +1,93 @@
+package com.mapbox.services.api.rx.geocoding.v5;
+
+import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.geocoding.v5.models.GeocodingResponse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import rx.observers.TestSubscriber;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test Rx support on the Mapbox Geocoding API
+ */
+
+public class MapboxGeocodingRxTest {
+
+  private static final double DELTA = 1E-10;
+
+  private static final String GEOCODING_FIXTURE = "../libjava-services/src/test/fixtures/geocoding.json";
+  private static final String ACCESS_TOKEN = "pk.XXX";
+
+  private MockWebServer server;
+  private HttpUrl mockUrl;
+
+  @Before
+  public void setUp() throws IOException {
+    server = new MockWebServer();
+
+    server.setDispatcher(new Dispatcher() {
+
+      @Override
+      public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+        try {
+          String body = new String(Files.readAllBytes(Paths.get(GEOCODING_FIXTURE)), Charset.forName("utf-8"));
+          return new MockResponse().setBody(body);
+        } catch (IOException ioException) {
+          throw new RuntimeException(ioException);
+        }
+      }
+    });
+    server.start();
+
+    mockUrl = server.url("");
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testSanityRX() throws ServicesException {
+    MapboxGeocodingRx client = new MapboxGeocodingRx.Builder()
+      .setAccessToken(ACCESS_TOKEN)
+      .setLocation("1600 pennsylvania ave nw")
+      .setBaseUrl(mockUrl.toString())
+      .build();
+
+    TestSubscriber<GeocodingResponse> testSubscriber = new TestSubscriber<>();
+    client.getObservable().subscribe(testSubscriber);
+
+    testSubscriber.assertCompleted();
+    testSubscriber.assertNoErrors();
+    testSubscriber.assertValueCount(1);
+
+    List<GeocodingResponse> events = testSubscriber.getOnNextEvents();
+    assertEquals(1, events.size());
+
+    GeocodingResponse response = events.get(0);
+    assertNotNull(response);
+  }
+
+}

--- a/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/mapmatching/v4/MapboxMapMatchingRxTest.java
+++ b/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/mapmatching/v4/MapboxMapMatchingRxTest.java
@@ -1,0 +1,102 @@
+package com.mapbox.services.api.rx.mapmatching.v4;
+
+import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.mapmatching.v4.MapMatchingCriteria;
+import com.mapbox.services.api.mapmatching.v4.models.MapMatchingResponse;
+import com.mapbox.services.commons.geojson.LineString;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import rx.observers.TestSubscriber;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test Rx support on the Mapbox Map Matching API
+ */
+
+public class MapboxMapMatchingRxTest {
+
+  public static final String POLYLINE_FIXTURE =
+    "../libjava-services/src/test/fixtures/mapmatching_v5_polyline.json";
+
+  private static final String ACCESS_TOKEN = "pk.XXX";
+
+  private MockWebServer server;
+  private HttpUrl mockUrl;
+
+  private LineString trace;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() throws IOException {
+    server = new MockWebServer();
+
+    server.setDispatcher(new Dispatcher() {
+
+      @Override
+      public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+        try {
+          String body = new String(Files.readAllBytes(Paths.get(POLYLINE_FIXTURE)), Charset.forName("utf-8"));
+          return new MockResponse().setBody(body);
+        } catch (IOException ioException) {
+          throw new RuntimeException(ioException);
+        }
+      }
+    });
+
+    server.start();
+    mockUrl = server.url("");
+
+    // From https://www.mapbox.com/api-documentation/#map-matching
+    trace = LineString.fromJson("{ \"type\": \"LineString\", \"coordinates\": [ [13.418946862220764, "
+      + "52.50055852688439], [13.419011235237122, 52.50113000479732], [13.419756889343262, 52.50171780290061],"
+      + " [13.419885635375975, 52.50237416816131], [13.420631289482117, 52.50294888790448] ] }");
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  public void testSanityRX() throws ServicesException {
+    MapboxMapMatchingRx client = new MapboxMapMatchingRx.Builder()
+      .setBaseUrl(mockUrl.toString())
+      .setAccessToken(ACCESS_TOKEN)
+      .setProfile(MapMatchingCriteria.PROFILE_WALKING)
+      .setTrace(trace)
+      .build();
+
+    TestSubscriber<MapMatchingResponse> testSubscriber = new TestSubscriber<>();
+    client.getObservable().subscribe(testSubscriber);
+
+    testSubscriber.assertCompleted();
+    testSubscriber.assertNoErrors();
+    testSubscriber.assertValueCount(1);
+
+    List<MapMatchingResponse> events = testSubscriber.getOnNextEvents();
+    assertEquals(1, events.size());
+
+    MapMatchingResponse response = events.get(0);
+    assertEquals(response.getCode(), MapMatchingCriteria.RESPONSE_OK);
+  }
+
+}

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
@@ -27,11 +27,11 @@ import retrofit2.converter.gson.GsonConverterFactory;
  */
 public class MapboxDirections extends MapboxService<DirectionsResponse> {
 
-  private Builder builder = null;
+  protected Builder builder = null;
   private DirectionsService service = null;
   private Call<DirectionsResponse> call = null;
 
-  private MapboxDirections(Builder builder) {
+  protected MapboxDirections(Builder builder) {
     this.builder = builder;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
@@ -125,7 +125,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
    *
    * @since 1.0.0
    */
-  public static class Builder extends MapboxBuilder {
+  public static class Builder<T extends Builder> extends MapboxBuilder {
 
     // We use `Boolean` instead of `boolean` to allow unset (null) values.
     private String user = null;
@@ -163,9 +163,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setUser(String user) {
+    public T setUser(String user) {
       this.user = user;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -173,9 +173,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setProfile(String profile) {
+    public T setProfile(String profile) {
       this.profile = profile;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -187,9 +187,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setCoordinates(List<Position> coordinates) {
+    public T setCoordinates(List<Position> coordinates) {
       this.coordinates = coordinates;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -201,7 +201,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setOrigin(Position origin) {
+    public T setOrigin(Position origin) {
       if (coordinates == null) {
         coordinates = new ArrayList<>();
       }
@@ -212,7 +212,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
       // their indices)
       coordinates.add(0, origin);
 
-      return this;
+      return (T) this;
     }
 
     /**
@@ -224,7 +224,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setDestination(Position destination) {
+    public T setDestination(Position destination) {
       if (coordinates == null) {
         coordinates = new ArrayList<>();
       }
@@ -233,7 +233,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
       // to the end of this list.
       coordinates.add(destination);
 
-      return this;
+      return (T) this;
     }
 
     /**
@@ -245,9 +245,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @since 1.0.0
      */
     @Override
-    public Builder setAccessToken(String accessToken) {
+    public T setAccessToken(String accessToken) {
       this.accessToken = accessToken;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -257,9 +257,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setAlternatives(Boolean alternatives) {
+    public T setAlternatives(Boolean alternatives) {
       this.alternatives = alternatives;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -270,9 +270,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setOverview(String overview) {
+    public T setOverview(String overview) {
       this.overview = overview;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -282,9 +282,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @param radiuses double array containing the radiuses
      * @return Builder
      */
-    public Builder setRadiuses(double[] radiuses) {
+    public T setRadiuses(double[] radiuses) {
       this.radiuses = radiuses;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -294,9 +294,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setSteps(Boolean steps) {
+    public T setSteps(Boolean steps) {
       this.steps = steps;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -307,9 +307,9 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setContinueStraight(Boolean continueStraight) {
+    public T setContinueStraight(Boolean continueStraight) {
       this.continueStraight = continueStraight;
-      return this;
+      return (T) this;
     }
 
     /*
@@ -439,14 +439,14 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
       return continueStraight;
     }
 
-    public Builder setClientAppName(String appName) {
+    public T setClientAppName(String appName) {
       super.clientAppName = appName;
-      return this;
+      return (T) this;
     }
 
-    public Builder setBaseUrl(String baseUrl) {
+    public T setBaseUrl(String baseUrl) {
       super.baseUrl = baseUrl;
-      return this;
+      return (T) this;
     }
 
     /**

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/distance/v1/DistanceService.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/distance/v1/DistanceService.java
@@ -31,6 +31,7 @@ public interface DistanceService {
    */
   @POST("distances/v1/{user}/{profile}")
   Call<DistanceResponse> getCall(
+    // NOTE: DistanceServiceRx should be updated as well
     @Header("User-Agent") String userAgent,
     @Path("user") String user,
     @Path("profile") String profile,

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/distance/v1/MapboxDistance.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/distance/v1/MapboxDistance.java
@@ -42,12 +42,24 @@ import retrofit2.converter.gson.GsonConverterFactory;
  */
 public class MapboxDistance extends MapboxService<DistanceResponse> {
 
-  private Builder builder = null;
+  protected Builder builder = null;
   private DistanceService service = null;
   private Call<DistanceResponse> call = null;
+  private Gson gson;
 
-  private MapboxDistance(Builder builder) {
+  protected MapboxDistance(Builder builder) {
     this.builder = builder;
+  }
+
+  protected Gson getGson() {
+    // Gson instance with type adapters
+    if (gson == null) {
+      gson = new GsonBuilder()
+        .registerTypeAdapter(Geometry.class, new DistanceGeometryDeserializer())
+        .create();
+    }
+
+    return gson;
   }
 
   private DistanceService getService() {
@@ -56,16 +68,11 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
       return service;
     }
 
-    // Gson instance with type adapters
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Geometry.class, new DistanceGeometryDeserializer())
-      .create();
-
     // Retrofit instance
     Retrofit retrofit = new Retrofit.Builder()
       .client(getOkHttpClient())
       .baseUrl(builder.getBaseUrl())
-      .addConverterFactory(GsonConverterFactory.create(gson))
+      .addConverterFactory(GsonConverterFactory.create(getGson()))
       .build();
 
     // Distance service
@@ -145,7 +152,7 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
    *
    * @since 2.0.0
    */
-  public static class Builder extends MapboxBuilder {
+  public static class Builder<T extends Builder> extends MapboxBuilder {
 
     private String accessToken;
     private String user = DirectionsCriteria.PROFILE_DEFAULT_USER;
@@ -167,9 +174,9 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
      * @return Builder
      * @since 2.0.0
      */
-    public Builder setUser(String user) {
+    public T setUser(String user) {
       this.user = user;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -190,9 +197,9 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
      * @return Builder
      * @since 2.0.0
      */
-    public Builder setProfile(String profile) {
+    public T setProfile(String profile) {
       this.profile = profile;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -210,9 +217,9 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
         MultiPoint.fromCoordinates(coordinates).toJson());
     }
 
-    public Builder setCoordinates(List<Position> coordinates) {
+    public T setCoordinates(List<Position> coordinates) {
       this.coordinates = coordinates;
-      return this;
+      return (T) this;
     }
 
     private void validateProfile() throws ServicesException {
@@ -244,9 +251,9 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
      * @since 2.0.0
      */
     @Override
-    public Builder setAccessToken(String accessToken) {
+    public T setAccessToken(String accessToken) {
       this.accessToken = accessToken;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -258,9 +265,9 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
       return this.accessToken;
     }
 
-    public Builder setClientAppName(String appName) {
+    public T setClientAppName(String appName) {
       super.clientAppName = appName;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -271,9 +278,9 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
      * @since 2.0.0
      */
     @Override
-    public Builder setBaseUrl(String baseUrl) {
+    public T setBaseUrl(String baseUrl) {
       super.baseUrl = baseUrl;
-      return this;
+      return (T) this;
     }
 
     /**

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/GeocodingService.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/GeocodingService.java
@@ -36,6 +36,7 @@ public interface GeocodingService {
    */
   @GET("/geocoding/v5/{mode}/{query}.json")
   Call<GeocodingResponse> getCall(
+    // NOTE: GeocodingServiceRx should be updated as well
     @Header("User-Agent") String userAgent,
     @Path("mode") String mode,
     @Path("query") String query,
@@ -66,6 +67,7 @@ public interface GeocodingService {
    */
   @GET("/geocoding/v5/{mode}/{query}.json")
   Call<List<GeocodingResponse>> getBatchCall(
+    // NOTE: GeocodingServiceRx should be updated as well
     @Header("User-Agent") String userAgent,
     @Path("mode") String mode,
     @Path("query") String query,

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/MapboxGeocoding.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/MapboxGeocoding.java
@@ -28,10 +28,11 @@ import retrofit2.converter.gson.GsonConverterFactory;
  */
 public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
 
-  private Builder builder = null;
+  protected Builder builder = null;
   private GeocodingService service = null;
   private Call<GeocodingResponse> call = null;
   private Call<List<GeocodingResponse>> batchCall = null;
+  private Gson gson;
 
   /**
    * Public constructor.
@@ -41,6 +42,17 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
    */
   public MapboxGeocoding(Builder builder) {
     this.builder = builder;
+  }
+
+  protected Gson getGson() {
+    // Gson instance with type adapters
+    if (gson == null) {
+      gson = new GsonBuilder()
+        .registerTypeAdapter(Geometry.class, new CarmenGeometryDeserializer())
+        .create();
+    }
+
+    return gson;
   }
 
   /**
@@ -55,15 +67,10 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
       return service;
     }
 
-    // Gson instance with type adapters
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Geometry.class, new CarmenGeometryDeserializer())
-      .create();
-
     Retrofit retrofit = new Retrofit.Builder()
       .client(getOkHttpClient())
       .baseUrl(builder.getBaseUrl())
-      .addConverterFactory(GsonConverterFactory.create(gson))
+      .addConverterFactory(GsonConverterFactory.create(getGson()))
       .build();
 
     service = retrofit.create(GeocodingService.class);
@@ -221,7 +228,7 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
    *
    * @since 1.0.0
    */
-  public static class Builder extends MapboxBuilder {
+  public static class Builder<T extends Builder> extends MapboxBuilder {
 
     // Required
     private String accessToken;
@@ -255,9 +262,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @since 1.0.0
      */
     @Override
-    public Builder setAccessToken(String accessToken) {
+    public T setAccessToken(String accessToken) {
       this.accessToken = accessToken;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -267,9 +274,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setLocation(String location) {
+    public T setLocation(String location) {
       query = location;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -277,14 +284,14 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setCoordinates(Position position) {
+    public T setCoordinates(Position position) {
       if (position == null) {
-        return this;
+        return (T) this;
       }
       query = String.format(Locale.US, "%f,%f",
         position.getLongitude(),
         position.getLatitude());
-      return this;
+      return (T) this;
     }
 
     /**
@@ -294,9 +301,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setMode(String mode) {
+    public T setMode(String mode) {
       this.mode = mode;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -306,9 +313,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setCountry(String country) {
+    public T setCountry(String country) {
       this.country = country;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -318,9 +325,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setCountries(String[] countries) {
+    public T setCountries(String[] countries) {
       this.country = TextUtils.join(",", countries);
-      return this;
+      return (T) this;
     }
 
     /**
@@ -330,14 +337,14 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setProximity(Position position) {
+    public T setProximity(Position position) {
       if (position == null) {
-        return this;
+        return (T) this;
       }
       proximity = String.format(Locale.US, "%f,%f",
         position.getLongitude(),
         position.getLatitude());
-      return this;
+      return (T) this;
     }
 
     /**
@@ -348,9 +355,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setGeocodingType(String geocodingType) {
+    public T setGeocodingType(String geocodingType) {
       this.geocodingTypes = geocodingType;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -361,9 +368,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setGeocodingTypes(String[] geocodingType) {
+    public T setGeocodingTypes(String[] geocodingType) {
       this.geocodingTypes = TextUtils.join(",", geocodingType);
-      return this;
+      return (T) this;
     }
 
     /**
@@ -373,9 +380,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 1.0.0
      */
-    public Builder setAutocomplete(boolean autocomplete) {
+    public T setAutocomplete(boolean autocomplete) {
       this.autocomplete = autocomplete;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -387,7 +394,7 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @throws ServicesException Generic Exception for all things geocoding.
      * @since 1.0.0
      */
-    public Builder setBbox(Position northeast, Position southwest) throws ServicesException {
+    public T setBbox(Position northeast, Position southwest) throws ServicesException {
       return setBbox(southwest.getLongitude(), southwest.getLatitude(),
         northeast.getLongitude(), northeast.getLatitude());
     }
@@ -403,13 +410,13 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @throws ServicesException Generic Exception for all things geocoding.
      * @since 1.0.0
      */
-    public Builder setBbox(double minX, double minY, double maxX, double maxY) throws ServicesException {
+    public T setBbox(double minX, double minY, double maxX, double maxY) throws ServicesException {
       if (minX == 0 && minY == 0 && maxX == 0 && maxY == 0) {
         throw new ServicesException("You provided an empty bounding box");
       }
 
       this.bbox = String.format(Locale.US, "%f,%f,%f,%f", minX, minY, maxX, maxY);
-      return this;
+      return (T) this;
     }
 
     /**
@@ -420,12 +427,12 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @return Builder
      * @since 2.0.0
      */
-    public Builder setLimit(int limit) {
+    public T setLimit(int limit) {
       if (limit == 0) {
-        return this;
+        return (T) this;
       }
       this.limit = String.format(Locale.US, "%d", limit);
-      return this;
+      return (T) this;
     }
 
     /**
@@ -506,9 +513,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
       return limit;
     }
 
-    public Builder setClientAppName(String appName) {
+    public T setClientAppName(String appName) {
       super.clientAppName = appName;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -519,9 +526,9 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
      * @since 2.0.0
      */
     @Override
-    public Builder setBaseUrl(String baseUrl) {
+    public T setBaseUrl(String baseUrl) {
       super.baseUrl = baseUrl;
-      return this;
+      return (T) this;
     }
 
     /**

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/MapboxGeocoding.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/MapboxGeocoding.java
@@ -40,7 +40,7 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
    * @param builder {@link Builder} object.
    * @since 1.0.0
    */
-  public MapboxGeocoding(Builder builder) {
+  protected MapboxGeocoding(Builder builder) {
     this.builder = builder;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v4/MapMatchingService.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v4/MapMatchingService.java
@@ -31,6 +31,7 @@ public interface MapMatchingService {
    */
   @POST("matching/v4/{profile}.json")
   Call<MapMatchingResponse> getCall(
+    // NOTE: MapMatchingServiceRx should be updated as well
     @Header("User-Agent") String userAgent,
     @Path("profile") String profile,
     @Query("access_token") String accessToken,

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v4/MapboxMapMatching.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v4/MapboxMapMatching.java
@@ -5,11 +5,11 @@ import com.google.gson.GsonBuilder;
 import com.mapbox.services.api.MapboxBuilder;
 import com.mapbox.services.api.MapboxService;
 import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.mapmatching.v4.gson.MapMatchingGeometryDeserializer;
+import com.mapbox.services.api.mapmatching.v4.models.MapMatchingResponse;
 import com.mapbox.services.commons.geojson.Feature;
 import com.mapbox.services.commons.geojson.Geometry;
 import com.mapbox.services.commons.geojson.LineString;
-import com.mapbox.services.api.mapmatching.v4.gson.MapMatchingGeometryDeserializer;
-import com.mapbox.services.api.mapmatching.v4.models.MapMatchingResponse;
 
 import java.io.IOException;
 
@@ -33,12 +33,24 @@ import retrofit2.converter.gson.GsonConverterFactory;
  */
 public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
 
-  private Builder builder = null;
+  protected Builder builder = null;
   private MapMatchingService service = null;
   private Call<MapMatchingResponse> call = null;
+  private Gson gson;
 
-  private MapboxMapMatching(Builder builder) {
+  protected MapboxMapMatching(Builder builder) {
     this.builder = builder;
+  }
+
+  protected Gson getGson() {
+    // Gson instance with type adapters
+    if (gson == null) {
+      gson = new GsonBuilder()
+        .registerTypeAdapter(Geometry.class, new MapMatchingGeometryDeserializer())
+        .create();
+    }
+
+    return gson;
   }
 
   private MapMatchingService getService() {
@@ -47,16 +59,11 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
       return service;
     }
 
-    // Gson instance with type adapters
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Geometry.class, new MapMatchingGeometryDeserializer())
-      .create();
-
     // Retrofit instance
     Retrofit retrofit = new Retrofit.Builder()
       .client(getOkHttpClient())
       .baseUrl(builder.getBaseUrl())
-      .addConverterFactory(GsonConverterFactory.create(gson))
+      .addConverterFactory(GsonConverterFactory.create(getGson()))
       .build();
 
     // MapMatching service
@@ -137,7 +144,7 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
    *
    * @since 1.2.0
    */
-  public static class Builder extends MapboxBuilder {
+  public static class Builder<T extends Builder> extends MapboxBuilder {
 
     private String accessToken;
     private String profile;
@@ -165,9 +172,9 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
      * @since 1.2.0
      */
     @Override
-    public Builder setAccessToken(String accessToken) {
+    public T setAccessToken(String accessToken) {
       this.accessToken = accessToken;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -188,9 +195,9 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
      * @return Builder
      * @since 1.2.0
      */
-    public Builder setProfile(String profile) {
+    public T setProfile(String profile) {
       this.profile = profile;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -220,9 +227,9 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
      * @return Builder
      * @since 1.2.0
      */
-    public Builder setNoGeometry() {
+    public T setNoGeometry() {
       this.geometry = MapMatchingCriteria.GEOMETRY_FALSE;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -254,9 +261,9 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
      * @return Builder
      * @since 1.2.0
      */
-    public Builder setGpsPrecison(Integer gpsPrecison) {
+    public T setGpsPrecison(Integer gpsPrecison) {
       this.gpsPrecison = gpsPrecison;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -264,9 +271,9 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
      * @return Builder
      * @since 1.2.0
      */
-    public Builder setTrace(LineString trace) {
+    public T setTrace(LineString trace) {
       this.trace = trace;
-      return this;
+      return (T) this;
     }
 
     private void validateProfile() throws ServicesException {
@@ -298,9 +305,9 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
       }
     }
 
-    public Builder setClientAppName(String appName) {
+    public T setClientAppName(String appName) {
       super.clientAppName = appName;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -311,9 +318,9 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
      * @since 2.0.0
      */
     @Override
-    public Builder setBaseUrl(String baseUrl) {
+    public T setBaseUrl(String baseUrl) {
       super.baseUrl = baseUrl;
-      return this;
+      return (T) this;
     }
 
     /**


### PR DESCRIPTION
WIP to bring back support for Rx as part of the `libjava-services-rx` module.

The first stab at it, extending the current `MapboxDirections` class, works but brings an inconsistent API. Unlike with the normal client where the `Builder` brings the `MapboxDirections` instance. Right now, we need to use them separately as we cannot use the `build` method:

```
MapboxDirectionsRx.Builder builder = new MapboxDirectionsRx.Builder()
  .setAccessToken(Utils.getMapboxAccessToken(this))
  .setCoordinates(positions)
  .setProfile(DirectionsCriteria.PROFILE_DRIVING)
  .setSteps(true)
  .setOverview(DirectionsCriteria.OVERVIEW_FULL);
MapboxDirectionsRx clientRx = new MapboxDirectionsRx(builder);
clientRx.getObservable()
  .subscribeOn(Schedulers.newThread())
  .observeOn(AndroidSchedulers.mainThread())
  .subscribe(new Action1<DirectionsResponse>() {
    @Override
    public void call(DirectionsResponse response) {
      DirectionsRoute currentRoute = response.getRoutes().get(0);
      Log.d(LOG_TAG, "Response code: " + response.getCode());
      Log.d(LOG_TAG, "Distance: " + currentRoute.getDistance());
    }
  });
```

This needs one more iteration.

Fixes https://github.com/mapbox/mapbox-java/issues/131.

cc: @mapbox/android for folks familiar with Rx willing to get some 👀.
