### PR TITLE
LostLocationEngine - add interval to request

### DIFF
--- a/mapbox/libandroid-services/src/main/java/com/mapbox/services/android/location/LostLocationEngine.java
+++ b/mapbox/libandroid-services/src/main/java/com/mapbox/services/android/location/LostLocationEngine.java
@@ -89,6 +89,7 @@ public class LostLocationEngine extends LocationEngine implements
   public void requestLocationUpdates() {
     // Common params
     LocationRequest request = LocationRequest.create()
+      .setInterval(1000)
       .setFastestInterval(1000)
       .setSmallestDisplacement(3.0f);
 


### PR DESCRIPTION
With the upgrade from LOST 1.0.0 to 2.0.0, it seems to be required to add an interval to the location request. This is shown in the documentation [here](https://github.com/mapzen/lost/blob/master/docs/location-updates.md) though it's not mentioned in the [upgrade guide](https://github.com/mapzen/lost/blob/master/docs/upgrade-1x-2.md) from v1 -> v2.

Closes #392 

