### PR TITLE
Fix broken geocoding docs link

### DIFF
--- a/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/MapboxGeocoding.java
+++ b/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/MapboxGeocoding.java
@@ -57,7 +57,7 @@ import retrofit2.Response;
  * {@link GeocodingResponse}s. Each query in a batch request counts individually against your
  * account's rate limits.
  *
- * @see <a href="https://www.mapbox.com/android-docs/mapbox-services/overview/geocoder/">Android
+ * @see <a href="https://www.mapbox.com/android-docs/java-sdk/overview/geocoder/">Android
  *   Geocoding documentation</a>
  * @since 1.0.0
  */


### PR DESCRIPTION
Does what the title says - the link was pointing to the wrong area for the java-sdk Android docs.