### PR TITLE
Add voiceUnits to MapMatching

### DIFF
--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapMatchingService.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapMatchingService.java
@@ -44,12 +44,12 @@ public interface MapMatchingService {
    *                           must be as many timestamps as there are coordinates in the request,
    *                           each separated by {@code ;}
    * @param annotations        whether or not to return additional metadata for each coordinate
-   *                           along the match geometry. Can be one or all of 'duration', 'distance',
-   *                           or 'nodes', each separated by ,. See the response object for more
-   *                           details on what it is included with annotations
+   *                           along the match geometry. Can be one or all of 'duration',
+   *                           'distance', or 'nodes', each separated by ,. See the response
+   *                           object for more details on what it is included with annotations
    * @param language           language of returned turn-by-turn text instructions
-   * @param tidy               whether or not to transparently remove clusters and re-sample traces for
-   *                           improved map matching results
+   * @param tidy               whether or not to transparently remove clusters and re-sample
+   *                           traces for improved map matching results
    * @param roundaboutExits    Whether or not to emit instructions at roundabout exits.
    * @param bannerInstructions Whether or not to return banner objects associated with
    *                           the `routeSteps`. Should be used in conjunction with `steps`.

--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapMatchingService.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapMatchingService.java
@@ -19,43 +19,44 @@ public interface MapMatchingService {
    * Constructs the html call using the information passed in through the
    * {@link MapboxMapMatching.Builder}.
    *
-   * @param userAgent   user agent
-   * @param user        user
-   * @param profile     directions profile ID; either mapbox/driving, mapbox/walking,
-   *                    or mapbox/cycling
-   * @param coordinates inaccurate traces from a GPS unit or a phone
-   * @param accessToken Mapbox access token
-   * @param geometries  format of the returned geometry. Allowed values are: geojson
-   *                    (as LineString), polyline with precision 5, polyline6. The default
-   *                    value is polyline
-   * @param radiuses    a list of integers in meters indicating the assumed precision of
-   *                    the used tracking device. There must be as many radiuses as there
-   *                    are coordinates in the request, each separated by ;. Values can be
-   *                    a number between 0 and 30. Use higher numbers (20-30) for noisy
-   *                    traces and lower numbers (1-10) for clean traces. The default value
-   *                    is 5
-   * @param steps       whether to return steps and turn-by-turn instructions. Can be true
-   *                    or false. The default is false
-   * @param overview    type of returned overview geometry. Can be full (the most detailed
-   *                    geometry available), simplified (a simplified version of the full
-   *                    geometry), or false (no overview geometry). The default is simplified
-   * @param timestamps  timestamps corresponding to each coordinate provided in the request;
-   *                    must be numbers in Unix time (seconds since the Unix epoch). There
-   *                    must be as many timestamps as there are coordinates in the request,
-   *                    each separated by {@code ;}
-   * @param annotations whether or not to return additional metadata for each coordinate
-   *                    along the match geometry. Can be one or all of 'duration', 'distance',
-   *                    or 'nodes', each separated by ,. See the response object for more
-   *                    details on what it is included with annotations
-   * @param language    language of returned turn-by-turn text instructions
-   * @param tidy        whether or not to transparently remove clusters and re-sample traces for
-   *                    improved map matching results
-   * @param roundaboutExits  Whether or not to emit instructions at roundabout exits.
+   * @param userAgent          user agent
+   * @param user               user
+   * @param profile            directions profile ID; either mapbox/driving, mapbox/walking,
+   *                           or mapbox/cycling
+   * @param coordinates        inaccurate traces from a GPS unit or a phone
+   * @param accessToken        Mapbox access token
+   * @param geometries         format of the returned geometry. Allowed values are: geojson
+   *                           (as LineString), polyline with precision 5, polyline6. The default
+   *                           value is polyline
+   * @param radiuses           a list of integers in meters indicating the assumed precision of
+   *                           the used tracking device. There must be as many radiuses as there
+   *                           are coordinates in the request, each separated by ;. Values can be
+   *                           a number between 0 and 30. Use higher numbers (20-30) for noisy
+   *                           traces and lower numbers (1-10) for clean traces. The default value
+   *                           is 5
+   * @param steps              whether to return steps and turn-by-turn instructions. Can be true
+   *                           or false. The default is false
+   * @param overview           type of returned overview geometry. Can be full (the most detailed
+   *                           geometry available), simplified (a simplified version of the full
+   *                           geometry), or false (no overview geometry). The default is simplified
+   * @param timestamps         timestamps corresponding to each coordinate provided in the request;
+   *                           must be numbers in Unix time (seconds since the Unix epoch). There
+   *                           must be as many timestamps as there are coordinates in the request,
+   *                           each separated by {@code ;}
+   * @param annotations        whether or not to return additional metadata for each coordinate
+   *                           along the match geometry. Can be one or all of 'duration', 'distance',
+   *                           or 'nodes', each separated by ,. See the response object for more
+   *                           details on what it is included with annotations
+   * @param language           language of returned turn-by-turn text instructions
+   * @param tidy               whether or not to transparently remove clusters and re-sample traces for
+   *                           improved map matching results
+   * @param roundaboutExits    Whether or not to emit instructions at roundabout exits.
    * @param bannerInstructions Whether or not to return banner objects associated with
    *                           the `routeSteps`. Should be used in conjunction with `steps`.
-   * @param voiceInstructions whether or not to return
-   *                        marked-up text for voice guidance along the route.
-   * @param waypoints  Which input coordinates should be treated as waypoints.
+   * @param voiceInstructions  whether or not to return
+   *                           marked-up text for voice guidance along the route.
+   * @param voiceUnits         voice units
+   * @param waypoints          Which input coordinates should be treated as waypoints.
    * @return the MapMatchingResponse in a Call wrapper
    * @since 2.0.0
    */
@@ -77,5 +78,6 @@ public interface MapMatchingService {
     @Query("roundabout_exits") Boolean roundaboutExits,
     @Query("banner_instructions") Boolean bannerInstructions,
     @Query("voice_instructions") Boolean voiceInstructions,
+    @Query("voice_units") String voiceUnits,
     @Query("waypoints") String waypoints);
 }

--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
@@ -15,6 +15,7 @@ import com.mapbox.api.directions.v5.DirectionsCriteria.AnnotationCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.GeometriesCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.OverviewCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.ProfileCriteria;
+import com.mapbox.api.directions.v5.MapboxDirections;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.api.matching.v5.models.MapMatchingAdapterFactory;
 import com.mapbox.api.matching.v5.models.MapMatchingError;
@@ -88,6 +89,7 @@ public abstract class MapboxMapMatching extends
       roundaboutExits(),
       bannerInstructions(),
       voiceInstructions(),
+      voiceUnits(),
       waypoints());
   }
 
@@ -183,11 +185,7 @@ public abstract class MapboxMapMatching extends
           .user(user())
           .voiceInstructions(voiceInstructions())
           .bannerInstructions(bannerInstructions())
-          //.continueStraight(continueStraight())
-          //.bearings(bearings())
-          //.alternatives(alternatives())
-          //.exclude(exclude())
-          //.voiceUnits(voiceUnits())
+          .voiceUnits(voiceUnits())
           .requestUuid("mapmatching")
           .accessToken(accessToken())
           .baseUrl(baseUrl())
@@ -259,8 +257,10 @@ public abstract class MapboxMapMatching extends
   abstract Boolean voiceInstructions();
 
   @Nullable
-  abstract String waypoints();
+  abstract String voiceUnits();
 
+  @Nullable
+  abstract String waypoints();
 
   @NonNull
   @Override
@@ -448,6 +448,14 @@ public abstract class MapboxMapMatching extends
      */
     public abstract Builder voiceInstructions(@Nullable Boolean voiceInstructions);
 
+    /**
+     * Specify what unit you'd like voice and banner instructions to use.
+     *
+     * @param voiceUnits either Imperial (default) or Metric
+     * @return this builder for chaining options together
+     * @since 3.0.0
+     */
+    public abstract Builder voiceUnits(@Nullable @DirectionsCriteria.VoiceUnitCriteria String voiceUnits);
 
     /**
      * Setting this will determine whether to return steps and turn-by-turn instructions. Can be

--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
@@ -1,7 +1,5 @@
 package com.mapbox.api.matching.v5;
 
-import static com.sun.xml.internal.ws.spi.db.BindingContextFactory.LOGGER;
-
 import android.support.annotation.FloatRange;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
@@ -15,7 +13,6 @@ import com.mapbox.api.directions.v5.DirectionsCriteria.AnnotationCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.GeometriesCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.OverviewCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.ProfileCriteria;
-import com.mapbox.api.directions.v5.MapboxDirections;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.api.matching.v5.models.MapMatchingAdapterFactory;
 import com.mapbox.api.matching.v5.models.MapMatchingError;
@@ -28,20 +25,20 @@ import com.mapbox.core.utils.ApiCallHelper;
 import com.mapbox.core.utils.MapboxUtils;
 import com.mapbox.core.utils.TextUtils;
 import com.mapbox.geojson.Point;
+import com.sun.xml.internal.ws.spi.db.BindingContextFactory;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Level;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Converter;
 import retrofit2.Response;
-
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.logging.Level;
 
 /**
  * The Mapbox map matching interface (v5)
@@ -51,7 +48,7 @@ import java.util.logging.Level;
  * be displayed on a map or used for other analysis.
  *
  * @see <a href="https://www.mapbox.com/api-documentation/#map-matching">Map matching API
- *   documentation</a>
+ * documentation</a>
  * @since 2.0.0
  */
 @AutoValue
@@ -110,9 +107,9 @@ public abstract class MapboxMapMatching extends
     }
 
     return Response.success(response.body()
-            .toBuilder()
-            .matchings(generateRouteOptions(response))
-            .build());
+      .toBuilder()
+      .matchings(generateRouteOptions(response))
+      .build());
   }
 
   /**
@@ -167,7 +164,9 @@ public abstract class MapboxMapMatching extends
       callback.onFailure(getCall(),
         new Throwable(errorConverter.convert(response.errorBody()).message()));
     } catch (IOException ioException) {
-      LOGGER.log(Level.WARNING, "Failed to complete your request. ", ioException);
+      BindingContextFactory.LOGGER.log(
+        Level.WARNING, "Failed to complete your request. ", ioException
+      );
     }
   }
 
@@ -455,7 +454,9 @@ public abstract class MapboxMapMatching extends
      * @return this builder for chaining options together
      * @since 3.0.0
      */
-    public abstract Builder voiceUnits(@Nullable @DirectionsCriteria.VoiceUnitCriteria String voiceUnits);
+    public abstract Builder voiceUnits(
+      @Nullable @DirectionsCriteria.VoiceUnitCriteria String voiceUnits
+    );
 
     /**
      * Setting this will determine whether to return steps and turn-by-turn instructions. Can be
@@ -481,7 +482,7 @@ public abstract class MapboxMapMatching extends
      *                    or null which will result in no annotations being used
      * @return this builder for chaining options together
      * @see <a href="https://www.mapbox.com/api-documentation/#routeleg-object">RouteLeg object
-     *   documentation</a>
+     * documentation</a>
      * @since 2.1.0
      */
     public Builder annotations(@Nullable @AnnotationCriteria String... annotations) {
@@ -553,7 +554,7 @@ public abstract class MapboxMapMatching extends
      *                 written in when returned
      * @return this builder for chaining options together
      * @see <a href="https://www.mapbox.com/api-documentation/#instructions-languages">Supported
-     *   Languages</a>
+     * Languages</a>
      * @since 3.0.0
      */
     public Builder language(@Nullable Locale language) {
@@ -572,7 +573,7 @@ public abstract class MapboxMapMatching extends
      *                 written in when returned
      * @return this builder for chaining options together
      * @see <a href="https://www.mapbox.com/api-documentation/#instructions-languages">Supported
-     *   Languages</a>
+     * Languages</a>
      * @since 2.2.0
      */
     public abstract Builder language(String language);

--- a/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
+++ b/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
@@ -1,13 +1,9 @@
 package com.mapbox.api.matching.v5;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
-
-import com.mapbox.api.matching.v5.models.MapMatchingMatching;
+import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.matching.v5.models.MapMatchingResponse;
 import com.mapbox.core.TestUtils;
 import com.mapbox.core.exceptions.ServicesException;
-import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.geojson.Point;
 
 import org.junit.After;
@@ -27,7 +23,9 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import retrofit2.Response;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -445,6 +443,21 @@ public class MapboxMapMatchingTest extends TestUtils {
     assertNotNull(mapMatching);
     assertTrue(mapMatching.cloneCall().request().url().toString()
       .contains("voice_instructions=true"));
+  }
+
+  @Test
+  public void sanityVoiceUnits() throws Exception {
+    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
+      .coordinate(Point.fromLngLat(2.0, 2.0))
+      .coordinate(Point.fromLngLat(4.0, 4.0))
+      .voiceInstructions(true)
+      .voiceUnits(DirectionsCriteria.METRIC)
+      .baseUrl("https://foobar.com")
+      .accessToken(ACCESS_TOKEN)
+      .build();
+    assertNotNull(mapMatching);
+    assertTrue(mapMatching.cloneCall().request().url().toString()
+      .contains("voice_units=metric"));
   }
 
   @Test


### PR DESCRIPTION
Adds voice units param to map matching request to be used to configure the voice instructions provided by the API 