### PR TITLE
Unclear setup instruction

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,4 +25,4 @@ Using the MAS testapp will require a valid [Mapbox access token](https://www.map
 
 ## 3: Begin developing
 
-We recommend using [Android Studio](https://developer.android.com/studio/index.html) to work on the code base.
+We recommend using [Android Studio](https://developer.android.com/studio/index.html) to work on the code base. Please import `mapbox-java/mapbox` as the project root folder.

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ Check the [Android Test App](https://github.com/mapbox/mapbox-java/tree/master/m
 
 ## Contributing
 
-All libraries are contained within the `mapbox` folder. You can import the project using Android Studio or IntelliJ IDEA. Read [the contribution guide](https://github.com/mapbox/mapbox-java/blob/master/CONTRIBUTING.md) to get setup properly.
+All libraries are contained within the `mapbox` folder. Please import `mapbox-java/mapbox` as the project root folder using Android Studio or IntelliJ IDEA. Read [the contribution guide](https://github.com/mapbox/mapbox-java/blob/master/CONTRIBUTING.md) to get setup properly.


### PR DESCRIPTION
In order to fix https://github.com/mapbox/mapbox-java/issues/559, I edited the content of INSTALL.md and README.md to clarify that mapbox-java/mapbox folder should be imported as a root project folder in Android Studio

cc: @zugaldia 