### PR TITLE
AppEngine support (and II)

### DIFF
--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/MapboxService.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/MapboxService.java
@@ -48,10 +48,6 @@ public abstract class MapboxService<T> {
    * @since 2.0.0
    */
   public okhttp3.Call.Factory getCallFactory() {
-    if (callFactory == null) {
-      return getOkHttpClient();
-    }
-
     return callFactory;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
@@ -42,15 +42,17 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
     }
 
     // Retrofit instance
-    Retrofit retrofit = new Retrofit.Builder()
-      .client(getOkHttpClient())
+    Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
       .baseUrl(builder.getBaseUrl())
-      .addConverterFactory(GsonConverterFactory.create())
-      .callFactory(getCallFactory())
-      .build();
+      .addConverterFactory(GsonConverterFactory.create());
+    if (getCallFactory() != null) {
+      retrofitBuilder.callFactory(getCallFactory());
+    } else {
+      retrofitBuilder.client(getOkHttpClient());
+    }
 
     // Directions service
-    service = retrofit.create(DirectionsService.class);
+    service = retrofitBuilder.build().create(DirectionsService.class);
     return service;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsResponse.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsResponse.java
@@ -13,6 +13,9 @@ public class DirectionsResponse {
   private List<DirectionsRoute> routes;
   private List<DirectionsWaypoint> waypoints;
 
+  public DirectionsResponse() {
+  }
+
   public DirectionsResponse(List<DirectionsRoute> routes, List<DirectionsWaypoint> waypoints) {
     this.routes = routes;
     this.waypoints = waypoints;

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsRoute.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsRoute.java
@@ -14,6 +14,9 @@ public class DirectionsRoute {
   private String geometry;
   private List<RouteLeg> legs;
 
+  public DirectionsRoute() {
+  }
+
   /**
    * The distance traveled from origin to destination.
    *

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsWaypoint.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsWaypoint.java
@@ -12,6 +12,9 @@ public class DirectionsWaypoint {
   private String name;
   private double[] location;
 
+  public DirectionsWaypoint() {
+  }
+
   /**
    * @return String with the name of the way the coordinate snapped to.
    * @since 1.0.0

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/IntersectionLanes.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/IntersectionLanes.java
@@ -8,6 +8,9 @@ public class IntersectionLanes {
   private boolean valid;
   private String[] indications;
 
+  public IntersectionLanes() {
+  }
+
   /**
    * @return Boolean value for whether this lane can be taken to complete the maneuver. For
    * instance, if the lane array has four objects and the first two are marked as valid, then the

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegStep.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegStep.java
@@ -23,6 +23,9 @@ public class LegStep {
   private StepManeuver maneuver;
   private List<StepIntersection> intersections;
 
+  public LegStep() {
+  }
+
   /**
    * The distance traveled from the maneuver to the next {@link LegStep}.
    *

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/RouteLeg.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/RouteLeg.java
@@ -14,6 +14,9 @@ public class RouteLeg {
   private String summary;
   private List<LegStep> steps;
 
+  public RouteLeg() {
+  }
+
   /**
    * The distance traveled from one waypoint to another.
    *

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepIntersection.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepIntersection.java
@@ -14,6 +14,9 @@ public class StepIntersection {
   private int out;
   private IntersectionLanes[] lanes;
 
+  public StepIntersection() {
+  }
+
   /**
    * @return A [longitude, latitude] pair describing the location of the turn.
    * @since 1.3.0

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepManeuver.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepManeuver.java
@@ -22,6 +22,9 @@ public class StepManeuver {
   private String instruction;
   private Integer exit;
 
+  public StepManeuver() {
+  }
+
   /**
    * @return double array of [longitude, latitude] for the snapped coordinate.
    * @since 1.0.0

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/distance/v1/MapboxDistance.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/distance/v1/MapboxDistance.java
@@ -69,15 +69,17 @@ public class MapboxDistance extends MapboxService<DistanceResponse> {
     }
 
     // Retrofit instance
-    Retrofit retrofit = new Retrofit.Builder()
-      .client(getOkHttpClient())
+    Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
       .baseUrl(builder.getBaseUrl())
-      .addConverterFactory(GsonConverterFactory.create(getGson()))
-      .callFactory(getCallFactory())
-      .build();
+      .addConverterFactory(GsonConverterFactory.create(getGson()));
+    if (getCallFactory() != null) {
+      retrofitBuilder.callFactory(getCallFactory());
+    } else {
+      retrofitBuilder.client(getOkHttpClient());
+    }
 
     // Distance service
-    service = retrofit.create(DistanceService.class);
+    service = retrofitBuilder.build().create(DistanceService.class);
     return service;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/MapboxGeocoding.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/MapboxGeocoding.java
@@ -67,14 +67,16 @@ public class MapboxGeocoding extends MapboxService<GeocodingResponse> {
       return service;
     }
 
-    Retrofit retrofit = new Retrofit.Builder()
-      .client(getOkHttpClient())
+    Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
       .baseUrl(builder.getBaseUrl())
-      .addConverterFactory(GsonConverterFactory.create(getGson()))
-      .callFactory(getCallFactory())
-      .build();
+      .addConverterFactory(GsonConverterFactory.create(getGson()));
+    if (getCallFactory() != null) {
+      retrofitBuilder.callFactory(getCallFactory());
+    } else {
+      retrofitBuilder.client(getOkHttpClient());
+    }
 
-    service = retrofit.create(GeocodingService.class);
+    service = retrofitBuilder.build().create(GeocodingService.class);
     return service;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenContext.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenContext.java
@@ -21,6 +21,9 @@ public class CarmenContext {
   private String category;
   private String maki;
 
+  public CarmenContext() {
+  }
+
   /**
    * ID of the feature of the form {index}.{id} where index is the id/handle of the datasource
    * that contributed the result.

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeatureCollection.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeatureCollection.java
@@ -15,7 +15,10 @@ public class CarmenFeatureCollection extends BaseFeatureCollection {
 
   private List<String> query;
   private String attribution;
-  private final List<CarmenFeature> features;
+  private List<CarmenFeature> features;
+
+  public CarmenFeatureCollection() {
+  }
 
   /**
    * Protected constructor.

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatching.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatching.java
@@ -48,15 +48,17 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
     }
 
     // Retrofit instance
-    Retrofit retrofit = new Retrofit.Builder()
-      .client(getOkHttpClient())
+    Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
       .baseUrl(builder.getBaseUrl())
-      .addConverterFactory(GsonConverterFactory.create())
-      .callFactory(getCallFactory())
-      .build();
+      .addConverterFactory(GsonConverterFactory.create());
+    if (getCallFactory() != null) {
+      retrofitBuilder.callFactory(getCallFactory());
+    } else {
+      retrofitBuilder.client(getOkHttpClient());
+    }
 
     // MapMatching service
-    service = retrofit.create(MapMatchingService.class);
+    service = retrofitBuilder.build().create(MapMatchingService.class);
     return service;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingMatching.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingMatching.java
@@ -9,6 +9,9 @@ public class MapMatchingMatching extends DirectionsRoute {
 
   private double confidence;
 
+  public MapMatchingMatching() {
+  }
+
   /**
    * A number between 0 (low) and 1 (high) indicating level of confidence in the returned match
    *

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingResponse.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingResponse.java
@@ -14,6 +14,9 @@ public class MapMatchingResponse {
   private List<MapMatchingMatching> matchings;
   private List<MapMatchingTracepoint> tracepoints;
 
+  public MapMatchingResponse() {
+  }
+
   /**
    * A string depicting the state of the response.
    * <ul>

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingTracepoint.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingTracepoint.java
@@ -14,6 +14,9 @@ public class MapMatchingTracepoint extends DirectionsWaypoint {
   @SerializedName("waypoint_index")
   private int waypointIndex;
 
+  public MapMatchingTracepoint() {
+  }
+
   /**
    * Index to the match object in matchings the sub-trace was matched to.
    *


### PR DESCRIPTION
Turns out that the approach in https://github.com/mapbox/mapbox-java/pull/344 wouldn't work if both the client and the factory were set at the same time. This PR makes sure we only set one.

It also adds a number of no-args constructors to make Gson happy.
