### PR TITLE
Clarify waypoint limit

### DIFF
--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
@@ -391,7 +391,7 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * <p>
      * - Each coordinate is a pair of a longitude double and latitude double, which are separated by a ,
      * - Coordinates are separated by a ; from each other
-     * - A query must at minimum have 2 coordinates and may at maximum have 25 coordinates
+     * - A query must have at least 2 coordinates and at most 25 coordinates (at most 3 when the profile is {@link com.mapbox.services.api.directions.v5.DirectionsCriteria#PROFILE_DRIVING_TRAFFIC})
      *
      * @return String containing coordinates formatted.
      * @since 1.0.0

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directions/v5/MapboxDirections.java
@@ -391,7 +391,8 @@ public class MapboxDirections extends MapboxService<DirectionsResponse> {
      * <p>
      * - Each coordinate is a pair of a longitude double and latitude double, which are separated by a ,
      * - Coordinates are separated by a ; from each other
-     * - A query must have at least 2 coordinates and at most 25 coordinates (at most 3 when the profile is {@link com.mapbox.services.api.directions.v5.DirectionsCriteria#PROFILE_DRIVING_TRAFFIC})
+     * - A query must have at least 2 coordinates and at most 25 coordinates (at most 3 when the profile is
+     * {@link com.mapbox.services.api.directions.v5.DirectionsCriteria#PROFILE_DRIVING_TRAFFIC})
      *
      * @return String containing coordinates formatted.
      * @since 1.0.0


### PR DESCRIPTION
`PROFILE_DRIVING_TRAFFIC` has a much lower limit of only three waypoints, per [the API documentation](https://www.mapbox.com/api-documentation/#directions).

/ref mapbox/MapboxDirections.swift#142
/cc @cammace @danswick