### PR TITLE
coordinates() should have @NotNull annotation in Geometry implementations

### DIFF
--- a/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
@@ -165,7 +165,8 @@ public abstract class Feature implements GeoJson {
    */
   public static Feature fromGeometry(@Nullable Geometry geometry, @NonNull JsonObject properties,
                                      @Nullable String id, @Nullable BoundingBox bbox) {
-    return new AutoValue_Feature(TYPE, bbox, id, geometry, properties);
+    return new AutoValue_Feature(TYPE, bbox, id, geometry,
+      properties == null ? new JsonObject() : properties);
   }
 
   /**

--- a/services-geojson/src/main/java/com/mapbox/geojson/MultiPoint.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/MultiPoint.java
@@ -130,7 +130,7 @@ public abstract class MultiPoint implements CoordinateContainer<List<Point>>, Se
    * @return a list of points
    * @since 3.0.0
    */
-  @Nullable
+  @NonNull
   @Override
   public abstract List<Point> coordinates();
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
@@ -323,7 +323,7 @@ public abstract class Polygon implements CoordinateContainer<List<List<Point>>>,
    * @return a list of points
    * @since 3.0.0
    */
-  @Nullable
+  @NonNull
   @Override
   public abstract List<List<Point>> coordinates();
 

--- a/services-geojson/src/test/java/com/mapbox/geojson/LineStringTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/LineStringTest.java
@@ -120,4 +120,10 @@ public class LineStringTest extends TestUtils {
     LineString geo = LineString.fromJson(json);
     compareJson(json, geo.toJson());
   }
+
+  @Test
+  public void fromJson_coordinatesPresent() throws Exception {
+    thrown.expect(NullPointerException.class);
+    LineString.fromJson("{\"type\":\"LineString\",\"coordinates\":null}");
+  }
 }

--- a/services-geojson/src/test/java/com/mapbox/geojson/MultiLineStringTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/MultiLineStringTest.java
@@ -6,7 +6,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import com.mapbox.core.TestUtils;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -15,6 +18,9 @@ import java.util.List;
 public class MultiLineStringTest extends TestUtils {
 
   private static final String SAMPLE_MULTILINESTRING = "sample-multilinestring.json";
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void sanity() throws Exception {
@@ -132,5 +138,11 @@ public class MultiLineStringTest extends TestUtils {
     final String json = loadJsonFixture(SAMPLE_MULTILINESTRING);
     MultiLineString geo = MultiLineString.fromJson(json);
     compareJson(json, geo.toJson());
+  }
+
+  @Test
+  public void fromJson_coordinatesPresent() throws Exception {
+    thrown.expect(NullPointerException.class);
+    MultiLineString.fromJson("{\"type\":\"MultiLineString\",\"coordinates\":null}");
   }
 }

--- a/services-geojson/src/test/java/com/mapbox/geojson/MultiPointTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/MultiPointTest.java
@@ -7,7 +7,9 @@ import static org.junit.Assert.assertNull;
 
 import com.mapbox.core.TestUtils;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -16,6 +18,9 @@ import java.util.List;
 public class MultiPointTest extends TestUtils {
 
   private static final String SAMPLE_MULTIPOINT = "sample-multipoint.json";
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void sanity() throws Exception {
@@ -105,5 +110,11 @@ public class MultiPointTest extends TestUtils {
     final String json = loadJsonFixture(SAMPLE_MULTIPOINT);
     MultiPoint geo = MultiPoint.fromJson(json);
     compareJson(json, geo.toJson());
+  }
+
+  @Test
+  public void fromJson_coordinatesPresent() throws Exception {
+    thrown.expect(NullPointerException.class);
+    MultiPoint.fromJson("{\"type\":\"MultiPoint\",\"coordinates\":null}");
   }
 }

--- a/services-geojson/src/test/java/com/mapbox/geojson/MultiPolygonTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/MultiPolygonTest.java
@@ -7,7 +7,9 @@ import static org.junit.Assert.assertNull;
 
 import com.mapbox.core.TestUtils;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -15,6 +17,9 @@ import java.util.List;
 
 public class MultiPolygonTest extends TestUtils {
   private static final String SAMPLE_MULTIPOLYGON = "sample-multipolygon.json";
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void sanity() throws Exception {
@@ -150,5 +155,11 @@ public class MultiPolygonTest extends TestUtils {
     final String json = loadJsonFixture(SAMPLE_MULTIPOLYGON);
     MultiPolygon geo = MultiPolygon.fromJson(json);
     compareJson(json, geo.toJson());
+  }
+
+  @Test
+  public void fromJson_coordinatesPresent() throws Exception {
+    thrown.expect(NullPointerException.class);
+    MultiPolygon.fromJson("{\"type\":\"MultiPolygon\",\"coordinates\":null}");
   }
 }

--- a/services-geojson/src/test/java/com/mapbox/geojson/PointTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/PointTest.java
@@ -7,7 +7,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import com.mapbox.core.TestUtils;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -16,6 +19,9 @@ import java.util.List;
 public class PointTest extends TestUtils {
 
   private static final String SAMPLE_POINT = "sample-point.json";
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void sanity() throws Exception {
@@ -60,7 +66,7 @@ public class PointTest extends TestUtils {
   }
 
   @Test
-  public void bbox_doesNotSerializeWhenNotPresent() throws Exception {
+  public void bbox_doesSerializeWhenNotPresent() throws Exception {
     Point point = Point.fromLngLat(1.0, 2.0);
     compareJson(point.toJson(),
       "{\"type\":\"Point\",\"coordinates\":[1.0, 2.0]}");
@@ -125,5 +131,11 @@ public class PointTest extends TestUtils {
     final String json = loadJsonFixture(SAMPLE_POINT);
     Point geo = Point.fromJson(json);
     compareJson(json, geo.toJson());
+  }
+
+  @Test
+  public void fromJson_coordinatesPresent() throws Exception {
+    thrown.expect(NullPointerException.class);
+    Point.fromJson("{\"type\":\"Point\",\"coordinates\":null}");
   }
 }

--- a/services-geojson/src/test/java/com/mapbox/geojson/PolygonTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/PolygonTest.java
@@ -264,4 +264,10 @@ public class PolygonTest extends TestUtils {
     Polygon geo = Polygon.fromJson(json);
     compareJson(json, geo.toJson());
   }
+
+  @Test
+  public void fromJson_coordinatesPresent() throws Exception {
+    thrown.expect(NullPointerException.class);
+    Polygon.fromJson("{\"type\":\"Polygon\",\"coordinates\":null}");
+  }
 }


### PR DESCRIPTION
coordinates() should have @NotNull annotation in Geometry implementations

closes #881 
addresses #880 