### PR TITLE
Add approaches to RouteOptions

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -206,6 +206,7 @@ public abstract class MapboxDirections extends
           .coordinates(coordinates())
           .continueStraight(continueStraight())
           .annotations(annotation())
+          .approaches(approaches())
           .bearings(bearing())
           .alternatives(alternatives())
           .language(language())

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -7,6 +7,7 @@ import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegAnnotation;
+import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.core.TestUtils;
 import com.mapbox.core.exceptions.ServicesException;
 import com.mapbox.geojson.Point;
@@ -617,5 +618,23 @@ public class MapboxDirectionsTest extends TestUtils {
     Response<DirectionsResponse> response = mapboxDirections.executeCall();
     assertEquals(200, response.code());
     assertEquals("Ok", response.body().code());
+  }
+
+  @Test
+  public void testRouteOptionsApproaches() throws Exception {
+    MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .profile(PROFILE_DRIVING)
+      .origin(Point.fromLngLat(13.4301,52.5109))
+      .destination(Point.fromLngLat(13.432508,52.501725))
+      .addApproaches(APPROACH_UNRESTRICTED, APPROACH_CURB)
+      .accessToken(ACCESS_TOKEN)
+      .baseUrl(mockUrl.toString())
+      .build();
+
+    mapboxDirections.setCallFactory(null);
+    Response<DirectionsResponse> response = mapboxDirections.executeCall();
+    RouteOptions routeOptions = response.body().routes().get(0).routeOptions();
+
+    assertEquals("unrestricted;curb", routeOptions.approaches());
   }
 }

--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
@@ -208,6 +208,7 @@ public abstract class MapboxMapMatching extends
           .profile(profile())
           .coordinates(formatCoordinates(coordinates()))
           .annotations(annotations())
+          .approaches(approaches())
           .language(language())
           .radiuses(radiuses())
           .user(user())

--- a/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
+++ b/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
@@ -1,6 +1,7 @@
 package com.mapbox.api.matching.v5;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.api.matching.v5.models.MapMatchingResponse;
 import com.mapbox.core.TestUtils;
 import com.mapbox.core.exceptions.ServicesException;
@@ -595,5 +596,22 @@ public class MapboxMapMatchingTest extends TestUtils {
     Response<MapMatchingResponse> response = mapMatching.executeCall();
     assertEquals(200, response.code());
     assertEquals("Ok", response.body().code());
+  }
+
+  @Test
+  public void testRouteOptionsApproaches() throws Exception {
+    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
+      .profile(PROFILE_DRIVING)
+      .coordinate(Point.fromLngLat(-117.1728265285492,32.71204416018209))
+      .coordinate(Point.fromLngLat(-117.17334151268004,32.71254065549407))
+      .addApproaches(APPROACH_UNRESTRICTED, APPROACH_CURB)
+      .accessToken(ACCESS_TOKEN)
+      .baseUrl(mockUrl.toString())
+      .build();
+
+    Response<MapMatchingResponse> response = mapMatching.executeCall();
+    RouteOptions routeOptions = response.body().matchings().get(0).routeOptions();
+
+    assertEquals("unrestricted;curb", routeOptions.approaches());
   }
 }


### PR DESCRIPTION
Adds approaches to `RouteOptions` after a successful response has been received by either the Directions or Map Matching API.