### PR TITLE
Fix arrival timestamp format

### DIFF
--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/navigation/MapboxNavigationEvent.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/navigation/MapboxNavigationEvent.java
@@ -226,7 +226,7 @@ public class MapboxNavigationEvent {
     event.put(KEY_DISTANCE_COMPLETED, distanceCompleted);
     event.put(KEY_DISTANCE_REMAINING, distanceRemaining);
     event.put(KEY_DURATION_REMAINING, durationRemaining);
-    event.put(KEY_ARRIVAL_TIMESTAMP, arrivalTimestamp);
+    event.put(KEY_ARRIVAL_TIMESTAMP, TelemetryUtils.generateCreateDateFormatted(arrivalTimestamp));
     return event;
   }
 


### PR DESCRIPTION
- Fixes `arrivalTimestamp` format to use ISO8601 format like the rest of the dates

👀 @cammace @ericrwolfe @zugaldia 
