### PR TITLE
Fixed up mapmatching API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ directions-fixtures:
 		-o mapbox/libjava-services/src/test/fixtures/directions_v5_traffic.json
 
 mapmatching-fixtures:
-	curl "https://api.mapbox.com/matching/v5/mapbox/driving/$(MAP_MATCHING_COORDINATES)?geometries=polyline&access_token=$(MAPBOX_ACCESS_TOKEN)" \
+	curl "https://api.mapbox.com/matching/v5/mapbox/driving/$(MAP_MATCHING_COORDINATES)?geometries=polyline&language=sv&steps=true&access_token=$(MAPBOX_ACCESS_TOKEN)" \
 		-o mapbox/libjava-services/src/test/fixtures/mapmatching_v5_polyline.json
 
 optimized-trips-fixtures:

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/mapmatching/v5/MapMatchingServiceRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/mapmatching/v5/MapMatchingServiceRx.java
@@ -45,6 +45,7 @@ public interface MapMatchingServiceRx {
    *                    along the match geometry. Can be one or all of 'duration', 'distance',
    *                    or 'nodes', each separated by ,. See the response object for more
    *                    details on what it is included with annotations.
+   * @param language    Language of returned turn-by-turn text instructions.
    * @return The MapMatchingResponse in an Observable wrapper
    * @since 2.0.0
    */
@@ -60,5 +61,6 @@ public interface MapMatchingServiceRx {
     @Query("steps") Boolean steps,
     @Query("overview") String overview,
     @Query("timestamps") String timestamps,
-    @Query("annotations") String annotations);
+    @Query("annotations") String annotations,
+    @Query("language") String language);
 }

--- a/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/mapmatching/v5/MapboxMapMatchingRx.java
+++ b/mapbox/libjava-services-rx/src/main/java/com/mapbox/services/api/rx/mapmatching/v5/MapboxMapMatchingRx.java
@@ -66,7 +66,8 @@ public class MapboxMapMatchingRx extends MapboxMapMatching {
       builder.getSteps(),
       builder.getOverview(),
       builder.getTimestamps(),
-      builder.getAnnotations()
+      builder.getAnnotations(),
+      builder.getLanguage()
     );
 
     // Done

--- a/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/BaseTest.java
+++ b/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/BaseTest.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.api;
+package com.mapbox.services.api.rx;
 
 import com.google.gson.JsonParser;
 

--- a/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/mapmatching/v5/MapboxMapMatchingRxTest.java
+++ b/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/mapmatching/v5/MapboxMapMatchingRxTest.java
@@ -29,11 +29,9 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test Rx support on the Mapbox Map Matching API
  */
-
 public class MapboxMapMatchingRxTest {
 
-  public static final String POLYLINE_FIXTURE =
-    "../libjava-services/src/test/fixtures/mapmatching_v5_polyline.json";
+  private static final String POLYLINE_FIXTURE = "src/test/fixtures/mapmatching_v5_polyline.json";
 
   private static final String ACCESS_TOKEN = "pk.XXX";
 

--- a/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/mapmatching/v5/MapboxMapMatchingRxTest.java
+++ b/mapbox/libjava-services-rx/src/test/java/com/mapbox/services/api/rx/mapmatching/v5/MapboxMapMatchingRxTest.java
@@ -3,6 +3,7 @@ package com.mapbox.services.api.rx.mapmatching.v5;
 import com.mapbox.services.api.ServicesException;
 import com.mapbox.services.api.mapmatching.v5.MapMatchingCriteria;
 import com.mapbox.services.api.mapmatching.v5.models.MapMatchingResponse;
+import com.mapbox.services.api.rx.BaseTest;
 import com.mapbox.services.commons.models.Position;
 
 import org.junit.After;
@@ -12,9 +13,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 
 import io.reactivex.observers.TestObserver;
@@ -29,9 +27,9 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test Rx support on the Mapbox Map Matching API
  */
-public class MapboxMapMatchingRxTest {
+public class MapboxMapMatchingRxTest extends BaseTest {
 
-  private static final String POLYLINE_FIXTURE = "src/test/fixtures/mapmatching_v5_polyline.json";
+  private static final String POLYLINE_FIXTURE = "../libjava-services/src/test/fixtures/mapmatching_v5_polyline.json";
 
   private static final String ACCESS_TOKEN = "pk.XXX";
 
@@ -52,7 +50,7 @@ public class MapboxMapMatchingRxTest {
       @Override
       public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
         try {
-          String body = new String(Files.readAllBytes(Paths.get(POLYLINE_FIXTURE)), Charset.forName("utf-8"));
+          String body = loadJsonFixture(POLYLINE_FIXTURE);
           return new MockResponse().setBody(body);
         } catch (IOException ioException) {
           throw new RuntimeException(ioException);

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/MapMatchingService.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/MapMatchingService.java
@@ -46,6 +46,7 @@ public interface MapMatchingService {
    *                    along the match geometry. Can be one or all of 'duration', 'distance',
    *                    or 'nodes', each separated by ,. See the response object for more
    *                    details on what it is included with annotations.
+   * @param language    Language of returned turn-by-turn text instructions.
    * @return The MapMatchingResponse in a Call wrapper
    * @since 2.0.0
    */
@@ -62,5 +63,6 @@ public interface MapMatchingService {
     @Query("steps") Boolean steps,
     @Query("overview") String overview,
     @Query("timestamps") String timestamps,
-    @Query("annotations") String annotations);
+    @Query("annotations") String annotations,
+    @Query("language") String language);
 }

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatching.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatching.java
@@ -1,6 +1,5 @@
 package com.mapbox.services.api.mapmatching.v5;
 
-import com.google.gson.Gson;
 import com.mapbox.services.api.MapboxBuilder;
 import com.mapbox.services.api.MapboxService;
 import com.mapbox.services.api.ServicesException;
@@ -35,7 +34,6 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
   protected Builder builder = null;
   private MapMatchingService service = null;
   private Call<MapMatchingResponse> call = null;
-  private Gson gson;
 
   protected MapboxMapMatching(Builder builder) {
     this.builder = builder;
@@ -85,7 +83,8 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
       builder.getSteps(),
       builder.getOverview(),
       builder.getTimestamps(),
-      builder.getAnnotations()
+      builder.getAnnotations(),
+      builder.getLanguage()
     );
 
     return call;
@@ -152,6 +151,7 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
     private String overview = null;
     private String[] timestamps = null;
     private String annotations = null;
+    private String language;
 
     /**
      * Constructor
@@ -376,6 +376,27 @@ public class MapboxMapMatching extends MapboxService<MapMatchingResponse> {
     public T setBaseUrl(String baseUrl) {
       super.baseUrl = baseUrl;
       return (T) this;
+    }
+
+    /**
+     * Optionally set the language of returned turn-by-turn text instructions. The default is {@code en} for English.
+     *
+     * @param language The locale in which results should be returned.
+     * @return Builder
+     * @see <a href="https://www.mapbox.com/api-documentation/#instructions-languages">Supported languages</a>
+     * @since 2.2.0
+     */
+    public T setLanguage(String language) {
+      this.language = language;
+      return (T) this;
+    }
+
+    /**
+     * @return The language the turn-by-turn directions will be in.
+     * @since 2.2.0
+     */
+    public String getLanguage() {
+      return language;
     }
 
     /**

--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingTracepoint.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/mapmatching/v5/models/MapMatchingTracepoint.java
@@ -10,11 +10,18 @@ public class MapMatchingTracepoint extends DirectionsWaypoint {
 
   @SerializedName("matchings_index")
   private int matchingsIndex;
-
+  @SerializedName("alternatives_count")
+  private int alternativesCount;
   @SerializedName("waypoint_index")
   private int waypointIndex;
 
   public MapMatchingTracepoint() {
+  }
+
+  public MapMatchingTracepoint(int matchingsIndex, int alternativesCount, int waypointIndex) {
+    this.matchingsIndex = matchingsIndex;
+    this.alternativesCount = alternativesCount;
+    this.waypointIndex = waypointIndex;
   }
 
   /**
@@ -51,5 +58,27 @@ public class MapMatchingTracepoint extends DirectionsWaypoint {
    */
   public void setWaypointIndex(int waypointIndex) {
     this.waypointIndex = waypointIndex;
+  }
+
+  /**
+   * Number of probable alternative matchings for this trace point. A value of zero indicates that this point was
+   * matched unambiguously. Split the trace at these points for incremental map matching.
+   *
+   * @return an integer representing the alternatives count
+   * @since 2.2.0
+   */
+  public int getAlternativesCount() {
+    return alternativesCount;
+  }
+
+  /**
+   * Set the number of probable alternative matchings for this trace point. A value of zero indicates that this point
+   * was matched unambiguously. Split the trace at these points for incremental map matching.
+   *
+   * @param alternativesCount an integer representing the alternatives count
+   * @since 2.2.0
+   */
+  public void setAlternativesCount(int alternativesCount) {
+    this.alternativesCount = alternativesCount;
   }
 }

--- a/mapbox/libjava-services/src/test/fixtures/mapmatching_v5_polyline.json
+++ b/mapbox/libjava-services/src/test/fixtures/mapmatching_v5_polyline.json
@@ -1,84 +1,411 @@
 {
-    "code": "Ok",
-    "matchings": [
+  "tracepoints": [
+    {
+      "waypoint_index": 0,
+      "matchings_index": 0,
+      "alternatives_count": 0,
+      "location": [
+        13.418807,
+        52.500595
+      ],
+      "name": "Adalbertstraße"
+    },
+    {
+      "waypoint_index": 1,
+      "matchings_index": 0,
+      "alternatives_count": 0,
+      "location": [
+        13.419148,
+        52.501096
+      ],
+      "name": "Adalbertstraße"
+    },
+    {
+      "waypoint_index": 2,
+      "matchings_index": 0,
+      "alternatives_count": 0,
+      "location": [
+        13.41962,
+        52.501755
+      ],
+      "name": "Adalbertstraße"
+    },
+    {
+      "waypoint_index": 3,
+      "matchings_index": 0,
+      "alternatives_count": 0,
+      "location": [
+        13.420041,
+        52.502334
+      ],
+      "name": "Adalbertstraße"
+    },
+    {
+      "waypoint_index": 4,
+      "matchings_index": 0,
+      "alternatives_count": 1,
+      "location": [
+        13.420494,
+        52.502984
+      ],
+      "name": "Adalbertstraße"
+    }
+  ],
+  "matchings": [
+    {
+      "duration": 42.9,
+      "distance": 289.20000000000005,
+      "weight": 83.6,
+      "geometry": "w_m_Iqz{pAcBcAcC}AqBsAaCyA",
+      "confidence": 0.8259225426255177,
+      "weight_name": "routability",
+      "legs": [
         {
-            "confidence": 0.8820996720716853,
-            "distance": 291.6,
-            "duration": 49.5,
-            "geometry": "}_m_Iu{{pAEZwA{@aC}AsBsAaCyA",
-            "legs": [
+          "steps": [
+            {
+              "intersections": [
                 {
-                    "distance": 62.7,
-                    "duration": 14.5,
-                    "steps": [],
-                    "summary": ""
-                },
-                {
-                    "distance": 79.9,
-                    "duration": 13.5,
-                    "steps": [],
-                    "summary": ""
-                },
-                {
-                    "distance": 70.5,
-                    "duration": 10.2,
-                    "steps": [],
-                    "summary": ""
-                },
-                {
-                    "distance": 78.5,
-                    "duration": 11.3,
-                    "steps": [],
-                    "summary": ""
+                  "out": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    13.418807,
+                    52.500595
+                  ],
+                  "bearings": [
+                    23
+                  ]
                 }
-            ]
+              ],
+              "geometry": "w_m_Iqz{pAKGoAu@GE",
+              "duration": 8.5,
+              "distance": 60.3,
+              "name": "Adalbertstraße",
+              "weight": 17,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 23,
+                "location": [
+                  13.418807,
+                  52.500595
+                ],
+                "type": "depart",
+                "bearing_before": 0,
+                "modifier": "right",
+                "instruction": "Kör åt nordost på Adalbertstraße"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "in": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    13.419148,
+                    52.501096
+                  ],
+                  "bearings": [
+                    202
+                  ]
+                }
+              ],
+              "geometry": "{bm_Iu|{pA",
+              "duration": 0,
+              "distance": 0,
+              "name": "Adalbertstraße",
+              "weight": 0,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 0,
+                "location": [
+                  13.419148,
+                  52.501096
+                ],
+                "type": "arrive",
+                "bearing_before": 22,
+                "modifier": "left",
+                "instruction": "Du är framme vid din destination, till vänster"
+              }
+            }
+          ],
+          "weight": 17,
+          "distance": 60.3,
+          "summary": "Adalbertstraße",
+          "duration": 8.5
+        },
+        {
+          "steps": [
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    13.419148,
+                    52.501096
+                  ],
+                  "bearings": [
+                    22
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    13.419277,
+                    52.501287
+                  ],
+                  "bearings": [
+                    30,
+                    120,
+                    195,
+                    300
+                  ]
+                }
+              ],
+              "geometry": "{bm_Iu|{pAe@Ym@a@o@a@",
+              "duration": 13.2,
+              "distance": 80,
+              "name": "Adalbertstraße",
+              "weight": 24.5,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 22,
+                "location": [
+                  13.419148,
+                  52.501096
+                ],
+                "type": "depart",
+                "bearing_before": 0,
+                "modifier": "left",
+                "instruction": "Kör åt nordost på Adalbertstraße"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "in": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    13.41962,
+                    52.501755
+                  ],
+                  "bearings": [
+                    204
+                  ]
+                }
+              ],
+              "geometry": "_gm_Is_|pA",
+              "duration": 0,
+              "distance": 0,
+              "name": "Adalbertstraße",
+              "weight": 0,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 0,
+                "location": [
+                  13.41962,
+                  52.501755
+                ],
+                "type": "arrive",
+                "bearing_before": 24,
+                "modifier": "right",
+                "instruction": "Du är framme vid din destination, till höger"
+              }
+            }
+          ],
+          "weight": 24.5,
+          "distance": 80,
+          "summary": "Adalbertstraße",
+          "duration": 13.2
+        },
+        {
+          "steps": [
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    13.41962,
+                    52.501755
+                  ],
+                  "bearings": [
+                    24
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    13.419982,
+                    52.502249
+                  ],
+                  "bearings": [
+                    30,
+                    120,
+                    210,
+                    300
+                  ]
+                }
+              ],
+              "geometry": "_gm_Is_|pAaBgAOK",
+              "duration": 10.1,
+              "distance": 70.4,
+              "name": "Adalbertstraße",
+              "weight": 19.9,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 24,
+                "location": [
+                  13.41962,
+                  52.501755
+                ],
+                "type": "depart",
+                "bearing_before": 0,
+                "modifier": "right",
+                "instruction": "Kör åt nordost på Adalbertstraße"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "in": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    13.420041,
+                    52.502334
+                  ],
+                  "bearings": [
+                    203
+                  ]
+                }
+              ],
+              "geometry": "qjm_Igb|pA",
+              "duration": 0,
+              "distance": 0,
+              "name": "Adalbertstraße",
+              "weight": 0,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 0,
+                "location": [
+                  13.420041,
+                  52.502334
+                ],
+                "type": "arrive",
+                "bearing_before": 23,
+                "modifier": "left",
+                "instruction": "Du är framme vid din destination, till vänster"
+              }
+            }
+          ],
+          "weight": 19.9,
+          "distance": 70.4,
+          "summary": "Adalbertstraße",
+          "duration": 10.1
+        },
+        {
+          "steps": [
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    13.420041,
+                    52.502334
+                  ],
+                  "bearings": [
+                    23
+                  ]
+                }
+              ],
+              "geometry": "qjm_Igb|pAaCyA",
+              "duration": 11.1,
+              "distance": 78.5,
+              "name": "Adalbertstraße",
+              "weight": 22.2,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 23,
+                "location": [
+                  13.420041,
+                  52.502334
+                ],
+                "type": "depart",
+                "bearing_before": 0,
+                "modifier": "left",
+                "instruction": "Kör åt nordost på Adalbertstraße"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "in": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    13.420494,
+                    52.502984
+                  ],
+                  "bearings": [
+                    203
+                  ]
+                }
+              ],
+              "geometry": "snm_Iae|pA",
+              "duration": 0,
+              "distance": 0,
+              "name": "Adalbertstraße",
+              "weight": 0,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 0,
+                "location": [
+                  13.420494,
+                  52.502984
+                ],
+                "type": "arrive",
+                "bearing_before": 23,
+                "modifier": "right",
+                "instruction": "Du är framme vid din destination, till höger"
+              }
+            }
+          ],
+          "weight": 22.2,
+          "distance": 78.5,
+          "summary": "Adalbertstraße",
+          "duration": 11.1
         }
-    ],
-    "tracepoints": [
-        {
-            "location": [
-                13.418991,
-                52.500625
-            ],
-            "matchings_index": 0,
-            "name": "",
-            "waypoint_index": 0
-        },
-        {
-            "location": [
-                13.419147,
-                52.501095
-            ],
-            "matchings_index": 0,
-            "name": "Adalbertstraße",
-            "waypoint_index": 1
-        },
-        {
-            "location": [
-                13.419618,
-                52.501754
-            ],
-            "matchings_index": 0,
-            "name": "Adalbertstraße",
-            "waypoint_index": 2
-        },
-        {
-            "location": [
-                13.42004,
-                52.502333
-            ],
-            "matchings_index": 0,
-            "name": "Adalbertstraße",
-            "waypoint_index": 3
-        },
-        {
-            "location": [
-                13.420492,
-                52.502983
-            ],
-            "matchings_index": 0,
-            "name": "Adalbertstraße",
-            "waypoint_index": 4
-        }
-    ]
+      ]
+    }
+  ],
+  "code": "Ok"
 }

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/BaseTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/BaseTest.java
@@ -19,7 +19,7 @@ public class BaseTest {
   }
 
   protected String loadJsonFixture(String folder, String filename) throws IOException {
-    byte[] content = Files.readAllBytes(Paths.get("src/test/fixtures/" + folder + "/" + filename));
+    byte[] content = Files.readAllBytes(Paths.get(folder + filename));
     return new String(content, Charset.forName("utf-8"));
   }
 

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatchingTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatchingTest.java
@@ -55,7 +55,7 @@ public class MapboxMapMatchingTest extends BaseTest {
       @Override
       public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
         try {
-          String body = loadJsonFixture("", POLYLINE_FIXTURE);
+          String body = loadJsonFixture(POLYLINE_FIXTURE);
           return new MockResponse().setBody(body);
         } catch (IOException ioException) {
           throw new RuntimeException(ioException);

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatchingTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatchingTest.java
@@ -15,7 +15,6 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.ArrayList;
 import java.util.List;
 
 import okhttp3.HttpUrl;

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatchingTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/mapmatching/v5/MapboxMapMatchingTest.java
@@ -1,6 +1,8 @@
 package com.mapbox.services.api.mapmatching.v5;
 
+import com.mapbox.services.api.BaseTest;
 import com.mapbox.services.api.ServicesException;
+import com.mapbox.services.api.directions.v5.DirectionsCriteria;
 import com.mapbox.services.api.mapmatching.v5.models.MapMatchingResponse;
 import com.mapbox.services.api.mapmatching.v5.models.MapMatchingTracepoint;
 import com.mapbox.services.commons.models.Position;
@@ -12,10 +14,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.List;
 
 import okhttp3.HttpUrl;
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test the Mapbox Map Matching API
  */
-public class MapboxMapMatchingTest {
+public class MapboxMapMatchingTest extends BaseTest {
 
-  public static final String POLYLINE_FIXTURE = "src/test/fixtures/mapmatching_v5_polyline.json";
+  private static final String POLYLINE_FIXTURE = "src/test/fixtures/mapmatching_v5_polyline.json";
 
   private static final String ACCESS_TOKEN = "pk.XXX";
 
@@ -56,7 +56,7 @@ public class MapboxMapMatchingTest {
       @Override
       public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
         try {
-          String body = new String(Files.readAllBytes(Paths.get(POLYLINE_FIXTURE)), Charset.forName("utf-8"));
+          String body = loadJsonFixture("", POLYLINE_FIXTURE);
           return new MockResponse().setBody(body);
         } catch (IOException ioException) {
           throw new RuntimeException(ioException);
@@ -174,11 +174,11 @@ public class MapboxMapMatchingTest {
     assertNotNull(response.body());
     assertEquals(1, response.body().getMatchings().size());
 
-    assertEquals("property confidence", 0.8820996720716853,
+    assertEquals("property confidence", 0.8259225426255177,
       response.body().getMatchings().get(0).getConfidence(), 0);
-    assertEquals("property distance", 291.6,
+    assertEquals("property distance", 289.20000000000005,
       response.body().getMatchings().get(0).getDistance(), 0);
-    assertEquals("property duration", 49.5,
+    assertEquals("property duration", 42.9,
       response.body().getMatchings().get(0).getDuration(), 0);
 
     // Test indices
@@ -186,6 +186,39 @@ public class MapboxMapMatchingTest {
     assertEquals("property indices count", 5, tracepoints.size());
     assertEquals("matchings index", tracepoints.get(0).getMatchingsIndex(), 0);
     assertEquals("waypoint index", tracepoints.get(0).getWaypointIndex(), 0);
+    assertEquals("alternatives count", tracepoints.get(0).getAlternativesCount(), 0);
+  }
+
+  @Test
+  public void setLanguage_urlDoesContainLanguageParam() throws IOException {
+    MapboxMapMatching client = new MapboxMapMatching.Builder()
+      .setAccessToken("pk.XXX")
+      .setProfile(DirectionsCriteria.PROFILE_DRIVING)
+      .setBaseUrl(mockUrl.toString())
+      .setCoordinates(coordinates)
+      .setLanguage("sv")
+      .build();
+
+    String callUrl = client.executeCall().raw().request().url().toString();
+    assertTrue(
+      callUrl.contains("language=sv")
+    );
+  }
+
+  @Test
+  public void setLanguage_doesReturnCorrectTurnInstructionLanguage() throws IOException {
+    MapboxMapMatching client = new MapboxMapMatching.Builder()
+      .setAccessToken("pk.XXX")
+      .setCoordinates(coordinates)
+      .setProfile(DirectionsCriteria.PROFILE_DRIVING)
+      .setBaseUrl(mockUrl.toString())
+      .setSteps(true)
+      .setLanguage("sv")
+      .build();
+
+    Response<MapMatchingResponse> response = client.executeCall();
+    assertTrue(response.body().getMatchings().get(0).getLegs().get(0)
+      .getSteps().get(0).getManeuver().getInstruction().contains("Kör åt nordost på Adalbertstraße"));
   }
 
 }


### PR DESCRIPTION
This PR fixes up the map matching api:
- Adds `alternatives_count` to MapMatchingTraceoint class
- Adds support for the language param