### PR TITLE
added some new Proguard rules

### DIFF
--- a/mapbox/app/proguard-rules.pro
+++ b/mapbox/app/proguard-rules.pro
@@ -1,1 +1,2 @@
 -dontwarn com.squareup.okhttp.**
+-dontwarn okio.**

--- a/mapbox/libandroid-services/proguard-rules.pro
+++ b/mapbox/libandroid-services/proguard-rules.pro
@@ -33,6 +33,8 @@
 -keep class com.mapbox.services.api.distance.v1.models.** { *; }
 -keep class com.mapbox.services.api.geocoding.v5.models.** { *; }
 -keep class com.mapbox.services.api.mapmatching.v5.models.** { *; }
+-keep class com.mapbox.services.api.optimizedtrips.v1.models.** { *; }
+-keep class com.mapbox.services.api.directionsmatrix.v1.models.** { *; }
 -keep class com.mapbox.services.commons.geojson.** { *; }
 
 -dontwarn javax.annotation.**


### PR DESCRIPTION
Rules to enforce keeping model classes for the new APIs. I ran into one issue but seems to be related to the Map SDK and its Proguard rules (opened a ticket https://github.com/mapbox/mapbox-gl-native/issues/9569)