### PR TITLE
Fixed source and destination formatting from DirectionsMatrix request builder

### DIFF
--- a/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directionsmatrix/v1/MapboxDirectionsMatrix.java
+++ b/mapbox/libjava-services/src/main/java/com/mapbox/services/api/directionsmatrix/v1/MapboxDirectionsMatrix.java
@@ -299,6 +299,11 @@ public class MapboxDirectionsMatrix extends MapboxService<DirectionsMatrixRespon
       }
 
       String[] destinationsFormatted = new String[destinations.length];
+
+      for (int i = 0; i < destinations.length; i++) {
+        destinationsFormatted[i] = String.valueOf(destinations[i]);
+      }
+
       return TextUtils.join(";", destinationsFormatted);
     }
 
@@ -312,6 +317,11 @@ public class MapboxDirectionsMatrix extends MapboxService<DirectionsMatrixRespon
       }
 
       String[] sourcesFormatted = new String[sources.length];
+
+      for (int i = 0; i < sources.length; i++) {
+        sourcesFormatted[i] = String.valueOf(sources[i]);
+      }
+
       return TextUtils.join(";", sourcesFormatted);
     }
 

--- a/mapbox/libjava-services/src/test/java/com/mapbox/services/api/directionsmatrix/v1/MapboxDirectionsMatrixTest.java
+++ b/mapbox/libjava-services/src/test/java/com/mapbox/services/api/directionsmatrix/v1/MapboxDirectionsMatrixTest.java
@@ -184,4 +184,26 @@ public class MapboxDirectionsMatrixTest extends BaseTest {
     assertEquals(response.body().getDurations()[0][1], 1888.3, DELTA);
     assertEquals(response.body().getDestinations().get(0).getName(), "McAllister Street");
   }
+
+  @Test
+  public void testDestinationsAreFormatted() {
+    MapboxDirectionsMatrix.Builder builder = new MapboxDirectionsMatrix.Builder()
+      .setDestinations(1, 2);
+
+    String formattedDestinations = builder.getDestinations();
+
+    assertNotNull(formattedDestinations);
+    assertEquals(formattedDestinations, "1;2");
+  }
+
+  @Test
+  public void testSourcesAreFormatted() {
+    MapboxDirectionsMatrix.Builder builder = new MapboxDirectionsMatrix.Builder()
+      .setSources(1, 2);
+
+    String formattedSources = builder.getSources();
+
+    assertNotNull(formattedSources);
+    assertEquals(formattedSources, "1;2");
+  }
 }


### PR DESCRIPTION
### Description

Fixed getDestinations and getSources return values from MapboxDirectionsMatrix.Builder.

Fixes #579.

### Check List

- [x] Javadoc added to any methods included
- [x] Added any test to ensure the fix works properly.
