### PR TITLE
Static image marker fixes

### DIFF
--- a/services-staticmap/src/main/java/com/mapbox/api/staticmap/v1/MapboxStaticMap.java
+++ b/services-staticmap/src/main/java/com/mapbox/api/staticmap/v1/MapboxStaticMap.java
@@ -103,11 +103,11 @@ public abstract class MapboxStaticMap {
 
     List<String> annotations = new ArrayList<>();
     if (staticMarkerAnnotations() != null) {
-      String[] markerStringArray = new String[staticMarkerAnnotations().size()];
+      List<String> markerStrings = new ArrayList<>(staticMarkerAnnotations().size());
       for (StaticMarkerAnnotation marker : staticMarkerAnnotations()) {
-        markerStringArray[staticMarkerAnnotations().indexOf(marker)] = marker.url();
+        markerStrings.add(marker.url());
       }
-      annotations.addAll(Arrays.asList(markerStringArray));
+      annotations.addAll(markerStrings);
     }
 
     if (staticPolylineAnnotations() != null) {

--- a/services-staticmap/src/main/java/com/mapbox/api/staticmap/v1/models/StaticMarkerAnnotation.java
+++ b/services-staticmap/src/main/java/com/mapbox/api/staticmap/v1/models/StaticMarkerAnnotation.java
@@ -50,12 +50,12 @@ public abstract class StaticMarkerAnnotation {
         Locale.US, "url-%s(%f,%f)", iconUrl(), lnglat().longitude(), lnglat().latitude());
     }
 
-    if (color() != null && label() != null && !TextUtils.isEmpty(label())) {
+    if (color() != null && !TextUtils.isEmpty(label())) {
       url = String.format(Locale.US, "%s-%s+%s", name(), label(), color());
-    } else if (label() != null && !TextUtils.isEmpty(label())) {
+    } else if (!TextUtils.isEmpty(label())) {
       url = String.format(Locale.US, "%s-%s", name(), label());
     } else if (color() != null) {
-      url = String.format(Locale.US, "%s-%s", name(), color());
+      url = String.format(Locale.US, "%s+%s", name(), color());
     } else {
       url = name();
     }


### PR DESCRIPTION
New version of Mapbox static map utils 3.x caused a few issues for us that should solve it.
Old working link from 2.x:
```
https://api.mapbox.com/styles/v1/username/styleId/static/pin-l+ff0000(-115.255990,36.263328),pin-l+ff0000(-115.255990,36.263328)/auto/800x300?access_token=token&logo=false
```
New failing link from 3.x:
```
https://api.mapbox.com/styles/v1/username/styleId/static/pin-l-ff0000(-115.255990,36.263328),null/auto/800x300?access_token=token&logo=false
```
PR contains:
- Fix string format for color
- remove useless null check - TextUtils already does that
- Fix wrong link generated when 2 pins are in the same location have same size and color - old behaviour was creating proper link, new one fails silently generating illegal url by placing null as second pin. This was the result of indexOf call which was also removed because its a waste of cpu cycles.