### PR TITLE
Bump OkHttp and retrofit versions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,8 +6,8 @@ ext {
             junit            : '4.12',
             supportLibVersion: '26.1.0',
             gson             : '2.8.0',
-            retrofit         : '2.2.0',
-            okhttp3          : '3.9.0',
+            retrofit         : '2.3.0',
+            okhttp3          : '3.9.1',
             mockito          : '2.7.13',
             hamcrestJunit    : '2.0.0.0',
             errorprone       : '2.0.21'


### PR DESCRIPTION
We recently had some [issues](https://github.com/mapbox/mapbox-gl-native/pull/10366) with OkHttp in gl-native (see [changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md) of patches included for 3.9.1).
Since these fixes are significant, I went ahead and created this PR. I added this to 3.0.0 for now, but feel free to remove or alter.