### PR TITLE
Update style versions to v10, add traffic styles

### DIFF
--- a/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
+++ b/mapbox/libjava-core/src/main/java/com/mapbox/services/Constants.java
@@ -42,12 +42,14 @@ public class Constants {
    * Mapbox default styles
    * https://www.mapbox.com/developers/api/styles/
    */
-  public static final String MAPBOX_STYLE_STREETS = "streets-v9";
+  public static final String MAPBOX_STYLE_STREETS = "streets-v10";
   public static final String MAPBOX_STYLE_LIGHT = "light-v9";
   public static final String MAPBOX_STYLE_DARK = "dark-v9";
-  public static final String MAPBOX_STYLE_OUTDOORS = "outdoors-v9";
+  public static final String MAPBOX_STYLE_OUTDOORS = "outdoors-v10";
   public static final String MAPBOX_STYLE_SATELLITE = "satellite-v9";
-  public static final String MAPBOX_STYLE_SATELLITE_HYBRID = "satellite-streets-v9";
+  public static final String MAPBOX_STYLE_SATELLITE_HYBRID = "satellite-streets-v10";
+  public static final String MAPBOX_STYLE_TRAFFIC_DAY = "traffic-day-v2";
+  public static final String MAPBOX_STYLE_TRAFFIC_NIGHT = "traffic-night-v2";
 
   public static final String PIN_SMALL = "pin-s";
   public static final String PIN_MEDIUM = "pin-m";

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/staticimage/v1/MapboxStaticImageTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/staticimage/v1/MapboxStaticImageTest.java
@@ -148,6 +148,6 @@ public class MapboxStaticImageTest {
     HttpUrl url = client.getUrl();
     assertEquals(
       url.toString(),
-      "https://api.mapbox.com/styles/v1/mapbox/streets-v9/static/1.23456,-98.76000,10.00000,345.67890,0.00000/100x200?access_token=pk.");
+      "https://api.mapbox.com/styles/v1/mapbox/streets-v10/static/1.23456,-98.76000,10.00000,345.67890,0.00000/100x200?access_token=pk.");
   }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-java/issues/452, updates the style in compliance with what we expose on mapbox-gl-native. This means updating availlable styles to v10 (if possible) and adding constants for traffic styles. 