### PR TITLE
Introduce setDebugLoggingEnabled API

### DIFF
--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -74,6 +74,7 @@ public class MapboxTelemetry implements Callback, LocationEngineListener {
   protected CopyOnWriteArrayList<TelemetryListener> telemetryListeners;
   private Hashtable<String, Object> customTurnstileEvent = null;
   private int sessionIdRotationTime = TelemetryConstants.DEFAULT_SESSION_ID_ROTATION_HOURS;
+  private boolean debugLoggingEnabled = false;
 
   /**
    * Private constructor for configuring the single instance per app.
@@ -165,6 +166,25 @@ public class MapboxTelemetry implements Callback, LocationEngineListener {
   @Experimental
   public void setSessionIdRotationTime(@IntRange(from = 1, to = 24) int sessionIdRotationTime) {
     this.sessionIdRotationTime = sessionIdRotationTime; // in hours
+  }
+
+  // For internal use only
+  // This is an experimental API. Experimental APIs are quickly evolving and
+  // might change or be removed in minor versions.
+  @Experimental
+  public boolean isDebugLoggingEnabled() {
+    return debugLoggingEnabled;
+  }
+
+  // For internal use only
+  // This is an experimental API. Experimental APIs are quickly evolving and
+  // might change or be removed in minor versions.
+  @Experimental
+  public void setDebugLoggingEnabled(boolean debugLoggingEnabled) {
+    this.debugLoggingEnabled = debugLoggingEnabled;
+    if (this.client != null) {
+      this.client.setDebugLoggingEnabled(debugLoggingEnabled);
+    }
   }
 
   /**

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/http/TelemetryClient.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/http/TelemetryClient.java
@@ -227,7 +227,7 @@ public class TelemetryClient {
     RequestBody body = RequestBody.create(JSON, payload);
     String url = getEventsEndpoint() + "/events/v2?access_token=" + getAccessToken();
 
-    // Extra debug in staging mode
+    // Extra debug if manually enabled or if in staging mode
     if (isDebugLoggingEnabled() || isStagingEnvironment()) {
       Log.d(LOG_TAG, String.format("Sending POST to %s with %d event(s) (user agent: %s) with payload: %s",
         url, events.size(), getUserAgent(), payload));

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/http/TelemetryClient.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/http/TelemetryClient.java
@@ -37,6 +37,7 @@ public class TelemetryClient {
   private String eventsCnEndpoint = MapboxEvent.MAPBOX_EVENTS_CN_BASE_URL;
   private boolean stagingEnvironment = false;
   private boolean enableCnEndpoint = false;
+  private boolean debugLoggingEnabled = false;
   private OkHttpClient client;
 
   public TelemetryClient(String accessToken) {
@@ -86,6 +87,14 @@ public class TelemetryClient {
 
   public void setEnableCnEndpoint() {
     this.enableCnEndpoint = true;
+  }
+
+  public boolean isDebugLoggingEnabled() {
+    return debugLoggingEnabled;
+  }
+
+  public void setDebugLoggingEnabled(boolean debugLoggingEnabled) {
+    this.debugLoggingEnabled = debugLoggingEnabled;
   }
 
   /**
@@ -219,7 +228,7 @@ public class TelemetryClient {
     String url = getEventsEndpoint() + "/events/v2?access_token=" + getAccessToken();
 
     // Extra debug in staging mode
-    if (isStagingEnvironment()) {
+    if (isDebugLoggingEnabled()) {
       Log.d(LOG_TAG, String.format("Sending POST to %s with %d event(s) (user agent: %s) with payload: %s",
         url, events.size(), getUserAgent(), payload));
     }

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/http/TelemetryClient.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/http/TelemetryClient.java
@@ -228,7 +228,7 @@ public class TelemetryClient {
     String url = getEventsEndpoint() + "/events/v2?access_token=" + getAccessToken();
 
     // Extra debug in staging mode
-    if (isDebugLoggingEnabled()) {
+    if (isDebugLoggingEnabled() || isStagingEnvironment()) {
       Log.d(LOG_TAG, String.format("Sending POST to %s with %d event(s) (user agent: %s) with payload: %s",
         url, events.size(), getUserAgent(), payload));
     }


### PR DESCRIPTION
This API lets us manually control the verbosity of HTTP requests.
