### PR TITLE
Make lost dependency provided

### DIFF
--- a/mapbox/app/build.gradle
+++ b/mapbox/app/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     compile rootProject.ext.dep.gmsLocation
 
     // LOST
-    compile rootProject.ext.dep.lost
+    compile "com.mapzen.android:lost:3.0.3"
 
     // Picasso (Static Image)
     compile rootProject.ext.dep.picasso

--- a/mapbox/dependencies.gradle
+++ b/mapbox/dependencies.gradle
@@ -36,7 +36,7 @@ ext {
             okhttp3Mockwebserver : 'com.squareup.okhttp3:mockwebserver:3.6.0',
 
             // lost
-            lost                 : 'com.mapzen.android:lost:3.0.3',
+            lost                 : 'com.mapzen.android:lost:1.1.1',
 
             // play services
             gmsLocation          : 'com.google.android.gms:play-services-location:10.2.0',

--- a/mapbox/libandroid-services/build.gradle
+++ b/mapbox/libandroid-services/build.gradle
@@ -43,7 +43,9 @@ dependencies {
     compile rootProject.ext.dep.timber
 
     // LOST
-    provided rootProject.ext.dep.lost
+    compile(rootProject.ext.dep.lost) {
+        exclude group: 'com.google.guava'
+    }
 
     // Testing
     testCompile rootProject.ext.dep.mockito

--- a/mapbox/libandroid-services/build.gradle
+++ b/mapbox/libandroid-services/build.gradle
@@ -43,9 +43,7 @@ dependencies {
     compile rootProject.ext.dep.timber
 
     // LOST
-    compile(rootProject.ext.dep.lost) {
-      exclude group: 'com.google.guava'
-    }
+    provided rootProject.ext.dep.lost
 
     // Testing
     testCompile rootProject.ext.dep.mockito

--- a/mapbox/libandroid-services/src/main/java/com/mapbox/services/android/location/LostLocationEngine.java
+++ b/mapbox/libandroid-services/src/main/java/com/mapbox/services/android/location/LostLocationEngine.java
@@ -3,7 +3,6 @@ package com.mapbox.services.android.location;
 import android.content.Context;
 import android.location.Location;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngineListener;
@@ -17,30 +16,20 @@ import java.lang.ref.WeakReference;
 
 /**
  * Sample LocationEngine using the Open Source Lost library
- *
- * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
  */
-@Deprecated
-public class LostLocationEngine extends LocationEngine implements
-  LostApiClient.ConnectionCallbacks, LocationListener {
-
-  private static final String LOG_TAG = LostLocationEngine.class.getSimpleName();
+public class LostLocationEngine extends LocationEngine implements LocationListener {
 
   private static LocationEngine instance;
 
   private WeakReference<Context> context;
   private LostApiClient lostApiClient;
 
-  @Deprecated
   public LostLocationEngine(Context context) {
     super();
     this.context = new WeakReference<>(context);
-    lostApiClient = new LostApiClient.Builder(this.context.get())
-      .addConnectionCallbacks(this)
-      .build();
+    lostApiClient = new LostApiClient.Builder(this.context.get()).build();
   }
 
-  @Deprecated
   public static synchronized LocationEngine getLocationEngine(Context context) {
     if (instance == null) {
       instance = new LostLocationEngine(context.getApplicationContext());
@@ -52,26 +41,25 @@ public class LostLocationEngine extends LocationEngine implements
   /**
    * Activate the location engine which will connect whichever location provider you are using. You'll need to call
    * this before requesting user location updates using {@link LocationEngine#requestLocationUpdates()}.
-   *
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
    */
-  @Deprecated
   @Override
   public void activate() {
-    connect();
+    if (!lostApiClient.isConnected()) {
+      lostApiClient.connect();
+    }
+    for (LocationEngineListener listener : locationListeners) {
+      listener.onConnected();
+    }
   }
 
   /**
    * Disconnect the location engine which is useful when you no longer need location updates or requesting the users
    * {@link LocationEngine#getLastLocation()}. Before deactivating, you'll need to stop request user location updates
    * using {@link LocationEngine#removeLocationUpdates()}.
-   *
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
    */
-  @Deprecated
   @Override
   public void deactivate() {
-    if (lostApiClient != null && lostApiClient.isConnected()) {
+    if (lostApiClient.isConnected()) {
       lostApiClient.disconnect();
     }
   }
@@ -81,61 +69,30 @@ public class LostLocationEngine extends LocationEngine implements
    * the rare case when you'd like to know if your location engine is connected or not.
    *
    * @return boolean true if the location engine has been activated/connected, else false.
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
    */
-  @Deprecated
   @Override
   public boolean isConnected() {
     return lostApiClient.isConnected();
   }
 
   /**
-   * Invoked when the location provider has connected.
-   *
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
-   */
-  @Deprecated
-  @Override
-  public void onConnected() {
-    for (LocationEngineListener listener : locationListeners) {
-      listener.onConnected();
-    }
-  }
-
-  /**
-   * Invoked when the location provider connection has been suspended.
-   *
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
-   */
-  @Deprecated
-  @Override
-  public void onConnectionSuspended() {
-    Log.d(LOG_TAG, "Connection suspended");
-  }
-
-  /**
-   * Returns the Last known location if the location provider is connected.
+   * Returns the Last known location if the location provider is connected and location permissions are granted.
    *
    * @return the last known location
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
    */
-  @Deprecated
   @Override
   @Nullable
   public Location getLastLocation() {
     if (lostApiClient.isConnected()) {
       //noinspection MissingPermission
-      return LocationServices.FusedLocationApi.getLastLocation(lostApiClient);
+      return LocationServices.FusedLocationApi.getLastLocation();
     }
     return null;
   }
 
   /**
    * Request location updates to the location provider.
-   *
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
    */
-  @Deprecated
   @Override
   public void requestLocationUpdates() {
     LocationRequest request = LocationRequest.create();
@@ -150,6 +107,7 @@ public class LostLocationEngine extends LocationEngine implements
       request.setSmallestDisplacement(smallestDisplacement);
     }
 
+    // Priority matching is straightforward
     if (priority == LocationEnginePriority.NO_POWER) {
       request.setPriority(LocationRequest.PRIORITY_NO_POWER);
     } else if (priority == LocationEnginePriority.LOW_POWER) {
@@ -162,50 +120,35 @@ public class LostLocationEngine extends LocationEngine implements
 
     if (lostApiClient.isConnected()) {
       //noinspection MissingPermission
-      LocationServices.FusedLocationApi.requestLocationUpdates(lostApiClient, request, this);
+      LocationServices.FusedLocationApi.requestLocationUpdates(request, this);
     }
   }
 
-  /**
-   * Dismiss ongoing location update to the location provider.
-   *
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
-   */
-  @Deprecated
-  @Override
-  public void removeLocationUpdates() {
-    if (lostApiClient.isConnected()) {
-      LocationServices.FusedLocationApi.removeLocationUpdates(lostApiClient, this);
-    }
-  }
-
-  @Deprecated
   @Override
   public Type obtainType() {
     return Type.LOST;
   }
 
   /**
+   * Dismiss ongoing location update to the location provider.
+   */
+  @Override
+  public void removeLocationUpdates() {
+    if (lostApiClient.isConnected()) {
+      LocationServices.FusedLocationApi.removeLocationUpdates(this);
+    }
+  }
+
+  /**
    * Invoked when the Location has changed.
    *
    * @param location the new location
-   * @deprecated Use {@link com.mapbox.services.android.telemetry.location.LostLocationEngine} instead
    */
   @Deprecated
   @Override
   public void onLocationChanged(Location location) {
     for (LocationEngineListener listener : locationListeners) {
       listener.onLocationChanged(location);
-    }
-  }
-
-  private void connect() {
-    if (lostApiClient != null) {
-      if (lostApiClient.isConnected()) {
-        onConnected();
-      } else {
-        lostApiClient.connect();
-      }
     }
   }
 }

--- a/mapbox/libandroid-telemetry/build.gradle
+++ b/mapbox/libandroid-telemetry/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     provided rootProject.ext.dep.gmsLocation
 
     // LOST
-    provided rootProject.ext.dep.lost
+    provided "com.mapzen.android:lost:3.0.3"
 
     // Testing
     testCompile rootProject.ext.dep.junit


### PR DESCRIPTION
- Makes lost dependency `provided`
- Per Lost 3.x excluding `guava` is not needed anymore

👀 @cammace @zugaldia 
