### PR TITLE
Mark style URL as untranslatable

### DIFF
--- a/mapbox/app/src/main/res/values/strings.xml
+++ b/mapbox/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_name">Mapbox Android Services</string>
     <string name="action_settings">Settings</string>
 
-    <string name="default_style">mapbox://styles/mapbox/streets-v9</string>
+    <string name="default_style" translatable="false">mapbox://styles/mapbox/streets-v9</string>
 
     <string name="category">category</string>
     <string name="category_directions">Directions</string>


### PR DESCRIPTION
Marked the `default_style` string as being untranslatable so translators on Transifex don’t feel pressured to translate it to some other value like `mapbox://estilos/mapbox/caminos-v9`.

/cc @cammace @langsmith