### PR TITLE
To log the current sdk version along with the date and time

### DIFF
--- a/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
+++ b/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
@@ -49,4 +49,10 @@ public class Constants {
   public static final String MAPBOX_STYLE_SATELLITE = "satellite-v9";
   public static final String MAPBOX_STYLE_SATELLITE_HYBRID = "satellite-streets-v9";
 
+  // call this to get version of library
+  public static String getVersion(){
+
+    return BuildConfig.VERSION;
+  }
+
 }

--- a/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
+++ b/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
@@ -49,9 +49,12 @@ public class Constants {
   public static final String MAPBOX_STYLE_SATELLITE = "satellite-v9";
   public static final String MAPBOX_STYLE_SATELLITE_HYBRID = "satellite-streets-v9";
 
-  // call this to get version of library
-  public static String getVersion(){
-
+  /**
+   * Get the version of the library
+   *
+   * @return version string
+   */
+  public static String getVersion() {
     return BuildConfig.VERSION;
   }
 

--- a/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
+++ b/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
@@ -49,13 +49,4 @@ public class Constants {
   public static final String MAPBOX_STYLE_SATELLITE = "satellite-v9";
   public static final String MAPBOX_STYLE_SATELLITE_HYBRID = "satellite-streets-v9";
 
-  /**
-   * Get the version of the library
-   *
-   * @return version string
-   */
-  public static String getVersion() {
-    return BuildConfig.VERSION;
-  }
-
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/MapboxService.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/MapboxService.java
@@ -3,9 +3,6 @@ package com.mapbox.services.api;
 import com.mapbox.services.Constants;
 
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Locale;
 import java.util.logging.Logger;
 
@@ -25,7 +22,7 @@ import static com.mapbox.services.commons.utils.TextUtils.isEmpty;
  */
 public abstract class MapboxService<T> {
 
-  private final static Logger logger = Logger.getLogger(MapboxService.class.getSimpleName());
+  private static final Logger logger = Logger.getLogger(MapboxService.class.getSimpleName());
 
   private boolean enableDebug = false;
   private OkHttpClient okHttpClient = null;
@@ -116,15 +113,8 @@ public abstract class MapboxService<T> {
       userAgent = Constants.HEADER_USER_AGENT;
     }
 
-    // Print userAgent and version number
-    String libVersion  = Constants.getVersion();
-
-
-      //get current date and time in format 2016/11/16 12:08:43
-      DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-      Date date = new Date();
-
-    logger.fine(String.format(Locale.US, "%s UserAgent - %s, JavaSDKVersion - %s ",dateFormat.format(date), userAgent, libVersion));
+    // Log the user agent (which includes the version number) for debugging purposes
+    logger.info(String.format(Constants.DEFAULT_LOCALE, "Current version: %s", userAgent));
 
     return userAgent;
   }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/MapboxService.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/MapboxService.java
@@ -3,7 +3,11 @@ package com.mapbox.services.api;
 import com.mapbox.services.Constants;
 
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
+import java.util.logging.Logger;
 
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -20,6 +24,8 @@ import static com.mapbox.services.commons.utils.TextUtils.isEmpty;
  * @since 1.0.0
  */
 public abstract class MapboxService<T> {
+
+  private final static Logger logger = Logger.getLogger(MapboxService.class.getSimpleName());
 
   private boolean enableDebug = false;
   private OkHttpClient okHttpClient = null;
@@ -91,21 +97,35 @@ public abstract class MapboxService<T> {
    * @since 1.0.0
    */
   public static String getHeaderUserAgent(String clientAppName) {
+    String userAgent;
+
     try {
       String osName = System.getProperty("os.name");
       String osVersion = System.getProperty("os.version");
       String osArch = System.getProperty("os.arch");
 
       if (isEmpty(osName) || isEmpty(osVersion) || isEmpty(osArch)) {
-        return Constants.HEADER_USER_AGENT;
+        userAgent = Constants.HEADER_USER_AGENT;
       } else {
         String baseUa = String.format(
           Locale.US, "%s %s/%s (%s)", Constants.HEADER_USER_AGENT, osName, osVersion, osArch);
-        return isEmpty(clientAppName) ? baseUa : String.format(Locale.US, "%s %s", clientAppName, baseUa);
+        userAgent = isEmpty(clientAppName) ? baseUa : String.format(Locale.US, "%s %s", clientAppName, baseUa);
       }
 
     } catch (Exception exception) {
-      return Constants.HEADER_USER_AGENT;
+      userAgent = Constants.HEADER_USER_AGENT;
     }
+
+    // Print userAgent and version number
+    String libVersion  = Constants.getVersion();
+
+
+      //get current date and time in format 2016/11/16 12:08:43
+      DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+      Date date = new Date();
+
+    logger.fine(String.format(Locale.US, "%s UserAgent - %s, JavaSDKVersion - %s ",dateFormat.format(date), userAgent, libVersion));
+
+    return userAgent;
   }
 }


### PR DESCRIPTION
- In libjava-core, added a getter getVersion to get the current version of the SDK from BuildConfig.java in Constants.
- In libjava-services, called the  same getter method in getHeaderUserAgent() to log version of the current sdk with userAgent and current date and time.  

https://github.com/mapbox/mapbox-java/issues/399