### PR TITLE
MapboxTelemetry String Log tag

### DIFF
--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -50,7 +50,7 @@ import okhttp3.internal.Util;
  */
 public class MapboxTelemetry implements Callback, LocationEngineListener {
 
-  private static final String LOG_TAG = MapboxTelemetry.class.getSimpleName();
+  private static final String LOG_TAG = "MapboxTelemetry";
 
   private static MapboxTelemetry instance;
 


### PR DESCRIPTION
A user reported seeing time spend on reflection when profiling:
> `MapboxTelemetry.class.getSimpleName();`

Replacing with a fixed String solves this.