### PR TITLE
Added toString, hashcode, and equal methods

### DIFF
--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/BaseFeatureCollection.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/BaseFeatureCollection.java
@@ -56,4 +56,30 @@ public class BaseFeatureCollection implements GeoJSON {
     return gson.create().toJson(this);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BaseFeatureCollection that = (BaseFeatureCollection) o;
+
+    return type.equals(that.type);
+
+  }
+
+  @Override
+  public int hashCode() {
+    return type.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "BaseFeatureCollection{"
+      + "type='" + type + '\''
+      + '}';
+  }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/Feature.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/Feature.java
@@ -296,4 +296,41 @@ public class Feature implements GeoJSON {
   public boolean hasNonNullValueForProperty(String key) {
     return hasProperty(key) && !getProperty(key).isJsonNull();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Feature feature = (Feature) o;
+
+    if (!type.equals(feature.type)) {
+      return false;
+    }
+    if (geometry != null ? !geometry.equals(feature.geometry) : feature.geometry != null) {
+      return false;
+    }
+    if (properties != null ? !properties.equals(feature.properties) : feature.properties != null) {
+      return false;
+    }
+    return id != null ? id.equals(feature.id) : feature.id == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + (geometry != null ? geometry.hashCode() : 0);
+    result = 31 * result + (properties != null ? properties.hashCode() : 0);
+    result = 31 * result + (id != null ? id.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson();
+  }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/FeatureCollection.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/FeatureCollection.java
@@ -47,8 +47,43 @@ public class FeatureCollection extends BaseFeatureCollection {
     return new FeatureCollection(features);
   }
 
+  /**
+   * Create a {@link FeatureCollection} from an array of features.
+   *
+   * @param features Array of {@link Feature}
+   * @return new {@link FeatureCollection}
+   * @since 1.0.0
+   */
   public static FeatureCollection fromFeatures(Feature[] features) {
     return new FeatureCollection(Arrays.asList(features));
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    FeatureCollection that = (FeatureCollection) o;
+
+    return features != null ? features.equals(that.features) : that.features == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (features != null ? features.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson();
+  }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/GeometryCollection.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/GeometryCollection.java
@@ -88,4 +88,33 @@ public class GeometryCollection implements GeoJSON {
     gson.registerTypeAdapter(Position.class, new PositionSerializer());
     return gson.create().toJson(this);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    GeometryCollection that = (GeometryCollection) o;
+
+    if (!type.equals(that.type)) {
+      return false;
+    }
+    return geometries != null ? geometries.equals(that.geometries) : that.geometries == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + (geometries != null ? geometries.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson();
+  }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/LineString.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/LineString.java
@@ -125,4 +125,33 @@ public class LineString implements Geometry<List<Position>> {
   public String toPolyline(int precision) {
     return PolylineUtils.encode(getCoordinates(), precision);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    LineString that = (LineString) o;
+
+    if (!type.equals(that.type)) {
+      return false;
+    }
+    return coordinates != null ? coordinates.equals(that.coordinates) : that.coordinates == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + (coordinates != null ? coordinates.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson();
+  }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/MultiLineString.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/MultiLineString.java
@@ -105,4 +105,33 @@ public class MultiLineString implements Geometry<List<List<Position>>> {
     gson.registerTypeAdapter(Position.class, new PositionSerializer());
     return gson.create().toJson(this);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MultiLineString that = (MultiLineString) o;
+
+    if (!type.equals(that.type)) {
+      return false;
+    }
+    return coordinates != null ? coordinates.equals(that.coordinates) : that.coordinates == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + (coordinates != null ? coordinates.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson();
+  }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/MultiPoint.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/MultiPoint.java
@@ -101,4 +101,34 @@ public class MultiPoint implements Geometry<List<Position>> {
     gson.registerTypeAdapter(Position.class, new PositionSerializer());
     return gson.create().toJson(this);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MultiPoint that = (MultiPoint) o;
+
+    if (!type.equals(that.type)) {
+      return false;
+    }
+    return coordinates != null ? coordinates.equals(that.coordinates) : that.coordinates == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + (coordinates != null ? coordinates.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson();
+  }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/MultiPolygon.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/MultiPolygon.java
@@ -109,4 +109,33 @@ public class MultiPolygon implements Geometry<List<List<List<Position>>>> {
     gson.registerTypeAdapter(Position.class, new PositionSerializer());
     return gson.create().toJson(this);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MultiPolygon that = (MultiPolygon) o;
+
+    if (!type.equals(that.type)) {
+      return false;
+    }
+    return coordinates != null ? coordinates.equals(that.coordinates) : that.coordinates == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + (coordinates != null ? coordinates.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson();
+  }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/Point.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/Point.java
@@ -115,9 +115,6 @@ public class Point implements Geometry<Position> {
 
   @Override
   public String toString() {
-    return "Point{"
-      + "type='" + type + '\''
-      + ", coordinates=" + coordinates
-      + '}';
+    return this.toJson();
   }
 }

--- a/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/Polygon.java
+++ b/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/Polygon.java
@@ -105,4 +105,33 @@ public class Polygon implements Geometry<List<List<Position>>> {
     gson.registerTypeAdapter(Position.class, new PositionSerializer());
     return gson.create().toJson(this);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Polygon polygon = (Polygon) o;
+
+    if (!type.equals(polygon.type)) {
+      return false;
+    }
+    return coordinates != null ? coordinates.equals(polygon.coordinates) : polygon.coordinates == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + (coordinates != null ? coordinates.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson();
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsResponse.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsResponse.java
@@ -103,4 +103,42 @@ public class DirectionsResponse {
   public void setRoutes(List<DirectionsRoute> routes) {
     this.routes = routes;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DirectionsResponse response = (DirectionsResponse) o;
+
+    if (!getCode().equals(response.getCode())) {
+      return false;
+    }
+    if (!getRoutes().equals(response.getRoutes())) {
+      return false;
+    }
+    return getWaypoints().equals(response.getWaypoints());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + getCode().hashCode();
+    result = 31 * result + getRoutes().hashCode();
+    result = 31 * result + getWaypoints().hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "DirectionsResponse{"
+      + "code='" + code + '\''
+      + ", routes=" + routes
+      + ", waypoints=" + waypoints
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsResponse.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsResponse.java
@@ -115,21 +115,22 @@ public class DirectionsResponse {
 
     DirectionsResponse response = (DirectionsResponse) o;
 
-    if (!getCode().equals(response.getCode())) {
+    if (getCode() != null ? !getCode().equals(response.getCode()) : response.getCode() != null) {
       return false;
     }
-    if (!getRoutes().equals(response.getRoutes())) {
+    if (getRoutes() != null ? !getRoutes().equals(response.getRoutes()) : response.getRoutes() != null) {
       return false;
     }
-    return getWaypoints().equals(response.getWaypoints());
+    return getWaypoints() != null ? getWaypoints().equals(response.getWaypoints()) : response.getWaypoints() == null;
+
   }
 
   @Override
   public int hashCode() {
     int result = 17;
-    result = 31 * result + getCode().hashCode();
-    result = 31 * result + getRoutes().hashCode();
-    result = 31 * result + getWaypoints().hashCode();
+    result = 31 * result + (getCode() != null ? getCode().hashCode() : 0);
+    result = 31 * result + (getRoutes() != null ? getRoutes().hashCode() : 0);
+    result = 31 * result + (getWaypoints() != null ? getWaypoints().hashCode() : 0);
     return result;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsRoute.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsRoute.java
@@ -168,13 +168,14 @@ public class DirectionsRoute {
     if (Double.compare(that.getWeight(), getWeight()) != 0) {
       return false;
     }
-    if (!getGeometry().equals(that.getGeometry())) {
+    if (getGeometry() != null ? !getGeometry().equals(that.getGeometry()) : that.getGeometry() != null) {
       return false;
     }
-    if (!getWeightName().equals(that.getWeightName())) {
+    if (getWeightName() != null ? !getWeightName().equals(that.getWeightName()) : that.getWeightName() != null) {
       return false;
     }
-    return getLegs().equals(that.getLegs());
+    return getLegs() != null ? getLegs().equals(that.getLegs()) : that.getLegs() == null;
+
   }
 
   @Override
@@ -182,10 +183,10 @@ public class DirectionsRoute {
     int result = 17;
     result = 31 * result + Double.valueOf(getDistance()).hashCode();
     result = 31 * result + Double.valueOf(getDuration()).hashCode();
-    result = 31 * result + getGeometry().hashCode();
+    result = 31 * result + (getGeometry() != null ? getGeometry().hashCode() : 0);
     result = 31 * result + Double.valueOf(getWeight()).hashCode();
-    result = 31 * result + getWeightName().hashCode();
-    result = 31 * result + getLegs().hashCode();
+    result = 31 * result + (getWeightName() != null ? getWeightName().hashCode() : 0);
+    result = 31 * result + (getLegs() != null ? getLegs().hashCode() : 0);
     return result;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsRoute.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsRoute.java
@@ -147,4 +147,57 @@ public class DirectionsRoute {
   public void setLegs(List<RouteLeg> legs) {
     this.legs = legs;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DirectionsRoute that = (DirectionsRoute) o;
+
+    if (Double.compare(that.getDistance(), getDistance()) != 0) {
+      return false;
+    }
+    if (Double.compare(that.getDuration(), getDuration()) != 0) {
+      return false;
+    }
+    if (Double.compare(that.getWeight(), getWeight()) != 0) {
+      return false;
+    }
+    if (!getGeometry().equals(that.getGeometry())) {
+      return false;
+    }
+    if (!getWeightName().equals(that.getWeightName())) {
+      return false;
+    }
+    return getLegs().equals(that.getLegs());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + Double.valueOf(getDistance()).hashCode();
+    result = 31 * result + Double.valueOf(getDuration()).hashCode();
+    result = 31 * result + getGeometry().hashCode();
+    result = 31 * result + Double.valueOf(getWeight()).hashCode();
+    result = 31 * result + getWeightName().hashCode();
+    result = 31 * result + getLegs().hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "DirectionsRoute{"
+      + "distance=" + distance
+      + ", duration=" + duration
+      + ", geometry='" + geometry + '\''
+      + ", weight=" + weight
+      + ", weightName='" + weightName + '\''
+      + ", legs=" + legs
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsWaypoint.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsWaypoint.java
@@ -2,6 +2,8 @@ package com.mapbox.services.api.directions.v5.models;
 
 import com.mapbox.services.commons.models.Position;
 
+import java.util.Arrays;
+
 /**
  * An input coordinate snapped to the roads network.
  *
@@ -69,5 +71,38 @@ public class DirectionsWaypoint {
    */
   public Position asPosition() {
     return Position.fromCoordinates(location[0], location[1]);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DirectionsWaypoint that = (DirectionsWaypoint) o;
+
+    if (!getName().equals(that.getName())) {
+      return false;
+    }
+    return Arrays.equals(getLocation(), that.getLocation());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + getName().hashCode();
+    result = 31 * result + Arrays.hashCode(getLocation());
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "DirectionsWaypoint{"
+      + "name='" + name + '\''
+      + ", location=" + Arrays.toString(location)
+      + '}';
   }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsWaypoint.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/DirectionsWaypoint.java
@@ -84,16 +84,17 @@ public class DirectionsWaypoint {
 
     DirectionsWaypoint that = (DirectionsWaypoint) o;
 
-    if (!getName().equals(that.getName())) {
+    if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null) {
       return false;
     }
     return Arrays.equals(getLocation(), that.getLocation());
+
   }
 
   @Override
   public int hashCode() {
     int result = 17;
-    result = 31 * result + getName().hashCode();
+    result = 31 * result + (getName() != null ? getName().hashCode() : 0);
     result = 31 * result + Arrays.hashCode(getLocation());
     return result;
   }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/IntersectionLanes.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/IntersectionLanes.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.api.directions.v5.models;
 
+import java.util.Arrays;
+
 /**
  * Object representing lanes in an intersection.
  *
@@ -75,5 +77,39 @@ public class IntersectionLanes {
    */
   public void setIndications(String[] indications) {
     this.indications = indications;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    IntersectionLanes that = (IntersectionLanes) o;
+
+    if (getValid() != that.getValid()) {
+      return false;
+    }
+    return !(getIndications() != null ? !Arrays.equals(getIndications(),
+      that.getIndications()) : that.getIndications() != null);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + (getValid() ? 1 : 0);
+    result = 31 * result + Arrays.hashCode(getIndications());
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "IntersectionLanes{"
+      + "valid=" + valid
+      + ", indications=" + Arrays.toString(indications)
+      + '}';
   }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/IntersectionLanes.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/IntersectionLanes.java
@@ -99,8 +99,7 @@ public class IntersectionLanes {
 
   @Override
   public int hashCode() {
-    int result = 17;
-    result = 31 * result + (getValid() ? 1 : 0);
+    int result = (getValid() ? 1 : 0);
     result = 31 * result + Arrays.hashCode(getIndications());
     return result;
   }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegAnnotation.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegAnnotation.java
@@ -130,6 +130,7 @@ public class LegAnnotation {
     result = 31 * result + Arrays.hashCode(getDistance());
     result = 31 * result + Arrays.hashCode(getDuration());
     result = 31 * result + Arrays.hashCode(getSpeed());
+    result = 31 * result + Arrays.hashCode(getCongestion());
     return result;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegAnnotation.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegAnnotation.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.api.directions.v5.models;
 
+import java.util.Arrays;
+
 /**
  * An annotations object that contains additional details about each line segment along the route geometry. Each entry
  * in an annotations field corresponds to a coordinate along the route geometry.
@@ -97,5 +99,47 @@ public class LegAnnotation {
    */
   public void setCongestion(String[] congestion) {
     this.congestion = congestion;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    LegAnnotation that = (LegAnnotation) o;
+
+    if (!Arrays.equals(getDistance(), that.getDistance())) {
+      return false;
+    }
+    if (!Arrays.equals(getDuration(), that.getDuration())) {
+      return false;
+    }
+    if (!Arrays.equals(getSpeed(), that.getSpeed())) {
+      return false;
+    }
+    return Arrays.equals(getCongestion(), that.getCongestion());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + Arrays.hashCode(getDistance());
+    result = 31 * result + Arrays.hashCode(getDuration());
+    result = 31 * result + Arrays.hashCode(getSpeed());
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "LegAnnotation{"
+      + "distance=" + Arrays.toString(distance)
+      + ", duration=" + Arrays.toString(duration)
+      + ", speed=" + Arrays.toString(speed)
+      + ", congestion=" + Arrays.toString(congestion)
+      + '}';
   }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegStep.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegStep.java
@@ -325,4 +325,92 @@ public class LegStep {
   public void setPronunciation(String pronunciation) {
     this.pronunciation = pronunciation;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    LegStep legStep = (LegStep) o;
+
+    if (Double.compare(legStep.getDistance(), getDistance()) != 0) {
+      return false;
+    }
+    if (Double.compare(legStep.getDuration(), getDuration()) != 0) {
+      return false;
+    }
+    if (Double.compare(legStep.getWeight(), getWeight()) != 0) {
+      return false;
+    }
+    if (!getGeometry().equals(legStep.getGeometry())) {
+      return false;
+    }
+    if (!getName().equals(legStep.getName())) {
+      return false;
+    }
+    if (!getRef().equals(legStep.getRef())) {
+      return false;
+    }
+    if (!getDestinations().equals(legStep.getDestinations())) {
+      return false;
+    }
+    if (!getMode().equals(legStep.getMode())) {
+      return false;
+    }
+    if (!getPronunciation().equals(legStep.getPronunciation())) {
+      return false;
+    }
+    if (!getRotaryName().equals(legStep.getRotaryName())) {
+      return false;
+    }
+    if (!getRotaryPronunciation().equals(legStep.getRotaryPronunciation())) {
+      return false;
+    }
+    if (!getManeuver().equals(legStep.getManeuver())) {
+      return false;
+    }
+    return getIntersections().equals(legStep.getIntersections());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + Double.valueOf(getDistance()).hashCode();
+    result = 31 * result + Double.valueOf(getDuration()).hashCode();
+    result = 31 * result + getGeometry().hashCode();
+    result = 31 * result + getName().hashCode();
+    result = 31 * result + getRef().hashCode();
+    result = 31 * result + getDestinations().hashCode();
+    result = 31 * result + getMode().hashCode();
+    result = 31 * result + getPronunciation().hashCode();
+    result = 31 * result + getRotaryName().hashCode();
+    result = 31 * result + getRotaryPronunciation().hashCode();
+    result = 31 * result + getManeuver().hashCode();
+    result = 31 * result + Double.valueOf(getWeight()).hashCode();
+    result = 31 * result + getIntersections().hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "LegStep{"
+      + "distance=" + distance
+      + ", duration=" + duration
+      + ", geometry='" + geometry + '\''
+      + ", name='" + name + '\''
+      + ", ref='" + ref + '\''
+      + ", destinations='" + destinations + '\''
+      + ", mode='" + mode + '\''
+      + ", pronunciation='" + pronunciation + '\''
+      + ", rotaryName='" + rotaryName + '\''
+      + ", rotaryPronunciation='" + rotaryPronunciation + '\''
+      + ", maneuver=" + maneuver
+      + ", weight=" + weight
+      + ", intersections=" + intersections
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegStep.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegStep.java
@@ -326,6 +326,7 @@ public class LegStep {
     this.pronunciation = pronunciation;
   }
 
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -346,34 +347,41 @@ public class LegStep {
     if (Double.compare(legStep.getWeight(), getWeight()) != 0) {
       return false;
     }
-    if (!getGeometry().equals(legStep.getGeometry())) {
+    if (getGeometry() != null ? !getGeometry().equals(legStep.getGeometry()) : legStep.getGeometry() != null) {
       return false;
     }
-    if (!getName().equals(legStep.getName())) {
+    if (getName() != null ? !getName().equals(legStep.getName()) : legStep.getName() != null) {
       return false;
     }
-    if (!getRef().equals(legStep.getRef())) {
+    if (getRef() != null ? !getRef().equals(legStep.getRef()) : legStep.getRef() != null) {
       return false;
     }
-    if (!getDestinations().equals(legStep.getDestinations())) {
+    if (getDestinations() != null
+      ? !getDestinations().equals(legStep.getDestinations()) : legStep.getDestinations() != null) {
       return false;
     }
-    if (!getMode().equals(legStep.getMode())) {
+    if (getMode() != null
+      ? !getMode().equals(legStep.getMode()) : legStep.getMode() != null) {
       return false;
     }
-    if (!getPronunciation().equals(legStep.getPronunciation())) {
+    if (getPronunciation() != null
+      ? !getPronunciation().equals(legStep.getPronunciation()) : legStep.getPronunciation() != null) {
       return false;
     }
-    if (!getRotaryName().equals(legStep.getRotaryName())) {
+    if (getRotaryName() != null
+      ? !getRotaryName().equals(legStep.getRotaryName()) : legStep.getRotaryName() != null) {
       return false;
     }
-    if (!getRotaryPronunciation().equals(legStep.getRotaryPronunciation())) {
+    if (getRotaryPronunciation() != null
+      ? !getRotaryPronunciation().equals(legStep.getRotaryPronunciation()) : legStep.getRotaryPronunciation() != null) {
       return false;
     }
-    if (!getManeuver().equals(legStep.getManeuver())) {
+    if (getManeuver() != null
+      ? !getManeuver().equals(legStep.getManeuver()) : legStep.getManeuver() != null) {
       return false;
     }
-    return getIntersections().equals(legStep.getIntersections());
+    return getIntersections() != null
+      ? getIntersections().equals(legStep.getIntersections()) : legStep.getIntersections() == null;
   }
 
   @Override
@@ -381,17 +389,17 @@ public class LegStep {
     int result = 17;
     result = 31 * result + Double.valueOf(getDistance()).hashCode();
     result = 31 * result + Double.valueOf(getDuration()).hashCode();
-    result = 31 * result + getGeometry().hashCode();
-    result = 31 * result + getName().hashCode();
-    result = 31 * result + getRef().hashCode();
-    result = 31 * result + getDestinations().hashCode();
-    result = 31 * result + getMode().hashCode();
-    result = 31 * result + getPronunciation().hashCode();
-    result = 31 * result + getRotaryName().hashCode();
-    result = 31 * result + getRotaryPronunciation().hashCode();
-    result = 31 * result + getManeuver().hashCode();
+    result = 31 * result + (getGeometry() != null ? getGeometry().hashCode() : 0);
+    result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+    result = 31 * result + (getRef() != null ? getRef().hashCode() : 0);
+    result = 31 * result + (getDestinations() != null ? getDestinations().hashCode() : 0);
+    result = 31 * result + (getMode() != null ? getMode().hashCode() : 0);
+    result = 31 * result + (getPronunciation() != null ? getPronunciation().hashCode() : 0);
+    result = 31 * result + (getRotaryName() != null ? getRotaryName().hashCode() : 0);
+    result = 31 * result + (getRotaryPronunciation() != null ? getRotaryPronunciation().hashCode() : 0);
+    result = 31 * result + (getManeuver() != null ? getManeuver().hashCode() : 0);
     result = 31 * result + Double.valueOf(getWeight()).hashCode();
-    result = 31 * result + getIntersections().hashCode();
+    result = 31 * result + (getIntersections() != null ? getIntersections().hashCode() : 0);
     return result;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/RouteLeg.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/RouteLeg.java
@@ -123,4 +123,53 @@ public class RouteLeg {
   public void setAnnotation(LegAnnotation annotation) {
     this.annotation = annotation;
   }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RouteLeg routeLeg = (RouteLeg) o;
+
+    if (Double.compare(routeLeg.getDistance(), getDistance()) != 0) {
+      return false;
+    }
+    if (Double.compare(routeLeg.getDuration(), getDuration()) != 0) {
+      return false;
+    }
+    if (!getSummary().equals(routeLeg.getSummary())) {
+      return false;
+    }
+    if (!getSteps().equals(routeLeg.getSteps())) {
+      return false;
+    }
+    return getAnnotation().equals(routeLeg.getAnnotation());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + Double.valueOf(getDistance()).hashCode();
+    result = 31 * result + Double.valueOf(getDuration()).hashCode();
+    result = 31 * result + getSummary().hashCode();
+    result = 31 * result + getSteps().hashCode();
+    result = 31 * result + getAnnotation().hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "RouteLeg{"
+      + "distance=" + distance
+      + ", duration=" + duration
+      + ", summary='" + summary + '\''
+      + ", steps=" + steps
+      + ", annotation=" + annotation
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/RouteLeg.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/RouteLeg.java
@@ -142,13 +142,14 @@ public class RouteLeg {
     if (Double.compare(routeLeg.getDuration(), getDuration()) != 0) {
       return false;
     }
-    if (!getSummary().equals(routeLeg.getSummary())) {
+    if (getSummary() != null ? !getSummary().equals(routeLeg.getSummary()) : routeLeg.getSummary() != null) {
       return false;
     }
-    if (!getSteps().equals(routeLeg.getSteps())) {
+    if (getSteps() != null ? !getSteps().equals(routeLeg.getSteps()) : routeLeg.getSteps() != null) {
       return false;
     }
-    return getAnnotation().equals(routeLeg.getAnnotation());
+    return getAnnotation() != null
+      ? getAnnotation().equals(routeLeg.getAnnotation()) : routeLeg.getAnnotation() == null;
   }
 
   @Override
@@ -156,9 +157,9 @@ public class RouteLeg {
     int result = 17;
     result = 31 * result + Double.valueOf(getDistance()).hashCode();
     result = 31 * result + Double.valueOf(getDuration()).hashCode();
-    result = 31 * result + getSummary().hashCode();
-    result = 31 * result + getSteps().hashCode();
-    result = 31 * result + getAnnotation().hashCode();
+    result = 31 * result + (getSummary() != null ? getSummary().hashCode() : 0);
+    result = 31 * result + (getSteps() != null ? getSteps().hashCode() : 0);
+    result = 31 * result + (getAnnotation() != null ? getAnnotation().hashCode() : 0);
     return result;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepIntersection.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepIntersection.java
@@ -2,6 +2,8 @@ package com.mapbox.services.api.directions.v5.models;
 
 import com.mapbox.services.commons.models.Position;
 
+import java.util.Arrays;
+
 /**
  * Object representing an intersection along the step.
  *
@@ -186,5 +188,62 @@ public class StepIntersection {
    */
   public void setLanes(IntersectionLanes[] lanes) {
     this.lanes = lanes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    StepIntersection stepIntersection = (StepIntersection) o;
+
+    if (getLocation() != null ? !Arrays.equals(getLocation(),
+      stepIntersection.getLocation()) : stepIntersection.getLocation() != null) {
+      return false;
+    }
+    if (getBearings() != null ? !Arrays.equals(getBearings(),
+      stepIntersection.getBearings()) : stepIntersection.getBearings() != null) {
+      return false;
+    }
+    if (getEntry() != null ? !Arrays.equals(getEntry(),
+      stepIntersection.getEntry()) : stepIntersection.getEntry() != null) {
+      return false;
+    }
+    if (getIn() != stepIntersection.getIn()) {
+      return false;
+    }
+    if (getOut() != stepIntersection.getOut()) {
+      return false;
+    }
+    return !(getLanes() != null ? !Arrays.equals(getLanes(),
+      stepIntersection.getLanes()) : stepIntersection.getLanes() != null);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + (getLocation() != null ? Arrays.hashCode(getLocation()) : 0);
+    result = 31 * result + (getBearings() != null ? Arrays.hashCode(getBearings()) : 0);
+    result = 31 * result + (getEntry() != null ? Arrays.hashCode(getEntry()) : 0);
+    result = 31 * result + getIn();
+    result = 31 * result + getOut();
+    result = 31 * result + (getLanes() != null ? Arrays.hashCode(getLanes()) : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "StepIntersection{"
+      + "location=" + Arrays.toString(location)
+      + ", bearings=" + Arrays.toString(bearings)
+      + ", entry=" + Arrays.toString(entry)
+      + ", in=" + in
+      + ", out=" + out
+      + ", lanes=" + Arrays.toString(lanes)
+      + '}';
   }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepManeuver.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepManeuver.java
@@ -230,21 +230,61 @@ public class StepManeuver {
     return Position.fromCoordinates(location[0], location[1]);
   }
 
-  /**
-   * Offers a convenient string with all the {@link StepManeuver} variables.
-   *
-   * @return String with all {@link StepManeuver} information within.
-   * @since 1.0.0
-   */
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    StepManeuver that = (StepManeuver) o;
+
+    if (Double.compare(that.getBearingBefore(), getBearingBefore()) != 0) {
+      return false;
+    }
+    if (Double.compare(that.getBearingAfter(), getBearingAfter()) != 0) {
+      return false;
+    }
+    if (!Arrays.equals(getLocation(), that.getLocation())) {
+      return false;
+    }
+    if (!getType().equals(that.getType())) {
+      return false;
+    }
+    if (!getModifier().equals(that.getModifier())) {
+      return false;
+    }
+    if (!getInstruction().equals(that.getInstruction())) {
+      return false;
+    }
+    return getExit().equals(that.getExit());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + Arrays.hashCode(getLocation());
+    result = 31 * result + Double.valueOf(getBearingBefore()).hashCode();
+    result = 31 * result + Double.valueOf(getBearingAfter()).hashCode();
+    result = 31 * result + getType().hashCode();
+    result = 31 * result + getModifier().hashCode();
+    result = 31 * result + getInstruction().hashCode();
+    result = 31 * result + getExit().hashCode();
+    return result;
+  }
+
   @Override
   public String toString() {
     return "StepManeuver{"
       + "location=" + Arrays.toString(location)
       + ", bearingBefore=" + bearingBefore
       + ", bearingAfter=" + bearingAfter
-      + ", instruction='" + instruction + '\''
       + ", type='" + type + '\''
       + ", modifier='" + modifier + '\''
+      + ", instruction='" + instruction + '\''
       + ", exit=" + exit
       + '}';
   }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepManeuver.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/StepManeuver.java
@@ -230,7 +230,6 @@ public class StepManeuver {
     return Position.fromCoordinates(location[0], location[1]);
   }
 
-
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -251,16 +250,17 @@ public class StepManeuver {
     if (!Arrays.equals(getLocation(), that.getLocation())) {
       return false;
     }
-    if (!getType().equals(that.getType())) {
+    if (getType() != null ? !getType().equals(that.getType()) : that.getType() != null) {
       return false;
     }
-    if (!getModifier().equals(that.getModifier())) {
+    if (getModifier() != null ? !getModifier().equals(that.getModifier()) : that.getModifier() != null) {
       return false;
     }
-    if (!getInstruction().equals(that.getInstruction())) {
+    if (getInstruction() != null ? !getInstruction().equals(that.getInstruction()) : that.getInstruction() != null) {
       return false;
     }
-    return getExit().equals(that.getExit());
+    return getExit() != null ? getExit().equals(that.getExit()) : that.getExit() == null;
+
   }
 
   @Override
@@ -269,10 +269,10 @@ public class StepManeuver {
     result = 31 * result + Arrays.hashCode(getLocation());
     result = 31 * result + Double.valueOf(getBearingBefore()).hashCode();
     result = 31 * result + Double.valueOf(getBearingAfter()).hashCode();
-    result = 31 * result + getType().hashCode();
-    result = 31 * result + getModifier().hashCode();
-    result = 31 * result + getInstruction().hashCode();
-    result = 31 * result + getExit().hashCode();
+    result = 31 * result + (getType() != null ? getType().hashCode() : 0);
+    result = 31 * result + (getModifier() != null ? getModifier().hashCode() : 0);
+    result = 31 * result + (getInstruction() != null ? getInstruction().hashCode() : 0);
+    result = 31 * result + (getExit() != null ? getExit().hashCode() : 0);
     return result;
   }
 

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directionsmatrix/v1/models/DirectionsMatrixResponse.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directionsmatrix/v1/models/DirectionsMatrixResponse.java
@@ -2,6 +2,7 @@ package com.mapbox.services.api.directionsmatrix.v1.models;
 
 import com.mapbox.services.api.directions.v5.models.DirectionsWaypoint;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -18,6 +19,7 @@ public class DirectionsMatrixResponse {
 
   /**
    * Empty constructor
+   *
    * @since 2.1.0
    */
   public DirectionsMatrixResponse() {
@@ -115,5 +117,50 @@ public class DirectionsMatrixResponse {
    */
   public void setSources(List<DirectionsWaypoint> sources) {
     this.sources = sources;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DirectionsMatrixResponse that = (DirectionsMatrixResponse) o;
+
+    if (getCode() != null ? !getCode().equals(that.getCode()) : that.getCode() != null) {
+      return false;
+    }
+    if (!Arrays.deepEquals(getDurations(), that.getDurations())) {
+      return false;
+    }
+    if (getDestinations() != null
+      ? !getDestinations().equals(that.getDestinations()) : that.getDestinations() != null) {
+      return false;
+    }
+    return getSources() != null ? getSources().equals(that.getSources()) : that.getSources() == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + (getCode() != null ? getCode().hashCode() : 0);
+    result = 31 * result + Arrays.deepHashCode(getDurations());
+    result = 31 * result + (getDestinations() != null ? getDestinations().hashCode() : 0);
+    result = 31 * result + (getSources() != null ? getSources().hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "DirectionsMatrixResponse{"
+      + "code='" + code + '\''
+      + ", durations=" + Arrays.toString(durations)
+      + ", destinations=" + destinations
+      + ", sources=" + sources
+      + '}';
   }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenContext.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenContext.java
@@ -77,4 +77,56 @@ public class CarmenContext {
   public String getMaki() {
     return maki;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CarmenContext that = (CarmenContext) o;
+
+    if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) {
+      return false;
+    }
+    if (getText() != null ? !getText().equals(that.getText()) : that.getText() != null) {
+      return false;
+    }
+    if (getShortCode() != null ? !getShortCode().equals(that.getShortCode()) : that.getShortCode() != null) {
+      return false;
+    }
+    if (getWikidata() != null ? !getWikidata().equals(that.getWikidata()) : that.getWikidata() != null) {
+      return false;
+    }
+    if (getCategory() != null ? !getCategory().equals(that.getCategory()) : that.getCategory() != null) {
+      return false;
+    }
+    return getMaki() != null ? getMaki().equals(that.getMaki()) : that.getMaki() == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getId() != null ? getId().hashCode() : 0;
+    result = 31 * result + (getText() != null ? getText().hashCode() : 0);
+    result = 31 * result + (getShortCode() != null ? getShortCode().hashCode() : 0);
+    result = 31 * result + (getWikidata() != null ? getWikidata().hashCode() : 0);
+    result = 31 * result + (getCategory() != null ? getCategory().hashCode() : 0);
+    result = 31 * result + (getMaki() != null ? getMaki().hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CarmenContext{"
+      + "id='" + id + '\''
+      + ", text='" + text + '\''
+      + ", shortCode='" + shortCode + '\''
+      + ", wikidata='" + wikidata + '\''
+      + ", category='" + category + '\''
+      + ", maki='" + maki + '\''
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeature.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeature.java
@@ -31,7 +31,6 @@ public class CarmenFeature extends Feature {
   private String address;
   private double[] center;
   private List<CarmenContext> context;
-
   private double relevance;
 
   /**

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeature.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeature.java
@@ -10,6 +10,7 @@ import com.mapbox.services.commons.geojson.custom.GeometryDeserializer;
 import com.mapbox.services.commons.geojson.custom.PositionDeserializer;
 import com.mapbox.services.commons.models.Position;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -158,15 +159,62 @@ public class CarmenFeature extends Feature {
     return Position.fromCoordinates(center[0], center[1]);
   }
 
-  /**
-   * Human-readable text representing the full result hierarchy
-   * (e.g. "Austin, Texas, United States").
-   *
-   * @return String with human-readable text.
-   * @since 1.0.0
-   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CarmenFeature that = (CarmenFeature) o;
+
+    if (Double.compare(that.getRelevance(), getRelevance()) != 0) {
+      return false;
+    }
+    if (getText() != null ? !getText().equals(that.getText()) : that.getText() != null) {
+      return false;
+    }
+    if (getPlaceName() != null ? !getPlaceName().equals(that.getPlaceName()) : that.getPlaceName() != null) {
+      return false;
+    }
+    if (!Arrays.equals(getBbox(), that.getBbox())) {
+      return false;
+    }
+    if (getAddress() != null ? !getAddress().equals(that.getAddress()) : that.getAddress() != null) {
+      return false;
+    }
+    if (!Arrays.equals(getCenter(), that.getCenter())) {
+      return false;
+    }
+    return getContext() != null ? getContext().equals(that.getContext()) : that.getContext() == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + (getText() != null ? getText().hashCode() : 0);
+    result = 31 * result + (getPlaceName() != null ? getPlaceName().hashCode() : 0);
+    result = 31 * result + Arrays.hashCode(getBbox());
+    result = 31 * result + (getAddress() != null ? getAddress().hashCode() : 0);
+    result = 31 * result + Arrays.hashCode(getCenter());
+    result = 31 * result + (getContext() != null ? getContext().hashCode() : 0);
+    result = 31 * result + Double.valueOf(getRelevance()).hashCode();
+    return result;
+  }
+
   @Override
   public String toString() {
-    return getPlaceName();
+    return "CarmenFeature{"
+      + "text='" + text + '\''
+      + ", placeName='" + placeName + '\''
+      + ", bbox=" + Arrays.toString(bbox)
+      + ", address='" + address + '\''
+      + ", center=" + Arrays.toString(center)
+      + ", context=" + context
+      + ", relevance=" + relevance
+      + '}';
   }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeatureCollection.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/geocoding/v5/models/CarmenFeatureCollection.java
@@ -93,4 +93,42 @@ public class CarmenFeatureCollection extends BaseFeatureCollection {
     return new CarmenFeatureCollection(features);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CarmenFeatureCollection that = (CarmenFeatureCollection) o;
+
+    if (getQuery() != null ? !getQuery().equals(that.getQuery()) : that.getQuery() != null) {
+      return false;
+    }
+    if (getAttribution() != null ? !getAttribution().equals(that.getAttribution()) : that.getAttribution() != null) {
+      return false;
+    }
+    return getFeatures() != null ? getFeatures().equals(that.getFeatures()) : that.getFeatures() == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + (getQuery() != null ? getQuery().hashCode() : 0);
+    result = 31 * result + (getAttribution() != null ? getAttribution().hashCode() : 0);
+    result = 31 * result + (getFeatures() != null ? getFeatures().hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CarmenFeatureCollection{"
+      + "query=" + query
+      + ", attribution='" + attribution + '\''
+      + ", features=" + features
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingMatching.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingMatching.java
@@ -29,4 +29,36 @@ public class MapMatchingMatching extends DirectionsRoute {
   public void setConfidence(double confidence) {
     this.confidence = confidence;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    MapMatchingMatching that = (MapMatchingMatching) o;
+
+    return Double.compare(that.getConfidence(), getConfidence()) == 0;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + Double.valueOf(getConfidence()).hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "MapMatchingMatching{"
+      + "confidence=" + confidence
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingResponse.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingResponse.java
@@ -81,4 +81,43 @@ public class MapMatchingResponse {
   public void setTracepoints(List<MapMatchingTracepoint> tracepoints) {
     this.tracepoints = tracepoints;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MapMatchingResponse that = (MapMatchingResponse) o;
+
+    if (getCode() != null ? !getCode().equals(that.getCode()) : that.getCode() != null) {
+      return false;
+    }
+    if (getMatchings() != null ? !getMatchings().equals(that.getMatchings()) : that.getMatchings() != null) {
+      return false;
+    }
+    return getTracepoints() != null ? getTracepoints().equals(that.getTracepoints()) : that.getTracepoints() == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + (getCode() != null ? getCode().hashCode() : 0);
+    result = 31 * result + (getMatchings() != null ? getMatchings().hashCode() : 0);
+    result = 31 * result + (getTracepoints() != null ? getTracepoints().hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "MapMatchingResponse{"
+      + "code='" + code + '\''
+      + ", matchings=" + matchings
+      + ", tracepoints=" + tracepoints
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingTracepoint.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingTracepoint.java
@@ -66,6 +66,7 @@ public class MapMatchingTracepoint extends DirectionsWaypoint {
     this.waypointIndex = waypointIndex;
   }
 
+
   /**
    * Number of probable alternative matchings for this trace point. A value of zero indicates that this point was
    * matched unambiguously. Split the trace at these points for incremental map matching.
@@ -86,5 +87,46 @@ public class MapMatchingTracepoint extends DirectionsWaypoint {
    */
   public void setAlternativesCount(int alternativesCount) {
     this.alternativesCount = alternativesCount;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    MapMatchingTracepoint that = (MapMatchingTracepoint) o;
+
+    if (getMatchingsIndex() != that.getMatchingsIndex()) {
+      return false;
+    }
+    if (getAlternativesCount() != that.getAlternativesCount()) {
+      return false;
+    }
+    return getWaypointIndex() == that.getWaypointIndex();
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + getMatchingsIndex();
+    result = 31 * result + getWaypointIndex();
+    result = 31 * result + getAlternativesCount();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "MapMatchingTracepoint{"
+      + "matchingsIndex=" + matchingsIndex
+      + ", waypointIndex=" + waypointIndex
+      + ", alternativesCount=" + alternativesCount
+      + '}';
   }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/optimizedtrips/v1/models/OptimizationWaypoint.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/optimizedtrips/v1/models/OptimizationWaypoint.java
@@ -69,4 +69,41 @@ public class OptimizationWaypoint extends DirectionsWaypoint {
   public void setTripsIndex(int tripsIndex) {
     this.tripsIndex = tripsIndex;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    OptimizationWaypoint that = (OptimizationWaypoint) o;
+
+    if (waypointIndex != that.waypointIndex) {
+      return false;
+    }
+    return tripsIndex == that.tripsIndex;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + waypointIndex;
+    result = 31 * result + tripsIndex;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "OptimizationWaypoint{"
+      + "waypointIndex=" + waypointIndex
+      + ", tripsIndex=" + tripsIndex
+      + '}';
+  }
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/optimizedtrips/v1/models/OptimizedTripsResponse.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/optimizedtrips/v1/models/OptimizedTripsResponse.java
@@ -111,4 +111,43 @@ public class OptimizedTripsResponse {
   public void setTrips(List<DirectionsRoute> trips) {
     this.trips = trips;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    OptimizedTripsResponse that = (OptimizedTripsResponse) o;
+
+    if (getCode() != null ? !getCode().equals(that.getCode()) : that.getCode() != null) {
+      return false;
+    }
+    if (getWaypoints() != null ? !getWaypoints().equals(that.getWaypoints()) : that.getWaypoints() != null) {
+      return false;
+    }
+    return getTrips() != null ? getTrips().equals(that.getTrips()) : that.getTrips() == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + (getCode() != null ? getCode().hashCode() : 0);
+    result = 31 * result + (getWaypoints() != null ? getWaypoints().hashCode() : 0);
+    result = 31 * result + (getTrips() != null ? getTrips().hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "OptimizedTripsResponse{"
+      + "code='" + code + '\''
+      + ", waypoints=" + waypoints
+      + ", trips=" + trips
+      + '}';
+  }
 }


### PR DESCRIPTION
This PR adds the standard `toString` `hashcode` and `equal` methods to model classes. Previously, if you tried comparing two matching objects, it would return false, this fixes that.

- [ ] Test should be added
- [ ] Javadoc needs to be added