### PR TITLE
downgrade LOST to v1.1.1

### DIFF
--- a/mapbox/app/build.gradle
+++ b/mapbox/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
         transitive = true
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-java-geojson'
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-telemetry'
+        exclude group: 'com.mapzen.android', module: 'lost'
     }
 
     // Leak Canary

--- a/mapbox/app/build.gradle
+++ b/mapbox/app/build.gradle
@@ -49,7 +49,6 @@ dependencies {
         transitive = true
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-java-geojson'
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-telemetry'
-        exclude group: 'com.mapzen.android', module: 'lost'
     }
 
     // Leak Canary

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/location/GoogleLocationEngine.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/location/GoogleLocationEngine.java
@@ -88,7 +88,7 @@ public class GoogleLocationEngine extends LocationEngine implements
 
   @Override
   public Location getLastLocation() {
-    if (googleApiClient.isConnected() && PermissionsManager.areLocationPermissionsGranted(context.get())) {
+    if (googleApiClient.isConnected()) {
       //noinspection MissingPermission
       return LocationServices.FusedLocationApi.getLastLocation(googleApiClient);
     }
@@ -114,7 +114,7 @@ public class GoogleLocationEngine extends LocationEngine implements
       request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
     }
 
-    if (googleApiClient.isConnected() && PermissionsManager.areLocationPermissionsGranted(context.get())) {
+    if (googleApiClient.isConnected()) {
       //noinspection MissingPermission
       LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, request, this);
     }

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/location/GoogleLocationEngine.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/location/GoogleLocationEngine.java
@@ -15,7 +15,6 @@ import com.google.android.gms.location.LocationServices;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngineListener;
 import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
-import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
 
 import java.lang.ref.WeakReference;
 

--- a/mapbox/app/src/main/java/com/mapbox/services/android/testapp/location/LocationEngineActivity.java
+++ b/mapbox/app/src/main/java/com/mapbox/services/android/testapp/location/LocationEngineActivity.java
@@ -15,8 +15,11 @@ import com.mapbox.services.android.location.MockLocationEngine;
 import com.mapbox.services.android.telemetry.location.AndroidLocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngineListener;
+import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
 import com.mapbox.services.android.testapp.R;
 import com.mapbox.services.commons.models.Position;
+
+import timber.log.Timber;
 
 public class LocationEngineActivity extends AppCompatActivity
   implements AdapterView.OnItemSelectedListener, LocationEngineListener {
@@ -88,6 +91,8 @@ public class LocationEngineActivity extends AppCompatActivity
 
     if (!engineName.equals(locationEngines[0]) && locationEngine != null) {
       // Not None
+      Timber.e("Last known location: %s", locationEngine.getLastLocation());
+      locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
       locationEngine.addLocationEngineListener(this);
       locationEngine.activate();
     }

--- a/mapbox/dependencies.gradle
+++ b/mapbox/dependencies.gradle
@@ -36,7 +36,7 @@ ext {
             okhttp3Mockwebserver : 'com.squareup.okhttp3:mockwebserver:3.6.0',
 
             // lost
-            lost                 : 'com.mapzen.android:lost:3.0.1',
+            lost                 : 'com.mapzen.android:lost:1.1.1',
 
             // play services
             gmsLocation          : 'com.google.android.gms:play-services-location:10.2.0',

--- a/mapbox/dependencies.gradle
+++ b/mapbox/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
             supportCardView      : 'com.android.support:cardview-v7:25.1.0',
 
             // mapbox
-            mapbox               : 'com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar',
+            mapbox               : 'com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.0-SNAPSHOT@aar',
 
             // gson
             gson                 : 'com.google.code.gson:gson:2.8.0',

--- a/mapbox/libandroid-services/build.gradle
+++ b/mapbox/libandroid-services/build.gradle
@@ -43,7 +43,9 @@ dependencies {
     compile rootProject.ext.dep.timber
 
     // LOST
-    compile rootProject.ext.dep.lost
+    compile(rootProject.ext.dep.lost) {
+        exclude group: 'com.google.guava'
+    }
 
     // Testing
     testCompile rootProject.ext.dep.mockito

--- a/mapbox/libandroid-services/src/main/java/com/mapbox/services/android/location/LostLocationEngine.java
+++ b/mapbox/libandroid-services/src/main/java/com/mapbox/services/android/location/LostLocationEngine.java
@@ -76,7 +76,7 @@ public class LostLocationEngine extends LocationEngine implements LocationListen
   }
 
   /**
-   * Returns the Last known location is the location provider is connected and location permissions are granted.
+   * Returns the Last known location if the location provider is connected and location permissions are granted.
    *
    * @return the last known location
    */

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/location/AndroidLocationEngine.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/location/AndroidLocationEngine.java
@@ -70,8 +70,7 @@ public class AndroidLocationEngine extends LocationEngine implements LocationLis
 
   @Override
   public Location getLastLocation() {
-    if (!TextUtils.isEmpty(currentProvider)
-      && PermissionsManager.areLocationPermissionsGranted(context.get())) {
+    if (!TextUtils.isEmpty(currentProvider)) {
       //noinspection MissingPermission
       return locationManager.getLastKnownLocation(currentProvider);
     }
@@ -81,8 +80,7 @@ public class AndroidLocationEngine extends LocationEngine implements LocationLis
 
   @Override
   public void requestLocationUpdates() {
-    if (!TextUtils.isEmpty(currentProvider)
-      && PermissionsManager.areLocationPermissionsGranted(context.get())) {
+    if (!TextUtils.isEmpty(currentProvider)) {
       //noinspection MissingPermission
       locationManager.requestLocationUpdates(currentProvider, DEFAULT_MIN_TIME, DEFAULT_MIN_DISTANCE, this);
     }

--- a/scripts/bitrise.yml
+++ b/scripts/bitrise.yml
@@ -115,8 +115,8 @@ workflows:
             #!/bin/bash        
             echo "Run Robo tests on firebase:"
             gcloud auth activate-service-account --key-file secret.json --project mapbox-java
-            gcloud beta test android devices list
-            gcloud beta test android run --type robo --app mapbox/app/build/outputs/apk/app-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
+            gcloud firebase test android devices list
+            gcloud firebase test android run --type robo --app mapbox/app/build/outputs/apk/app-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
     - slack:
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"


### PR DESCRIPTION
Copied from downstream ticket in https://github.com/mapbox/mapbox-gl-native/pull/9394:

> We have been having some issues with recent releases of the LOST library. To be able to ship a next final release for 5.1.0. We are downgrading back to `v1.1.1`. This version shipped as part of our 4.x series.

This PR requires a newer version of the SDK first to pass CI, excluding lost from the maps sdk makes the test application crash at startup. 

