### PR TITLE
Adds fix for origin and destination overriding list

### DIFF
--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
@@ -143,6 +143,8 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
     private double[][] bearings = null;
     private Boolean steps = null;
     private Boolean continueStraight = null;
+    private Position origin = null;
+    private Position destination = null;
 
     /**
      * Constructor
@@ -219,16 +221,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @since 1.0.0
      */
     public T setOrigin(Position origin) {
-      if (coordinates == null) {
-        coordinates = new ArrayList<>();
-      }
-
-      // The default behavior of ArrayList is to inserts the specified element at the
-      // specified position in this list (beginning) and to shift the element currently at
-      // that position (if any) and any subsequent elements to the right (adds one to
-      // their indices)
-      coordinates.add(0, origin);
-
+      this.origin = origin;
       return (T) this;
     }
 
@@ -242,14 +235,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * @since 1.0.0
      */
     public T setDestination(Position destination) {
-      if (coordinates == null) {
-        coordinates = new ArrayList<>();
-      }
-
-      // The default behavior for ArrayList is to appends the specified element
-      // to the end of this list.
-      coordinates.add(destination);
-
+      this.destination = destination;
       return (T) this;
     }
 
@@ -392,10 +378,24 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      */
     public String getCoordinates() {
       List<String> coordinatesFormatted = new ArrayList<>();
-      for (Position coordinate : coordinates) {
+      // Insert origin at beginning of list if one is provided.
+      if (origin != null) {
         coordinatesFormatted.add(String.format(Locale.US, "%f,%f",
-          coordinate.getLongitude(),
-          coordinate.getLatitude()));
+          origin.getLongitude(),
+          origin.getLatitude()));
+      }
+      if (coordinates != null) {
+        for (Position coordinate : coordinates) {
+          coordinatesFormatted.add(String.format(Locale.US, "%f,%f",
+            coordinate.getLongitude(),
+            coordinate.getLatitude()));
+        }
+      }
+      // Insert destination at end of list if one is provided.
+      if (destination != null) {
+        coordinatesFormatted.add(String.format(Locale.US, "%f,%f",
+          destination.getLongitude(),
+          destination.getLatitude()));
       }
 
       return TextUtils.join(";", coordinatesFormatted.toArray());

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/directions/v5/MapboxDirectionsTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/directions/v5/MapboxDirectionsTest.java
@@ -545,21 +545,6 @@ public class MapboxDirectionsTest {
   }
 
   @Test
-  public void testSetCoordinatesMixedHidden() {
-    List<Position> test = new ArrayList<>();
-    test.add(Position.fromCoordinates(2.1, 2.2));
-    test.add(Position.fromCoordinates(3.1, 3.2));
-
-    // The order matters
-    String coordinates = new MapboxDirections.Builder()
-      .setOrigin(Position.fromCoordinates(1.1, 1.2))
-      .setDestination(Position.fromCoordinates(4.1, 4.2))
-      .setCoordinates(test)
-      .getCoordinates();
-    assertEquals(coordinates, "2.100000,2.200000;3.100000,3.200000");
-  }
-
-  @Test
   public void testLocale() {
     List<Position> test = new ArrayList<>();
     test.add(Position.fromCoordinates(2.1, 2.2));
@@ -572,7 +557,7 @@ public class MapboxDirectionsTest {
       .setDestination(Position.fromCoordinates(4.1, 4.2))
       .setCoordinates(test)
       .getCoordinates();
-    assertEquals(coordinates, "2.100000,2.200000;3.100000,3.200000");
+    assertEquals(coordinates, "1.100000,1.200000;2.100000,2.200000;3.100000,3.200000;4.100000,4.200000");
   }
 
   @Test

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/directions/v5/MapboxDirectionsTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/directions/v5/MapboxDirectionsTest.java
@@ -40,10 +40,10 @@ import static org.junit.Assert.assertTrue;
 
 public class MapboxDirectionsTest {
 
-  public static final String DIRECTIONS_V5_FIXTURE = "src/test/fixtures/directions_v5.json";
-  public static final String DIRECTIONS_V5_PRECISION6_FIXTURE = "src/test/fixtures/directions_v5_precision_6.json";
-  public static final String DIRECTIONS_TRAFFIC_FIXTURE = "src/test/fixtures/directions_v5_traffic.json";
-  public static final String DIRECTIONS_ROTARY_FIXTURE = "src/test/fixtures/directions_v5_fixtures_rotary.json";
+  private static final String DIRECTIONS_V5_FIXTURE = "src/test/fixtures/directions_v5.json";
+  private static final String DIRECTIONS_V5_PRECISION6_FIXTURE = "src/test/fixtures/directions_v5_precision_6.json";
+  private static final String DIRECTIONS_TRAFFIC_FIXTURE = "src/test/fixtures/directions_v5_traffic.json";
+  private static final String DIRECTIONS_ROTARY_FIXTURE = "src/test/fixtures/directions_v5_fixtures_rotary.json";
   private static final double DELTA = 1E-10;
 
   private MockWebServer server;
@@ -108,11 +108,11 @@ public class MapboxDirectionsTest {
   @Test
   public void callFactoryNonNull() throws ServicesException, IOException {
     MapboxDirections client = new MapboxDirections.Builder()
-            .setAccessToken("pk.XXX")
-            .setCoordinates(positions)
-            .setProfile(DirectionsCriteria.PROFILE_DRIVING)
-            .setBaseUrl(mockUrl.toString())
-            .build();
+      .setAccessToken("pk.XXX")
+      .setCoordinates(positions)
+      .setProfile(DirectionsCriteria.PROFILE_DRIVING)
+      .setBaseUrl(mockUrl.toString())
+      .build();
 
     // Setting a null call factory doesn't make the request fail
     // (the default OkHttp client is used)
@@ -499,7 +499,7 @@ public class MapboxDirectionsTest {
     assertEquals(maneuver.getModifier(), "slight right");
     assertEquals(maneuver.getInstruction(),
       "Enter Dupont Circle Northwest and take the 3rd exit onto P Street Northwest");
-    assertEquals(maneuver.getExit(), new Integer(3));
+    assertEquals(maneuver.getExit(), Integer.valueOf(3));
 
 
     LegStep step = response.body().getRoutes().get(0).getLegs().get(0).getSteps().get(1);
@@ -510,7 +510,7 @@ public class MapboxDirectionsTest {
 
   @Test
   public void testSetCoordinates() {
-    ArrayList test = new ArrayList<>();
+    List<Position> test = new ArrayList<>();
     test.add(Position.fromCoordinates(2.1, 2.2));
     test.add(Position.fromCoordinates(3.1, 3.2));
 
@@ -531,7 +531,7 @@ public class MapboxDirectionsTest {
 
   @Test
   public void testSetCoordinatesMixed() {
-    ArrayList test = new ArrayList<>();
+    List<Position> test = new ArrayList<>();
     test.add(Position.fromCoordinates(2.1, 2.2));
     test.add(Position.fromCoordinates(3.1, 3.2));
 
@@ -546,7 +546,7 @@ public class MapboxDirectionsTest {
 
   @Test
   public void testSetCoordinatesMixedHidden() {
-    ArrayList test = new ArrayList<>();
+    List<Position> test = new ArrayList<>();
     test.add(Position.fromCoordinates(2.1, 2.2));
     test.add(Position.fromCoordinates(3.1, 3.2));
 
@@ -561,7 +561,7 @@ public class MapboxDirectionsTest {
 
   @Test
   public void testLocale() {
-    ArrayList test = new ArrayList<>();
+    List<Position> test = new ArrayList<>();
     test.add(Position.fromCoordinates(2.1, 2.2));
     test.add(Position.fromCoordinates(3.1, 3.2));
 
@@ -585,5 +585,22 @@ public class MapboxDirectionsTest {
       .setBaseUrl(mockUrl.toString())
       .build();
     assertTrue(service.executeCall().raw().request().header("User-Agent").contains("APP"));
+  }
+
+  @Test
+  public void OriginDestinationCoordinatesListCorrectOrder() throws ServicesException, IOException {
+    MapboxDirections client = new MapboxDirections.Builder()
+      .setAccessToken("pk.XXX")
+      .setOrigin(Position.fromCoordinates(-122.4313, 37.7789))
+      .setCoordinates(positions)
+      .setDestination(Position.fromCoordinates(-121.8001, 37.2275))
+      .setProfile(DirectionsCriteria.PROFILE_DRIVING)
+      .setBaseUrl(mockUrl.toString())
+      .build();
+
+    String callUrl = client.executeCall().raw().request().url().toString();
+    assertTrue(
+      callUrl.contains("-122.431300,37.778900;-122.416667,37.783333;-121.900000,37.333333;-121.800100,37.227500")
+    );
   }
 }

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/directions/v5/MapboxDirectionsTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/directions/v5/MapboxDirectionsTest.java
@@ -588,7 +588,7 @@ public class MapboxDirectionsTest {
   }
 
   @Test
-  public void OriginDestinationCoordinatesListCorrectOrder() throws ServicesException, IOException {
+  public void originDestinationCoordinatesListCorrectOrder() throws ServicesException, IOException {
     MapboxDirections client = new MapboxDirections.Builder()
       .setAccessToken("pk.XXX")
       .setOrigin(Position.fromCoordinates(-122.4313, 37.7789))


### PR DESCRIPTION
closes: #378

replaces PR https://github.com/mapbox/mapbox-java/pull/383

you are allowed to set only origin and destination or origin, destination, and a list of coordinates. if a list is provided, it will go in between the origin and destination when creating the string for the API.