### PR TITLE
Step Metadata is serialized improperly

### DIFF
--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/navigation/MapboxNavigationEvent.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/navigation/MapboxNavigationEvent.java
@@ -296,7 +296,7 @@ public class MapboxNavigationEvent {
     }
   }
 
-  private static Hashtable<String, Object> getStepMetadata(
+  private static JSONObject getStepMetadata(
     String upcomingInstruction, String upcomingType, String upcomingModifier, String upcomingName,
     String previousInstruction, String previousType, String previousModifier, String previousName,
     int distance, int duration, int distanceRemaining, int durationRemaining
@@ -314,6 +314,8 @@ public class MapboxNavigationEvent {
     event.put(KEY_DURATION, duration);
     event.put(KEY_DISTANCE_REMAINING, distanceRemaining);
     event.put(KEY_DURATION_REMAINING, durationRemaining);
-    return event;
+
+    JSONObject jsonObject = new JSONObject(event);
+    return jsonObject;
   }
 }


### PR DESCRIPTION
Closes #585

Current iteration returns a string instead of a json object. 