### PR TITLE
Adds annotations and test for polylineUtils

### DIFF
--- a/services-geojson/src/main/java/com/mapbox/geojson/utils/PolylineUtils.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/utils/PolylineUtils.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson.utils;
 
+import android.support.annotation.NonNull;
 import com.mapbox.geojson.Point;
 
 import java.util.ArrayList;
@@ -34,7 +35,8 @@ public final class PolylineUtils {
    * @see <a href="https://github.com/googlemaps/android-maps-utils/blob/master/library/src/com/google/maps/android/PolyUtil.java">Part of algorithm came from this source.</a>
    * @since 1.0.0
    */
-  public static List<Point> decode(final String encodedPath, int precision) {
+  @NonNull
+  public static List<Point> decode(@NonNull final String encodedPath, int precision) {
     int len = encodedPath.length();
 
     // OSRM uses precision=6, the default Polyline spec divides by 1E5, capping at precision=5
@@ -83,7 +85,8 @@ public final class PolylineUtils {
    * @return a String representing a path string
    * @since 1.0.0
    */
-  public static String encode(final List<Point> path, int precision) {
+  @NonNull
+  public static String encode(@NonNull final List<Point> path, int precision) {
     long lastLat = 0;
     long lastLng = 0;
 
@@ -131,7 +134,8 @@ public final class PolylineUtils {
    * @see <a href="http://mourner.github.io/simplify-js/">JavaScript implementation</a>
    * @since 1.2.0
    */
-  public static List<Point> simplify(List<Point> points) {
+  @NonNull
+  public static List<Point> simplify(@NonNull List<Point> points) {
     return simplify(points, SIMPLIFY_DEFAULT_TOLERANCE, SIMPLIFY_DEFAULT_HIGHEST_QUALITY);
   }
 
@@ -146,7 +150,8 @@ public final class PolylineUtils {
    * @see <a href="http://mourner.github.io/simplify-js/">JavaScript implementation</a>
    * @since 1.2.0
    */
-  public static List<Point> simplify(List<Point> points, double tolerance) {
+  @NonNull
+  public static List<Point> simplify(@NonNull List<Point> points, double tolerance) {
     return simplify(points, tolerance, SIMPLIFY_DEFAULT_HIGHEST_QUALITY);
   }
 
@@ -161,7 +166,8 @@ public final class PolylineUtils {
    * @see <a href="http://mourner.github.io/simplify-js/">JavaScript implementation</a>
    * @since 1.2.0
    */
-  public static List<Point> simplify(List<Point> points, boolean highestQuality) {
+  @NonNull
+  public static List<Point> simplify(@NonNull List<Point> points, boolean highestQuality) {
     return simplify(points, SIMPLIFY_DEFAULT_TOLERANCE, highestQuality);
   }
 
@@ -178,7 +184,9 @@ public final class PolylineUtils {
    * @see <a href="http://mourner.github.io/simplify-js/">JavaScript implementation</a>
    * @since 1.2.0
    */
-  public static List<Point> simplify(List<Point> points, double tolerance, boolean highestQuality) {
+  @NonNull
+  public static List<Point> simplify(@NonNull List<Point> points, double tolerance,
+                                     boolean highestQuality) {
     if (points.size() <= 2) {
       return points;
     }

--- a/services-geojson/src/test/java/com/mapbox/geojson/utils/PolylineUtilsTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/utils/PolylineUtilsTest.java
@@ -1,12 +1,17 @@
 package com.mapbox.geojson.utils;
 
-import com.mapbox.core.constants.Constants;
-import com.mapbox.core.TestUtils;
-import com.mapbox.geojson.Point;
+import static com.mapbox.geojson.utils.PolylineUtils.decode;
+import static com.mapbox.geojson.utils.PolylineUtils.encode;
+import static com.mapbox.geojson.utils.PolylineUtils.simplify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import org.junit.Assert;
+import com.mapbox.core.TestUtils;
+import com.mapbox.core.constants.Constants;
+import com.mapbox.geojson.Point;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class PolylineUtilsTest extends TestUtils {
@@ -15,10 +20,10 @@ public class PolylineUtilsTest extends TestUtils {
 
   @Test
   public void testDecodePath() {
-    List<Point> latLngs = PolylineUtils.decode(TEST_LINE, Constants.PRECISION_5);
+    List<Point> latLngs = decode(TEST_LINE, Constants.PRECISION_5);
 
     int expectedLength = 21;
-    Assert.assertEquals("Wrong length.", expectedLength, latLngs.size());
+    assertEquals("Wrong length.", expectedLength, latLngs.size());
 
     Point lastPoint = latLngs.get(expectedLength - 1);
     expectNearNumber(37.76953, lastPoint.latitude(), 1e-6);
@@ -27,8 +32,27 @@ public class PolylineUtilsTest extends TestUtils {
 
   @Test
   public void testEncodePath() {
-    List<Point> path = PolylineUtils.decode(TEST_LINE, Constants.PRECISION_5);
-    String encoded = PolylineUtils.encode(path, Constants.PRECISION_5);
-    Assert.assertEquals(TEST_LINE, encoded);
+    List<Point> path = decode(TEST_LINE, Constants.PRECISION_5);
+    String encoded = encode(path, Constants.PRECISION_5);
+    assertEquals(TEST_LINE, encoded);
+  }
+
+  @Test
+  public void decode_neverReturnsNullButRatherAnEmptyList() throws Exception {
+    List<Point> path = decode("", Constants.PRECISION_5);
+    assertNotNull(path);
+    assertEquals(0, path.size());
+  }
+
+  @Test
+  public void encode_neverReturnsNull() throws Exception {
+    String encodedString = encode(new ArrayList<Point>(), Constants.PRECISION_6);
+    assertNotNull(encodedString);
+  }
+
+  @Test
+  public void simplify_neverReturnsNullButRatherAnEmptyList() throws Exception {
+    List<Point> simplifiedPath = simplify(new ArrayList<Point>(), Constants.PRECISION_6);
+    assertNotNull(simplifiedPath);
   }
 }

--- a/services-geojson/src/test/java/com/mapbox/geojson/utils/PolylineUtilsTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/utils/PolylineUtilsTest.java
@@ -16,7 +16,8 @@ import java.util.List;
 
 public class PolylineUtilsTest extends TestUtils {
 
-  private static final String TEST_LINE = "_cqeFf~cjVf@p@fA}AtAoB`ArAx@hA`GbIvDiFv@gAh@t@X\\|@z@`@Z\\Xf@Vf@VpA\\tATJ@NBBkC";
+  private static final String TEST_LINE
+    = "_cqeFf~cjVf@p@fA}AtAoB`ArAx@hA`GbIvDiFv@gAh@t@X\\|@z@`@Z\\Xf@Vf@VpA\\tATJ@NBBkC";
 
   @Test
   public void testDecodePath() {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-java/issues/633

Even with an empty list or path string, the returned results for all PolylineUtils results in a nonnull value, thus annotating the methods will help developers know they can skip over this check.