### PR TITLE
bump ci image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: mbgl/ci@sha256:c34e221294d81da80918d3e9a9df5de795b067e88f86d7c9a5e262763332536e
+      - image: mbgl/ci:20171122150543-android-ndk-r16
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
@@ -56,7 +56,7 @@ jobs:
       only:
       - master
     docker:
-      - image: mbgl/ci@sha256:c34e221294d81da80918d3e9a9df5de795b067e88f86d7c9a5e262763332536e
+      - image: mbgl/ci:20171122150543-android-ndk-r16
     working_directory: ~/code
     environment:
     environment:


### PR DESCRIPTION
PR bumping the used CI docker images to mbgl/ci:20171122150543-android-ndk-r16.

