### PR TITLE
Add telem audio type support

### DIFF
--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/MapboxTelemetry.java
@@ -636,6 +636,7 @@ public class MapboxTelemetry implements Callback, LocationEngineListener {
   private void addGeneralNavigationMetadataTo(Hashtable<String, Object> eventWithAttributes) {
     eventWithAttributes.put(MapboxNavigationEvent.KEY_DEVICE, Build.MODEL);
     eventWithAttributes.put(MapboxNavigationEvent.KEY_VOLUME_LEVEL, TelemetryUtils.getVolumeLevel(context));
+    eventWithAttributes.put(MapboxNavigationEvent.KEY_AUDIO_TYPE, TelemetryUtils.obtainAudioType(context));
     eventWithAttributes.put(MapboxNavigationEvent.KEY_SCREEN_BRIGHTNESS, TelemetryUtils.getScreenBrightness(context));
     eventWithAttributes.put(MapboxNavigationEvent.KEY_APPLICATION_STATE, TelemetryUtils.getApplicationState(context));
     eventWithAttributes.put(MapboxNavigationEvent.KEY_BATTERY_PLUGGED_IN, isPluggedIn());

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/navigation/MapboxNavigationEvent.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/navigation/MapboxNavigationEvent.java
@@ -300,8 +300,6 @@ public class MapboxNavigationEvent {
     event.put(KEY_ORIGINAL_GEOMETRY, originalGeometry);
     event.put(KEY_ORIGINAL_ESTIMATED_DISTANCE, originalEstimatedDistance);
     event.put(KEY_ORIGINAL_ESTIMATED_DURATION, originalEstimatedDuration);
-    // audioType may be "null"
-    addPairIntoEventIfNeeded(event, KEY_AUDIO_TYPE, audioType);
     return event;
   }
 
@@ -317,6 +315,8 @@ public class MapboxNavigationEvent {
     // See NavigationMetricsWrapper.java in https://github.com/mapbox/mapbox-navigation-android
     if (value == null || value.equalsIgnoreCase("null")) {
       event.put(key, JSONObject.NULL);
+    } else {
+      event.put(key, value);
     }
   }
 

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/AudioTypeChain.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/AudioTypeChain.java
@@ -1,0 +1,17 @@
+package com.mapbox.services.android.telemetry.utils;
+
+
+class AudioTypeChain {
+
+  AudioTypeResolver setup() {
+    AudioTypeResolver unknown = new UnknownAudioType();
+    AudioTypeResolver headphones = new HeadphonesAudioType();
+    headphones.nextChain(unknown);
+    AudioTypeResolver bluetooth = new BluetoothAudioType();
+    bluetooth.nextChain(headphones);
+    AudioTypeResolver rootOfTheChain = new SpeakerAudioType();
+    rootOfTheChain.nextChain(bluetooth);
+
+    return rootOfTheChain;
+  }
+}

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/AudioTypeChain.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/AudioTypeChain.java
@@ -5,12 +5,12 @@ class AudioTypeChain {
 
   AudioTypeResolver setup() {
     AudioTypeResolver unknown = new UnknownAudioType();
+    AudioTypeResolver speaker = new SpeakerAudioType();
+    speaker.nextChain(unknown);
     AudioTypeResolver headphones = new HeadphonesAudioType();
-    headphones.nextChain(unknown);
-    AudioTypeResolver bluetooth = new BluetoothAudioType();
-    bluetooth.nextChain(headphones);
-    AudioTypeResolver rootOfTheChain = new SpeakerAudioType();
-    rootOfTheChain.nextChain(bluetooth);
+    headphones.nextChain(speaker);
+    AudioTypeResolver rootOfTheChain = new BluetoothAudioType();
+    rootOfTheChain.nextChain(headphones);
 
     return rootOfTheChain;
   }

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/AudioTypeResolver.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/AudioTypeResolver.java
@@ -1,0 +1,10 @@
+package com.mapbox.services.android.telemetry.utils;
+
+
+import android.content.Context;
+
+interface AudioTypeResolver {
+  void nextChain(AudioTypeResolver chain);
+
+  String obtainAudioType(Context context);
+}

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/BluetoothAudioType.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/BluetoothAudioType.java
@@ -1,0 +1,25 @@
+package com.mapbox.services.android.telemetry.utils;
+
+
+import android.content.Context;
+import android.media.AudioManager;
+
+class BluetoothAudioType implements AudioTypeResolver {
+  private static final String BLUETOOTH = "bluetooth";
+  private AudioTypeResolver chain;
+
+  @Override
+  public void nextChain(AudioTypeResolver chain) {
+    this.chain = chain;
+  }
+
+  @Override
+  public String obtainAudioType(Context context) {
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    if (audioManager.isBluetoothScoOn()) {
+      return BLUETOOTH;
+    } else {
+      return chain.obtainAudioType(context);
+    }
+  }
+}

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/HeadphonesAudioType.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/HeadphonesAudioType.java
@@ -1,0 +1,25 @@
+package com.mapbox.services.android.telemetry.utils;
+
+
+import android.content.Context;
+import android.media.AudioManager;
+
+class HeadphonesAudioType implements AudioTypeResolver {
+  private static final String HEADPHONES = "headphones";
+  private AudioTypeResolver chain;
+
+  @Override
+  public void nextChain(AudioTypeResolver chain) {
+    this.chain = chain;
+  }
+
+  @Override
+  public String obtainAudioType(Context context) {
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    if (audioManager.isWiredHeadsetOn()) {
+      return HEADPHONES;
+    } else {
+      return chain.obtainAudioType(context);
+    }
+  }
+}

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/SpeakerAudioType.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/SpeakerAudioType.java
@@ -1,0 +1,25 @@
+package com.mapbox.services.android.telemetry.utils;
+
+
+import android.content.Context;
+import android.media.AudioManager;
+
+class SpeakerAudioType implements AudioTypeResolver {
+  private static final String SPEAKER = "speaker";
+  private AudioTypeResolver chain;
+
+  @Override
+  public void nextChain(AudioTypeResolver chain) {
+    this.chain = chain;
+  }
+
+  @Override
+  public String obtainAudioType(Context context) {
+    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    if (audioManager.isSpeakerphoneOn()) {
+      return SPEAKER;
+    } else {
+      return chain.obtainAudioType(context);
+    }
+  }
+}

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/TelemetryUtils.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/TelemetryUtils.java
@@ -182,8 +182,8 @@ public class TelemetryUtils {
     int screenBrightness;
     try {
       screenBrightness = android.provider.Settings.System.getInt(
-          context.getContentResolver(),
-          android.provider.Settings.System.SCREEN_BRIGHTNESS);
+        context.getContentResolver(),
+        android.provider.Settings.System.SCREEN_BRIGHTNESS);
 
       // Android returns values between 0 and 255, here we normalize to 0-100.
       screenBrightness = (int) Math.floor(100.0 * screenBrightness / 255.0);
@@ -200,7 +200,7 @@ public class TelemetryUtils {
   public static int getVolumeLevel(Context context) {
     AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
     return (int) Math.floor(100.0 * audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
-        / audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC));
+      / audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC));
   }
 
   /**
@@ -208,5 +208,15 @@ public class TelemetryUtils {
    */
   public static String buildUUID() {
     return UUID.randomUUID().toString();
+  }
+
+  /**
+   * Returns the current audio type
+   */
+  public static String obtainAudioType(Context context) {
+    AudioTypeChain audioTypeChain = new AudioTypeChain();
+    AudioTypeResolver setupChain = audioTypeChain.setup();
+
+    return setupChain.obtainAudioType(context);
   }
 }

--- a/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/UnknownAudioType.java
+++ b/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/utils/UnknownAudioType.java
@@ -1,0 +1,17 @@
+package com.mapbox.services.android.telemetry.utils;
+
+
+import android.content.Context;
+
+class UnknownAudioType implements AudioTypeResolver {
+  private static final String UNKNOWN = "unknown";
+
+  @Override
+  public void nextChain(AudioTypeResolver chain) {
+  }
+
+  @Override
+  public String obtainAudioType(Context context) {
+    return UNKNOWN;
+  }
+}


### PR DESCRIPTION
- Adds telem `audioType` support using a chain of responsibility:

`speaker` > `bluetooth` > `headphones` > `unknown`

👀 @zugaldia @cammace @electrostat @ericrwolfe 
