### PR TITLE
Add baseUrl to RouteOptions

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -210,6 +210,7 @@ public abstract class MapboxDirections extends MapboxService<DirectionsResponse>
           .voiceUnits(voiceUnits())
           .accessToken(accessToken())
           .requestUuid(response.body().uuid())
+          .baseUrl(baseUrl())
           .build()
       ).build());
     }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -41,6 +41,16 @@ public abstract class RouteOptions {
   }
 
   /**
+   * The same base URL which was used during the request that resulted in this root directions
+   * response.
+   *
+   * @return string value representing the base URL
+   * @since 3.0.0
+   */
+  @NonNull
+  public abstract String baseUrl();
+
+  /**
    * The same user which was used during the request that resulted in this root directions response.
    *
    * @return string value representing the user
@@ -66,7 +76,7 @@ public abstract class RouteOptions {
    * that these are the non-snapped coordinates.
    *
    * @return a list of {@link Point}s which represent the route origin, destination, and optionally,
-   *   waypoints
+   * waypoints
    * @since 3.0.0
    */
   @NonNull
@@ -87,7 +97,7 @@ public abstract class RouteOptions {
    * response.
    *
    * @return the language as a string used during the request, if english, this will most likely be
-   *   empty
+   * empty
    * @since 3.0.0
    */
   @Nullable
@@ -118,7 +128,7 @@ public abstract class RouteOptions {
    * directions response.
    *
    * @return a boolean value representing whether or not continueStraight was enabled or not during
-   *   the initial request
+   * the initial request
    * @since 3.0.0
    */
   @Nullable
@@ -208,6 +218,16 @@ public abstract class RouteOptions {
    */
   @AutoValue.Builder
   public abstract static class Builder {
+
+    /**
+     * The base URL that was used during the request time and resulted in this responses
+     * result.
+     *
+     * @param baseUrl base URL used for original request
+     * @return this builder for chaining options together
+     * @since 3.0.0
+     */
+    public abstract Builder baseUrl(@NonNull String baseUrl);
 
     /**
      * The user value that was used during the request.

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -392,6 +392,20 @@ public class MapboxDirectionsTest extends TestUtils {
   }
 
   @Test
+  public void baseUrl_doesGetAddedToRouteOptions() throws Exception {
+    MapboxDirections directions = MapboxDirections.builder()
+      .destination(Point.fromLngLat(13.4930, 9.958))
+      .origin(Point.fromLngLat(1.234, 2.345))
+      .accessToken(ACCESS_TOKEN)
+      .baseUrl(mockUrl.toString())
+      .build();
+
+    Response<DirectionsResponse> response = directions.executeCall();
+    String baseUrl = response.body().routes().get(0).routeOptions().baseUrl();
+    assertEquals( mockUrl.toString(), baseUrl);
+  }
+
+  @Test
   public void callFactoryNonNull() throws IOException {
     MapboxDirections client = MapboxDirections.builder()
       .accessToken(ACCESS_TOKEN)

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -392,20 +392,6 @@ public class MapboxDirectionsTest extends TestUtils {
   }
 
   @Test
-  public void baseUrl_doesGetAddedToRouteOptions() throws Exception {
-    MapboxDirections directions = MapboxDirections.builder()
-      .destination(Point.fromLngLat(13.4930, 9.958))
-      .origin(Point.fromLngLat(1.234, 2.345))
-      .accessToken(ACCESS_TOKEN)
-      .baseUrl(mockUrl.toString())
-      .build();
-
-    Response<DirectionsResponse> response = directions.executeCall();
-    String baseUrl = response.body().routes().get(0).routeOptions().baseUrl();
-    assertEquals( mockUrl.toString(), baseUrl);
-  }
-
-  @Test
   public void callFactoryNonNull() throws IOException {
     MapboxDirections client = MapboxDirections.builder()
       .accessToken(ACCESS_TOKEN)

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -96,4 +96,20 @@ public class RouteOptionsTest extends TestUtils {
     assertNull(route.routeOptions().annotations());
     assertNull(route.routeOptions().bearings());
   }
+
+  @Test
+  public void requestResult_doesContainBaseUrl() throws Exception {
+    Response<DirectionsResponse> response = MapboxDirections.builder()
+      .baseUrl(mockUrl.toString())
+      .accessToken(ACCESS_TOKEN)
+      .origin(Point.fromLngLat(1.0, 1.0))
+      .destination(Point.fromLngLat(5.0, 5.0))
+      .profile(DirectionsCriteria.PROFILE_WALKING)
+      .continueStraight(false)
+      .language(Locale.CANADA)
+      .alternatives(true).build().executeCall();
+    DirectionsRoute route = response.body().routes().get(0);
+
+    assertEquals(mockUrl.toString(), route.routeOptions().baseUrl());
+  }
 }

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -65,6 +65,7 @@ public class RouteOptionsTest extends TestUtils {
     pointList.add(Point.fromLngLat(1.0, 2.0));
     pointList.add(Point.fromLngLat(3.0, 4.0));
     RouteOptions routeOptions = RouteOptions.builder()
+      .baseUrl(mockUrl.toString())
       .profile("hello")
       .user("user")
       .coordinates(pointList)


### PR DESCRIPTION
In the navigation SDK, we need the baseUrl in `RouteOptions` to ensure our re-routing requests go to the same endpoint as the original route.