### PR TITLE
NPE for BatteryStatus

### DIFF
--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -367,12 +367,13 @@ public class MapboxTelemetry implements Callback, LocationEngineListener {
    * @return true if plugged in, false if not
    */
   private boolean isPluggedIn() {
-    int chargePlug = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
-    if (chargePlug == BatteryManager.BATTERY_PLUGGED_USB
-      || chargePlug == BatteryManager.BATTERY_PLUGGED_AC) {
-      return true;
+    if (batteryStatus != null) {
+      int chargePlug = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
+      if (chargePlug == BatteryManager.BATTERY_PLUGGED_USB
+        || chargePlug == BatteryManager.BATTERY_PLUGGED_AC) {
+        return true;
+      }
     }
-
     return false;
   }
 


### PR DESCRIPTION
### Description
Issue found when testing on YotaPhone. BatteryStatus can be null and throws a Null Pointer Exception.

cc @lilykaiser 