### PR TITLE
Conveniences to Position model

### DIFF
--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/MainActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/MainActivity.java
@@ -37,6 +37,7 @@ import com.mapbox.services.android.testapp.turf.TurfLineSliceActivity;
 import com.mapbox.services.android.testapp.turf.TurfMidpointActivity;
 import com.mapbox.services.android.testapp.utils.MapMatchingActivity;
 import com.mapbox.services.android.testapp.utils.SimplifyPolylineActivity;
+import com.mapbox.services.commons.models.Position;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -168,6 +169,10 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
     // Debug information
     Log.d(LOG_TAG, "MAS version name: " + BuildConfig.VERSION_NAME);
     Log.d(LOG_TAG, "MAS version code: " + BuildConfig.VERSION_CODE);
+
+    // Check Position warnings are working
+    Log.d(LOG_TAG, "The following Position warnings are intentional:");
+    Position.fromLngLat(185, 95);
 
     // RecyclerView
     recyclerView = (RecyclerView) findViewById(R.id.recycler_view);

--- a/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
+++ b/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
@@ -5,6 +5,11 @@ import java.util.Locale;
 public class Constants {
 
   /**
+   * Default locale
+   */
+  public static final Locale DEFAULT_LOCALE = Locale.US;
+
+  /**
    * User agent for HTTP requests
    */
   public static final String HEADER_USER_AGENT =

--- a/mapbox/libjava-core/src/main/java/com/mapbox/services/commons/models/Position.java
+++ b/mapbox/libjava-core/src/main/java/com/mapbox/services/commons/models/Position.java
@@ -1,5 +1,9 @@
 package com.mapbox.services.commons.models;
 
+import com.mapbox.services.Constants;
+
+import java.util.logging.Logger;
+
 /**
  * Represents a position defined by a longitude, latitude, and optionally, an altitude.
  *
@@ -7,12 +11,15 @@ package com.mapbox.services.commons.models;
  */
 public class Position {
 
+  private static final Logger logger = Logger.getLogger(Position.class.getSimpleName());
+
   private final double longitude;
   private final double latitude;
   private final double altitude;
 
   /**
-   * Private Constructor
+   * Private constructor. It'll emit a warning if either latitude or longitude seem
+   * to be out of range.
    *
    * @param longitude double value with position's longitude.
    * @param latitude  double value with position's latitude.
@@ -23,6 +30,22 @@ public class Position {
     this.longitude = longitude;
     this.latitude = latitude;
     this.altitude = altitude;
+
+    if (latitude < -90 || latitude > 90) {
+      // Checks the latitude value is within range or provide a warning otherwise
+      logger.warning(String.format(Constants.DEFAULT_LOCALE,
+        "Latitude value seems to be out of range (found: %f, expected: [-90, 90]). "
+          + "Did you accidentally reverse the longitude/latitude order?",
+        latitude));
+    }
+
+    if (longitude < -180 || longitude > 180) {
+      // Checks the longitude value is within range or provide a warning otherwise
+      logger.warning(String.format(Constants.DEFAULT_LOCALE,
+        "Longitude value seems to be out of range (found: %f, expected: [-180, 180]). "
+        + "Did you accidentally reverse the longitude/latitude order?",
+        longitude));
+    }
   }
 
   /**
@@ -95,6 +118,14 @@ public class Position {
     return new Position(longitude, latitude, Double.NaN);
   }
 
+  public static Position fromCoordinates(double[] coordinates) {
+    if (coordinates.length == 3) {
+      return Position.fromCoordinates(coordinates[0], coordinates[1], coordinates[2]);
+    } else {
+      return Position.fromCoordinates(coordinates[0], coordinates[1]);
+    }
+  }
+
   /**
    * Builds a {@link Position} from a double longitude and latitude. Identical to
    * {@link #fromCoordinates(double, double)} but more explicit about the right order
@@ -107,14 +138,6 @@ public class Position {
    */
   public static Position fromLngLat(double longitude, double latitude) {
     return Position.fromCoordinates(longitude, latitude);
-  }
-
-  public static Position fromCoordinates(double[] coordinates) {
-    if (coordinates.length == 3) {
-      return Position.fromCoordinates(coordinates[0], coordinates[1], coordinates[2]);
-    } else {
-      return Position.fromCoordinates(coordinates[0], coordinates[1]);
-    }
   }
 
   /**

--- a/mapbox/libjava-core/src/main/java/com/mapbox/services/commons/models/Position.java
+++ b/mapbox/libjava-core/src/main/java/com/mapbox/services/commons/models/Position.java
@@ -95,6 +95,20 @@ public class Position {
     return new Position(longitude, latitude, Double.NaN);
   }
 
+  /**
+   * Builds a {@link Position} from a double longitude and latitude. Identical to
+   * {@link #fromCoordinates(double, double)} but more explicit about the right order
+   * for the longitude and latitude parameters.
+   *
+   * @param longitude double longitude value.
+   * @param latitude  double latitude value.
+   * @return {@link Position}.
+   * @since 2.0.0
+   */
+  public static Position fromLngLat(double longitude, double latitude) {
+    return Position.fromCoordinates(longitude, latitude);
+  }
+
   public static Position fromCoordinates(double[] coordinates) {
     if (coordinates.length == 3) {
       return Position.fromCoordinates(coordinates[0], coordinates[1], coordinates[2]);


### PR DESCRIPTION
This PR does two things:

- Adds a new `Position.fromLngLat(double longitude, double latitude)` method the be more explicit about the lat/lon order. It does not deprecate the `Position.fromCoordinates()` method as this is used for other cases too (e.g. set an altitude or a double array). Fixes https://github.com/mapbox/mapbox-java/issues/283.
- Adds a warning to the `Position` constructor if the lat/lon values seem out of range. Fixes https://github.com/mapbox/mapbox-java/issues/266.

This last item is tested via the Test App. In `MainActivity` we create an object with values out of range and the warning can be seen as usual in the Android log window:

![image](https://cloud.githubusercontent.com/assets/6964/22700596/2e99b344-ed29-11e6-873e-b50cf2265a35.png)

@cammace Please review.