### PR TITLE
Document correct units for LegAnnotation.speed

### DIFF
--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegAnnotation.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/models/LegAnnotation.java
@@ -36,7 +36,7 @@ public class LegAnnotation {
   }
 
   /**
-   * The speed, in km/h, between each pair of coordinates.
+   * The speed, in meters per second, between each pair of coordinates.
    *
    * @return a double array with each entry being a speed value between two of the routeLeg geometry coordinates.
    * @since 2.1.0


### PR DESCRIPTION
The speed is measured in meters per second, not kilometers per hour.

/cc @cammace @miccolis