### PR TITLE
Bumped snapshot to 3.1.0 in repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-services:2.3.0-SNAPSHOT'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-services:3.1.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
Part of the 3.0.0 Mapbox Java SDK release: https://github.com/mapbox/mapbox-java/issues/774