### PR TITLE
rename BoundingBox.fromCoordinates() to BoundingBox.fromLngLats() 

### DIFF
--- a/services-geojson/src/main/java/com/mapbox/geojson/BoundingBox.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/BoundingBox.java
@@ -73,8 +73,59 @@ public abstract class BoundingBox implements Serializable {
    * @param north the top side of the bounding box when the map is facing due north
    * @return a new instance of this class defined by the provided coordinates
    * @since 3.0.0
+   * @deprecated As of 3.1.0, use {@link #fromLngLats} instead.
    */
+
+  @Deprecated
   public static BoundingBox fromCoordinates(
+    @FloatRange(from = MIN_LONGITUDE, to = GeoJsonConstants.MAX_LONGITUDE) double west,
+    @FloatRange(from = MIN_LATITUDE, to = GeoJsonConstants.MAX_LATITUDE) double south,
+    @FloatRange(from = MIN_LONGITUDE, to = GeoJsonConstants.MAX_LONGITUDE) double east,
+    @FloatRange(from = MIN_LATITUDE, to = GeoJsonConstants.MAX_LATITUDE) double north) {
+    return fromLngLats(west, south, east, north);
+  }
+
+  /**
+   * Define a new instance of this class by passing in four coordinates in the same order they would
+   * appear in the serialized GeoJson form. Limits are placed on the minimum and maximum coordinate
+   * values which can exist and comply with the GeoJson spec.
+   *
+   * @param west              the left side of the bounding box when the map is facing due north
+   * @param south             the bottom side of the bounding box when the map is facing due north
+   * @param southwestAltitude the southwest corner altitude or elevation when the map is facing due
+   *                          north
+   * @param east              the right side of the bounding box when the map is facing due north
+   * @param north             the top side of the bounding box when the map is facing due north
+   * @param northEastAltitude the northeast corner altitude or elevation when the map is facing due
+   *                          north
+   * @return a new instance of this class defined by the provided coordinates
+   * @since 3.0.0
+   * @deprecated As of 3.1.0, use {@link #fromLngLats} instead.
+   * */
+  @Deprecated
+  public static BoundingBox fromCoordinates(
+    @FloatRange(from = MIN_LONGITUDE, to = GeoJsonConstants.MAX_LONGITUDE) double west,
+    @FloatRange(from = MIN_LATITUDE, to = GeoJsonConstants.MAX_LATITUDE) double south,
+    double southwestAltitude,
+    @FloatRange(from = MIN_LONGITUDE, to = GeoJsonConstants.MAX_LONGITUDE) double east,
+    @FloatRange(from = MIN_LATITUDE, to = GeoJsonConstants.MAX_LATITUDE) double north,
+    double northEastAltitude) {
+    return fromLngLats(west, south, southwestAltitude, east, north, northEastAltitude);
+  }
+
+  /**
+   * Define a new instance of this class by passing in four coordinates in the same order they would
+   * appear in the serialized GeoJson form. Limits are placed on the minimum and maximum coordinate
+   * values which can exist and comply with the GeoJson spec.
+   *
+   * @param west  the left side of the bounding box when the map is facing due north
+   * @param south the bottom side of the bounding box when the map is facing due north
+   * @param east  the right side of the bounding box when the map is facing due north
+   * @param north the top side of the bounding box when the map is facing due north
+   * @return a new instance of this class defined by the provided coordinates
+   * @since 3.1.0
+   */
+  public static BoundingBox fromLngLats(
     @FloatRange(from = MIN_LONGITUDE, to = GeoJsonConstants.MAX_LONGITUDE) double west,
     @FloatRange(from = MIN_LATITUDE, to = GeoJsonConstants.MAX_LATITUDE) double south,
     @FloatRange(from = MIN_LONGITUDE, to = GeoJsonConstants.MAX_LONGITUDE) double east,
@@ -96,9 +147,9 @@ public abstract class BoundingBox implements Serializable {
    * @param northEastAltitude the northeast corner altitude or elevation when the map is facing due
    *                          north
    * @return a new instance of this class defined by the provided coordinates
-   * @since 3.0.0
+   * @since 3.1.0
    */
-  public static BoundingBox fromCoordinates(
+  public static BoundingBox fromLngLats(
     @FloatRange(from = MIN_LONGITUDE, to = GeoJsonConstants.MAX_LONGITUDE) double west,
     @FloatRange(from = MIN_LATITUDE, to = GeoJsonConstants.MAX_LATITUDE) double south,
     double southwestAltitude,

--- a/services-geojson/src/main/java/com/mapbox/geojson/gson/BoundingBoxDeserializer.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/gson/BoundingBoxDeserializer.java
@@ -48,7 +48,7 @@ public class BoundingBoxDeserializer implements JsonDeserializer<BoundingBox> {
     JsonArray rawCoordinates = json.getAsJsonArray();
 
     if (rawCoordinates.size() == 6) {
-      return BoundingBox.fromCoordinates(
+      return BoundingBox.fromLngLats(
         rawCoordinates.get(0).getAsDouble(),
         rawCoordinates.get(1).getAsDouble(),
         rawCoordinates.get(2).getAsDouble(),
@@ -57,7 +57,7 @@ public class BoundingBoxDeserializer implements JsonDeserializer<BoundingBox> {
         rawCoordinates.get(5).getAsDouble());
     }
     if (rawCoordinates.size() == 4) {
-      return BoundingBox.fromCoordinates(
+      return BoundingBox.fromLngLats(
         rawCoordinates.get(0).getAsDouble(),
         rawCoordinates.get(1).getAsDouble(),
         rawCoordinates.get(2).getAsDouble(),

--- a/services-geojson/src/test/java/com/mapbox/geojson/FeatureCollectionTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/FeatureCollectionTest.java
@@ -59,7 +59,7 @@ public class FeatureCollectionTest extends TestUtils {
     List<Feature> features = new ArrayList<>();
     features.add(Feature.fromGeometry(null));
     features.add(Feature.fromGeometry(null));
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     FeatureCollection featureCollection = FeatureCollection.fromFeatures(features, bbox);
     assertNotNull(featureCollection.bbox());
     assertEquals(1.0, featureCollection.bbox().west(), DELTA);
@@ -79,7 +79,7 @@ public class FeatureCollectionTest extends TestUtils {
     List<Feature> features = new ArrayList<>();
     features.add(feature);
     features.add(feature);
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     FeatureCollection featureCollection = FeatureCollection.fromFeatures(features, bbox);
     compareJson(featureCollection.toJson(),
       "{\"type\":\"FeatureCollection\",\"bbox\":[1.0,2.0,3.0,4.0],"

--- a/services-geojson/src/test/java/com/mapbox/geojson/FeatureTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/FeatureTest.java
@@ -57,7 +57,7 @@ public class FeatureTest extends TestUtils {
     points.add(Point.fromLngLat(2.0, 3.0));
     LineString lineString = LineString.fromLngLats(points);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     Feature feature = Feature.fromGeometry(lineString, bbox);
     assertNotNull(feature.bbox());
     assertEquals(1.0, feature.bbox().west(), DELTA);
@@ -73,7 +73,7 @@ public class FeatureTest extends TestUtils {
     points.add(Point.fromLngLat(2.0, 3.0));
     LineString lineString = LineString.fromLngLats(points);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     Feature feature = Feature.fromGeometry(lineString, bbox);
     compareJson("{\"type\":\"Feature\",\"bbox\":[1.0,2.0,3.0,4.0],\"geometry\":"
         + "{\"type\":\"LineString\",\"coordinates\":[[1,2],[2,3]]},\"properties\":{}}",

--- a/services-geojson/src/test/java/com/mapbox/geojson/GeometryCollectionTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/GeometryCollectionTest.java
@@ -70,7 +70,7 @@ public class GeometryCollectionTest extends TestUtils {
     geometries.add(points.get(0));
     geometries.add(lineString);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     GeometryCollection geometryCollection = GeometryCollection.fromGeometries(geometries, bbox);
     assertNotNull(geometryCollection.bbox());
     assertEquals(1.0, geometryCollection.bbox().west(), DELTA);
@@ -98,7 +98,7 @@ public class GeometryCollectionTest extends TestUtils {
     geometries.add(points.get(0));
     geometries.add(lineString);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     GeometryCollection geometryCollection = GeometryCollection.fromGeometries(geometries, bbox);
     compareJson(geometryCollection.toJson(),
       "{\"type\":\"GeometryCollection\",\"bbox\":[1.0,2.0,3.0,4.0],"
@@ -116,7 +116,7 @@ public class GeometryCollectionTest extends TestUtils {
     geometries.add(points.get(0));
     geometries.add(lineString);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     GeometryCollection geometryCollection = GeometryCollection.fromGeometries(geometries, bbox);
     byte[] bytes = serialize(geometryCollection);
     assertEquals(geometryCollection, deserialize(bytes, GeometryCollection.class));

--- a/services-geojson/src/test/java/com/mapbox/geojson/LineStringTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/LineStringTest.java
@@ -70,7 +70,7 @@ public class LineStringTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 1.0));
     points.add(Point.fromLngLat(2.0, 2.0));
     points.add(Point.fromLngLat(3.0, 3.0));
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     LineString lineString = LineString.fromLngLats(points, bbox);
     assertNotNull(lineString.bbox());
     assertEquals(1.0, lineString.bbox().west(), DELTA);
@@ -85,7 +85,7 @@ public class LineStringTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 1.0));
     points.add(Point.fromLngLat(2.0, 2.0));
     points.add(Point.fromLngLat(3.0, 3.0));
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     LineString lineString = LineString.fromLngLats(points, bbox);
     compareJson(lineString.toJson(),
       "{\"coordinates\":[[1,1],[2,2],[3,3]],"
@@ -98,7 +98,7 @@ public class LineStringTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 1.0));
     points.add(Point.fromLngLat(2.0, 2.0));
     points.add(Point.fromLngLat(3.0, 3.0));
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     LineString lineString = LineString.fromLngLats(points, bbox);
     byte[] bytes = serialize(lineString);
     assertEquals(lineString, deserialize(bytes, LineString.class));

--- a/services-geojson/src/test/java/com/mapbox/geojson/MultiLineStringTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/MultiLineStringTest.java
@@ -62,7 +62,7 @@ public class MultiLineStringTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     points.add(Point.fromLngLat(2.0, 3.0));
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<LineString> lineStrings = new ArrayList<>();
     lineStrings.add(LineString.fromLngLats(points));
     lineStrings.add(LineString.fromLngLats(points));
@@ -92,7 +92,7 @@ public class MultiLineStringTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     points.add(Point.fromLngLat(2.0, 3.0));
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<LineString> lineStrings = new ArrayList<>();
     lineStrings.add(LineString.fromLngLats(points));
     lineStrings.add(LineString.fromLngLats(points));
@@ -108,7 +108,7 @@ public class MultiLineStringTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     points.add(Point.fromLngLat(2.0, 3.0));
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<LineString> lineStrings = new ArrayList<>();
     lineStrings.add(LineString.fromLngLats(points));
     lineStrings.add(LineString.fromLngLats(points));

--- a/services-geojson/src/test/java/com/mapbox/geojson/MultiPointTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/MultiPointTest.java
@@ -54,7 +54,7 @@ public class MultiPointTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     points.add(Point.fromLngLat(2.0, 3.0));
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     MultiPoint multiPoint = MultiPoint.fromLngLats(points, bbox);
     assertNotNull(multiPoint.bbox());
     assertEquals(1.0, multiPoint.bbox().west(), DELTA);
@@ -69,7 +69,7 @@ public class MultiPointTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     points.add(Point.fromLngLat(2.0, 3.0));
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     MultiPoint multiPoint = MultiPoint.fromLngLats(points, bbox);
     compareJson(multiPoint.toJson(),
       "{\"coordinates\":[[1,2],[2,3]],\"type\":\"MultiPoint\",\"bbox\":[1.0,2.0,3.0,4.0]}");
@@ -81,7 +81,7 @@ public class MultiPointTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     points.add(Point.fromLngLat(2.0, 3.0));
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     MultiPoint multiPoint = MultiPoint.fromLngLats(points, bbox);
     byte[] bytes = serialize(multiPoint);
     assertEquals(multiPoint, deserialize(bytes, MultiPoint.class));

--- a/services-geojson/src/test/java/com/mapbox/geojson/MultiPolygonTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/MultiPolygonTest.java
@@ -72,7 +72,7 @@ public class MultiPolygonTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     LineString outer = LineString.fromLngLats(points);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<Polygon> polygons = new ArrayList<>();
     polygons.add(Polygon.fromOuterInner(outer));
     polygons.add(Polygon.fromOuterInner(outer));
@@ -107,7 +107,7 @@ public class MultiPolygonTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     LineString outer = LineString.fromLngLats(points);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<Polygon> polygons = new ArrayList<>();
     polygons.add(Polygon.fromOuterInner(outer));
     polygons.add(Polygon.fromOuterInner(outer));
@@ -126,7 +126,7 @@ public class MultiPolygonTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     LineString outer = LineString.fromLngLats(points);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<Polygon> polygons = new ArrayList<>();
     polygons.add(Polygon.fromOuterInner(outer));
     polygons.add(Polygon.fromOuterInner(outer));

--- a/services-geojson/src/test/java/com/mapbox/geojson/PointTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/PointTest.java
@@ -72,7 +72,7 @@ public class PointTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 1.0));
     points.add(Point.fromLngLat(2.0, 2.0));
     points.add(Point.fromLngLat(3.0, 3.0));
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     LineString lineString = LineString.fromLngLats(points, bbox);
     assertNotNull(lineString.bbox());
     assertEquals(1.0, lineString.bbox().west(), DELTA);
@@ -87,7 +87,7 @@ public class PointTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 1.0));
     points.add(Point.fromLngLat(2.0, 2.0));
     points.add(Point.fromLngLat(3.0, 3.0));
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     LineString lineString = LineString.fromLngLats(points, bbox);
     compareJson(lineString.toJson(),
       "{\"coordinates\":[[1,1],[2,2],[3,3]],"
@@ -100,7 +100,7 @@ public class PointTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 1.0));
     points.add(Point.fromLngLat(2.0, 2.0));
     points.add(Point.fromLngLat(3.0, 3.0));
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     LineString lineString = LineString.fromLngLats(points, bbox);
     byte[] bytes = serialize(lineString);
     assertEquals(lineString, deserialize(bytes, LineString.class));

--- a/services-geojson/src/test/java/com/mapbox/geojson/PolygonTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/PolygonTest.java
@@ -127,7 +127,7 @@ public class PolygonTest extends TestUtils {
     inner.add(Point.fromLngLat(5.0, 2.0));
     LineString innerLineString = LineString.fromLngLats(inner);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     Polygon polygon = Polygon.fromOuterInner(outerLineString, bbox, innerLineString);
 
     assertEquals(bbox, polygon.bbox());
@@ -179,7 +179,7 @@ public class PolygonTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     LineString outer = LineString.fromLngLats(points);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<LineString> inner = new ArrayList<>();
     inner.add(LineString.fromLngLats(points));
     inner.add(LineString.fromLngLats(points));
@@ -200,7 +200,7 @@ public class PolygonTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     LineString outer = LineString.fromLngLats(points);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<LineString> inner = new ArrayList<>();
     inner.add(LineString.fromLngLats(points));
     inner.add(LineString.fromLngLats(points));
@@ -219,7 +219,7 @@ public class PolygonTest extends TestUtils {
     points.add(Point.fromLngLat(1.0, 2.0));
     LineString outer = LineString.fromLngLats(points);
 
-    BoundingBox bbox = BoundingBox.fromCoordinates(1.0, 2.0, 3.0, 4.0);
+    BoundingBox bbox = BoundingBox.fromLngLats(1.0, 2.0, 3.0, 4.0);
     List<LineString> inner = new ArrayList<>();
     inner.add(LineString.fromLngLats(points));
     inner.add(LineString.fromLngLats(points));

--- a/services-staticmap/src/test/java/com/mapbox/api/staticmap/v1/models/StaticMarkerAnnotationTest.java
+++ b/services-staticmap/src/test/java/com/mapbox/api/staticmap/v1/models/StaticMarkerAnnotationTest.java
@@ -189,7 +189,7 @@ public class StaticMarkerAnnotationTest {
 //
 //  @Test
 //  public void markerPositionWorking() throws ServicesException {
-//    Position position = Position.fromCoordinates(1.0, 2.0);
+//    Position position = Position.fromLngLats(1.0, 2.0);
 //
 //    StaticMarkerAnnotation staticMarkerAnnotation
 //      = new StaticMarkerAnnotation.Builder().setName(Constants.PIN_SMALL).setPosition(position).build();
@@ -200,14 +200,14 @@ public class StaticMarkerAnnotationTest {
 //  public void singleMarkerInUrl() {
 //    StaticMarkerAnnotation staticMarkerAnnotation = new StaticMarkerAnnotation.Builder()
 //      .setName(Constants.PIN_SMALL)
-//      .setPosition(Position.fromCoordinates(1.0, 2.0))
+//      .setPosition(Position.fromLngLats(1.0, 2.0))
 //      .build();
 //
 //    MapboxStaticImage image = new MapboxStaticImage.Builder()
 //      .setAccessToken("pk.")
 //      .setStyleId(Constants.MAPBOX_STYLE_STREETS)
 //      .setStaticMarkerAnnotations(staticMarkerAnnotation)
-//      .setPosition(Position.fromCoordinates(1.0, 2.0))
+//      .setPosition(Position.fromLngLats(1.0, 2.0))
 //      .setWidth(100).setHeight(200)
 //      .build();
 //
@@ -218,19 +218,19 @@ public class StaticMarkerAnnotationTest {
 //  public void doubleMarkersInUrl() {
 //    StaticMarkerAnnotation staticMarkerAnnotation1 = new StaticMarkerAnnotation.Builder()
 //      .setName(Constants.PIN_SMALL)
-//      .setPosition(Position.fromCoordinates(1.0, 2.0))
+//      .setPosition(Position.fromLngLats(1.0, 2.0))
 //      .build();
 //
 //    StaticMarkerAnnotation staticMarkerAnnotation2 = new StaticMarkerAnnotation.Builder()
 //      .setName(Constants.PIN_MEDIUM)
-//      .setPosition(Position.fromCoordinates(5.0, 6.0))
+//      .setPosition(Position.fromLngLats(5.0, 6.0))
 //      .build();
 //
 //    MapboxStaticImage image = new MapboxStaticImage.Builder()
 //      .setAccessToken("pk.")
 //      .setStyleId(Constants.MAPBOX_STYLE_STREETS)
 //      .setStaticMarkerAnnotations(staticMarkerAnnotation1, staticMarkerAnnotation2)
-//      .setPosition(Position.fromCoordinates(1.0, 2.0))
+//      .setPosition(Position.fromLngLats(1.0, 2.0))
 //      .setWidth(100).setHeight(200)
 //      .build();
 //
@@ -241,7 +241,7 @@ public class StaticMarkerAnnotationTest {
 //  public void customMarkerIcon() {
 //    StaticMarkerAnnotation staticMarkerAnnotation = new StaticMarkerAnnotation.Builder()
 //      .setUrl("https://www.mapbox.com/img/rocket.png")
-//      .setPosition(Position.fromCoordinates(1.0, 2.0))
+//      .setPosition(Position.fromLngLats(1.0, 2.0))
 //      .build();
 //
 //    assertTrue(staticMarkerAnnotation.getMarker().contains("url-https://www.mapbox.com/img/rocket.png(1.0,2.0)"));


### PR DESCRIPTION
rename BoundingBox.fromCoordinates() to BoundingBox.fromLngLats() 
for consistency with the rest of the API

closes #788 