### PR TITLE
Remove all elements after a failed request

### DIFF
--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -387,7 +387,7 @@ public class MapboxTelemetry implements Callback, LocationEngineListener {
     LocalBroadcastManager.getInstance(context.getApplicationContext()).sendBroadcast(intent);
   }
 
-  private boolean isReadyForEvent() {
+  private boolean isInitializedAndEnabled() {
     return initialized && isTelemetryEnabled();
   }
 
@@ -410,7 +410,7 @@ public class MapboxTelemetry implements Callback, LocationEngineListener {
    */
   protected void addLocationEvent(Location location) {
     // Only add events when we're properly initialized and the user has opted-in
-    if (!isReadyForEvent()) {
+    if (!isInitializedAndEnabled()) {
       return;
     }
 
@@ -454,7 +454,7 @@ public class MapboxTelemetry implements Callback, LocationEngineListener {
    */
   public void pushEvent(Hashtable<String, Object> eventWithAttributes) {
     // Only add events when we're properly initialized and the user has opted-in
-    if (!isReadyForEvent()) {
+    if (!isInitializedAndEnabled()) {
       return;
     }
 
@@ -510,7 +510,7 @@ public class MapboxTelemetry implements Callback, LocationEngineListener {
    * Immediately attempt to send all events data in the queue to the server.
    */
   private void flushEventsQueueImmediately(boolean hasTurnstileEvent) {
-    boolean doRequest = hasTurnstileEvent || isReadyForEvent();
+    boolean doRequest = hasTurnstileEvent || isInitializedAndEnabled();
     if (events.size() > 0 && ConnectivityReceiver.isConnected(context) && doRequest) {
       client.sendEvents(events, this);
       for (TelemetryListener listener : telemetryListeners) {

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryLocationReceiver.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryLocationReceiver.java
@@ -13,15 +13,11 @@ import android.util.Log;
  */
 public class TelemetryLocationReceiver extends BroadcastReceiver {
 
-  private static final String LOG_TAG = TelemetryLocationReceiver.class.getSimpleName();
-
   public static final String INTENT_STRING =
     "com.mapbox.services.android.telemetry.location.TelemetryLocationReceiver";
 
   @Override
   public void onReceive(Context context, Intent intent) {
-    Log.v(LOG_TAG, "Event received.");
-
     // See https://github.com/mapbox/mapbox-gl-native/issues/6934
     if (intent == null || intent.getExtras() == null) {
       return;

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryLocationReceiver.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/TelemetryLocationReceiver.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.location.LocationManager;
-import android.util.Log;
 
 /**
  * The TelemetryService will register for updates sent to this TelemetryLocationReceiver.


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-java/issues/389.

It also removes unnecessary logging from `TelemetryLocationReceiver` (the `TelemetryListener` should be used instead to hook up to location updates).
