### PR TITLE
Add local aar and jar generation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,25 +41,25 @@ javadoc:
 	cd mapbox; ./gradlew :libandroid-ui:javadocrelease
 
 publish-java:
-	cd mapbox; ./gradlew :libjava-core:uploadArchives
-	cd mapbox; ./gradlew :libjava-geojson:uploadArchives
-	cd mapbox; ./gradlew :libjava-services:uploadArchives
-	cd mapbox; ./gradlew :libjava-services-rx:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libjava-core:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libjava-geojson:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libjava-services:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libjava-services-rx:uploadArchives
 
 publish-android:
-	cd mapbox; ./gradlew :libandroid-telemetry:uploadArchives
-	cd mapbox; ./gradlew :libandroid-services:uploadArchives
-	cd mapbox; ./gradlew :libandroid-ui:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libandroid-telemetry:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libandroid-services:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=false; ./gradlew :libandroid-ui:uploadArchives
 
 publish-local:
 	# This publishes to ~/.m2/repository/com/mapbox/mapboxsdk
-	cd mapbox; ./gradlew :libjava-core:install
-	cd mapbox; ./gradlew :libjava-geojson:install
-	cd mapbox; ./gradlew :libjava-services:install
-	cd mapbox; ./gradlew :libjava-services-rx:install
-	# cd mapbox; ./gradlew :libandroid-telemetry:install
-	# cd mapbox; ./gradlew :libandroid-services:install
-	# cd mapbox; ./gradlew :libandroid-ui:install
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libjava-core:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libjava-geojson:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libjava-services:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libjava-services-rx:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libandroid-telemetry:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libandroid-services:uploadArchives
+	cd mapbox; export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libandroid-ui:uploadArchives
 
 dex-count:
 	cd mapbox; ./gradlew countDebugDexMethods

--- a/mapbox/gradle-mvn-push-android.gradle
+++ b/mapbox/gradle-mvn-push-android.gradle
@@ -21,6 +21,10 @@ def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
 }
 
+def isLocalBuild() {
+    return IS_LOCAL_DEVELOPMENT.toBoolean() == true
+}
+
 def getReleaseRepositoryUrl() {
     return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
             : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
@@ -29,6 +33,10 @@ def getReleaseRepositoryUrl() {
 def getSnapshotRepositoryUrl() {
     return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
             : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def obtainMavenLocalUrl() {
+    return getRepositories().mavenLocal().getUrl()
 }
 
 def getRepositoryUsername() {
@@ -49,11 +57,15 @@ afterEvaluate { project ->
                 pom.artifactId = POM_ARTIFACT_ID
                 pom.version = VERSION_NAME
 
-                repository(url: getReleaseRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                }
-                snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                if (isLocalBuild()) {
+                    repository(url: obtainMavenLocalUrl())
+                } else {
+                    repository(url: getReleaseRepositoryUrl()) {
+                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                    }
+                    snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                    }
                 }
 
                 pom.project {

--- a/mapbox/gradle-mvn-push-android.gradle
+++ b/mapbox/gradle-mvn-push-android.gradle
@@ -22,7 +22,10 @@ def isReleaseBuild() {
 }
 
 def isLocalBuild() {
-    return IS_LOCAL_DEVELOPMENT.toBoolean() == true
+    if(System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
+        return System.getenv('IS_LOCAL_DEVELOPMENT').toBoolean()
+    }
+    return false
 }
 
 def getReleaseRepositoryUrl() {

--- a/mapbox/gradle-mvn-push-android.gradle
+++ b/mapbox/gradle-mvn-push-android.gradle
@@ -22,10 +22,10 @@ def isReleaseBuild() {
 }
 
 def isLocalBuild() {
-    if(System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
+    if (System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
         return System.getenv('IS_LOCAL_DEVELOPMENT').toBoolean()
     }
-    return false
+    return true
 }
 
 def getReleaseRepositoryUrl() {

--- a/mapbox/gradle-mvn-push-java.gradle
+++ b/mapbox/gradle-mvn-push-java.gradle
@@ -21,6 +21,10 @@ def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
 }
 
+def isLocalBuild() {
+    return IS_LOCAL_DEVELOPMENT.toBoolean() == true
+}
+
 def getReleaseRepositoryUrl() {
     return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
             : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
@@ -29,6 +33,10 @@ def getReleaseRepositoryUrl() {
 def getSnapshotRepositoryUrl() {
     return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
             : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def obtainMavenLocalUrl() {
+    return getRepositories().mavenLocal().getUrl()
 }
 
 def getRepositoryUsername() {
@@ -49,11 +57,15 @@ afterEvaluate { project ->
                 pom.artifactId = POM_ARTIFACT_ID
                 pom.version = VERSION_NAME
 
-                repository(url: getReleaseRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                }
-                snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                if (isLocalBuild()) {
+                    repository(url: obtainMavenLocalUrl())
+                } else {
+                    repository(url: getReleaseRepositoryUrl()) {
+                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                    }
+                    snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                    }
                 }
 
                 pom.project {

--- a/mapbox/gradle-mvn-push-java.gradle
+++ b/mapbox/gradle-mvn-push-java.gradle
@@ -22,7 +22,10 @@ def isReleaseBuild() {
 }
 
 def isLocalBuild() {
-    return IS_LOCAL_DEVELOPMENT.toBoolean() == true
+    if(System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
+        return System.getenv('IS_LOCAL_DEVELOPMENT').toBoolean()
+    }
+    return false
 }
 
 def getReleaseRepositoryUrl() {

--- a/mapbox/gradle-mvn-push-java.gradle
+++ b/mapbox/gradle-mvn-push-java.gradle
@@ -22,10 +22,10 @@ def isReleaseBuild() {
 }
 
 def isLocalBuild() {
-    if(System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
+    if (System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
         return System.getenv('IS_LOCAL_DEVELOPMENT').toBoolean()
     }
-    return false
+    return true
 }
 
 def getReleaseRepositoryUrl() {

--- a/mapbox/gradle.properties
+++ b/mapbox/gradle.properties
@@ -14,6 +14,8 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
+IS_LOCAL_DEVELOPMENT=false
+
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048M

--- a/mapbox/gradle.properties
+++ b/mapbox/gradle.properties
@@ -14,8 +14,6 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
-IS_LOCAL_DEVELOPMENT=false
-
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048M

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxEvent.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxEvent.java
@@ -62,14 +62,15 @@ public class MapboxEvent implements Serializable {
   /**
    * Helper method for tracking gesture events
    *
-   * @param gestureId Type of Gesture See {@see MapboxEvent#GESTURE_SINGLETAP
-   *                  MapboxEvent#GESTURE_DOUBLETAP
-   *                  MapboxEvent#GESTURE_TWO_FINGER_SINGLETAP
-   *                  MapboxEvent#GESTURE_QUICK_ZOOM
-   *                  MapboxEvent#GESTURE_PAN_START
-   *                  MapboxEvent#GESTURE_PINCH_START
-   *                  MapboxEvent#GESTURE_ROTATION_START
-   *                  MapboxEvent#GESTURE_PITCH_START}
+   * @param gestureId Type of Gesture
+   * @see MapboxEvent#GESTURE_SINGLETAP
+   * @see MapboxEvent#GESTURE_DOUBLETAP
+   * @see MapboxEvent#GESTURE_TWO_FINGER_SINGLETAP
+   * @see MapboxEvent#GESTURE_QUICK_ZOOM
+   * @see MapboxEvent#GESTURE_PAN_START
+   * @see MapboxEvent#GESTURE_PINCH_START
+   * @see MapboxEvent#GESTURE_ROTATION_START
+   * @see MapboxEvent#GESTURE_PITCH_START
    * @param location  Location coordinates at start of gesture
    * @param zoom      Zoom level to be registered
    */
@@ -96,7 +97,7 @@ public class MapboxEvent implements Serializable {
 
   /**
    * Helper method for tracking DragEnd gesture event
-   * See {@see MapboxEvent#TYPE_MAP_DRAG_END}
+   * @see MapboxEvent#TYPE_MAP_DRAG_END
    *
    * @param location Original location coordinate at end of drag
    * @param zoom     Zoom level to be registered


### PR DESCRIPTION
- [x] Added local `aar` and `jar` generation support
In order to build locally (same procedure to both Android and Java libraries):
1. Set `IS_LOCAL_DEVELOPMENT` gradle property to `true` (is `false` by default)
2. `$> gradlew uploadArchives`
3. `aar` or `jar` will be automatically installed in your Maven local repo folder (`.m2`/`M2_HOME`)
4. Remember to add `mavenLocal()` in `repositories{}` (`build.gradle`) in the project in which you'd like to use Maven local repository
- [x] Fixed javadoc issue

👀  @zugaldia 
