### PR TITLE
Rework dependency tree, use api instead of implementation

### DIFF
--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -5,8 +5,6 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  implementation project(":services-core")
-  implementation project(":services-directions")
   implementation project(":services-geocoding")
   implementation project(":services-optimization")
   implementation project(":services-geojson")

--- a/services-core/build.gradle
+++ b/services-core/build.gradle
@@ -21,17 +21,17 @@ static def getGitRevision() {
 dependencies {
 
   // Gson
-  implementation dependenciesList.gson
+  api dependenciesList.gson
 
   // Retrofit
-  implementation dependenciesList.retrofit
-  implementation dependenciesList.retrofit2Gson
+  api dependenciesList.retrofit
+  api dependenciesList.retrofit2Gson
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation
 
   // OkHttp
-  implementation dependenciesList.okhttp3Logging
+  api dependenciesList.okhttp3Logging
 
   // AutoValue
   compileOnly dependenciesList.autoValue

--- a/services-directions/build.gradle
+++ b/services-directions/build.gradle
@@ -1,19 +1,11 @@
 apply plugin: 'java-library'
 
 dependencies {
-
-  implementation project(":services-core")
-  implementation project(":services-geojson")
-
-  // Retrofit
-  implementation dependenciesList.retrofit
-  implementation dependenciesList.retrofit2Gson
+  api project(":services-core")
+  api project(":services-geojson")
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation
-
-  // OkHttp
-  implementation dependenciesList.okhttp3Logging
 
   // AutoValue
   compileOnly dependenciesList.autoValue

--- a/services-geocoding/build.gradle
+++ b/services-geocoding/build.gradle
@@ -2,18 +2,11 @@ apply plugin: 'java-library'
 
 dependencies {
 
-  implementation project(":services-core")
-  implementation project(":services-geojson")
-
-  // Retrofit
-  implementation dependenciesList.retrofit
-  implementation dependenciesList.retrofit2Gson
+  api project(":services-core")
+  api project(":services-geojson")
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation
-
-  // OkHttp
-  implementation dependenciesList.okhttp3Logging
 
   // AutoValue
   compileOnly dependenciesList.autoValue

--- a/services-geojson/build.gradle
+++ b/services-geojson/build.gradle
@@ -1,11 +1,8 @@
 apply plugin: 'java-library'
 
 dependencies {
-
-  implementation project(":services-core")
-
   // Gson
-  implementation dependenciesList.gson
+  api dependenciesList.gson
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation

--- a/services-matching/build.gradle
+++ b/services-matching/build.gradle
@@ -1,20 +1,10 @@
 apply plugin: 'java-library'
 
 dependencies {
-
-  implementation project(":services-core")
-  implementation project(":services-geojson")
-  implementation project(":services-directions")
-
-  // Retrofit
-  implementation dependenciesList.retrofit
-  implementation dependenciesList.retrofit2Gson
+  api project(":services-directions")
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation
-
-  // OkHttp
-  implementation dependenciesList.okhttp3Logging
 
   // AutoValue
   compileOnly dependenciesList.autoValue

--- a/services-matrix/build.gradle
+++ b/services-matrix/build.gradle
@@ -1,20 +1,10 @@
 apply plugin: 'java-library'
 
 dependencies {
-
-  implementation project(":services-core")
-  implementation project(":services-geojson")
-  implementation project(":services-directions")
-
-  // Retrofit
-  implementation dependenciesList.retrofit
-  implementation dependenciesList.retrofit2Gson
+  api project(":services-directions")
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation
-
-  // OkHttp
-  implementation dependenciesList.okhttp3Logging
 
   // AutoValue
   compileOnly dependenciesList.autoValue

--- a/services-optimization/build.gradle
+++ b/services-optimization/build.gradle
@@ -1,20 +1,10 @@
 apply plugin: 'java-library'
 
 dependencies {
-
-  implementation project(":services-core")
-  implementation project(":services-geojson")
-  implementation project(":services-directions")
-
-  // Retrofit
-  implementation dependenciesList.retrofit
-  implementation dependenciesList.retrofit2Gson
+  api project(":services-directions")
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation
-
-  // OkHttp
-  implementation dependenciesList.okhttp3Logging
 
   // AutoValue
   compileOnly dependenciesList.autoValue

--- a/services-staticmap/build.gradle
+++ b/services-staticmap/build.gradle
@@ -1,12 +1,8 @@
 apply plugin: 'java-library'
 
 dependencies {
-
-  implementation project(":services-core")
-  implementation project(":services-geojson")
-
-  // OkHttp
-  implementation dependenciesList.okhttp3Logging
+  api project(":services-core")
+  api project(":services-geojson")
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation

--- a/services-turf/build.gradle
+++ b/services-turf/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: 'java-library'
 
 dependencies {
-
-  implementation project(":services-core")
-  implementation project(":services-geojson")
+  api project(":services-core")
+  api project(":services-geojson")
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -7,27 +7,15 @@ sourceSets {
 }
 
 dependencies {
-
-  implementation project(":services-core")
-  implementation project(":services-geojson")
-
-  // Gson
-  implementation dependenciesList.gson
-
-  // Retrofit
-  implementation dependenciesList.retrofit
-  implementation dependenciesList.retrofit2Gson
+  api project(":services-core")
+  api project(":services-geojson")
 
   // Annotations
   compileOnly dependenciesList.supportAnnotation
 
-  // OkHttp
-  implementation dependenciesList.okhttp3Logging
-
   // AutoValue
   compileOnly dependenciesList.autoValue
   compileOnly dependenciesList.autoValueGson
-
 }
 
 apply from: "${rootDir}/gradle/mvn-push.gradle"


### PR DESCRIPTION
This PR merges into https://github.com/mapbox/mapbox-java/pull/737 and reworks the dependency tree.