### PR TITLE
[WIP] add bicycle route options

### DIFF
--- a/services-core/src/main/java/com/mapbox/core/utils/TextUtils.java
+++ b/services-core/src/main/java/com/mapbox/core/utils/TextUtils.java
@@ -199,4 +199,24 @@ public final class TextUtils {
     }
     return TextUtils.join(";", waypointNames);
   }
+
+  /**
+   * Converts String array with waypoint types values
+   * to a string ready for API consumption.
+   * A waypoint type could be break, through or null.
+   *
+   * @param waypointTypes a string representing waypoint types to each coordinate.
+   * @return a formatted string.
+   */
+  public static String formatWaypointTypes(String[] waypointTypes) {
+    for (int i = 0; i < waypointTypes.length; i++) {
+      if (waypointTypes[i] == null) {
+        waypointTypes[i] = "";
+      } else if (!waypointTypes[i].equals("break")
+              && !waypointTypes[i].equals("through") && !waypointTypes[i].isEmpty()) {
+        return null;
+      }
+    }
+    return TextUtils.join(";", waypointTypes);
+  }
 }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
@@ -226,6 +226,41 @@ public final class DirectionsCriteria {
    */
   public static final String APPROACH_CURB = "curb";
 
+  /**
+   * Bicycle type for road bike.
+   *
+   * @since 4.1.0
+   */
+  public static final String ROAD = "Road";
+
+  /**
+   * Bicycle type for hybrid bike.
+   *
+   * @since 4.1.0
+   */
+  public static final String HYBRID = "Hybrid";
+
+  /**
+   * Bicycle type for city bike.
+   *
+   * @since 4.1.0
+   */
+  public static final String CITY = "City";
+
+  /**
+   * Bicycle type for cross bike.
+   *
+   * @since 4.1.0
+   */
+  public static final String CROSS = "Cross";
+
+  /**
+   * Bicycle type for mountain bike.
+   *
+   * @since 4.1.0
+   */
+  public static final String MOUNTAIN = "Mountain";
+
   private DirectionsCriteria() {
     //not called
   }
@@ -355,5 +390,21 @@ public final class DirectionsCriteria {
     APPROACH_CURB
   })
   public @interface ApproachesCriteria {
+  }
+
+  /**
+   * Retention policy for the bicycle type parameter in the Directions API.
+   *
+   * @since 4.1.0
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @StringDef( {
+          ROAD,
+          HYBRID,
+          CITY,
+          CROSS,
+          MOUNTAIN
+  })
+  public @interface BicycleType {
   }
 }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
@@ -261,6 +261,16 @@ public final class DirectionsCriteria {
    */
   public static final String MOUNTAIN = "Mountain";
 
+  /**
+   * Break waypoint type.
+   */
+  public static final String BREAK = "break";
+
+  /**
+   * Through waypoint type.
+   */
+  public static final String THROUGH = "through";
+
   private DirectionsCriteria() {
     //not called
   }
@@ -406,5 +416,16 @@ public final class DirectionsCriteria {
           MOUNTAIN
   })
   public @interface BicycleType {
+  }
+
+  /**
+   * Retention policy for the waypoint type parameter in the Directions API.
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @StringDef( {
+          BREAK,
+          THROUGH
+  })
+  public @interface WaypointType {
   }
 }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
@@ -1,7 +1,6 @@
 package com.mapbox.api.directions.v5;
 
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
-
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
@@ -46,7 +45,15 @@ public interface DirectionsService {
    * @param voiceUnits         voice units
    * @param exclude            exclude tolls, motorways or more along your route
    * @param approaches         which side of the road to approach a waypoint
-   * @param waypointNames     custom names for waypoints used for the arrival instruction.
+   * @param waypointNames      custom names for waypoints used for the arrival instruction.
+   * @param bicycleType        The type of bicycle, either `Road`, `Hybrid`, `City`, `Cross`,
+   *                           `Mountain`.
+   * @param cyclingSpeed       Cycling speed is the average travel speed along smooth, flat roads.
+   * @param useRoads           A cyclist's propensity to use roads alongside other vehicles
+   * @param useHills           A cyclist's desire to tackle hills in their routes
+   * @param useFerry           This value indicates the willingness to take ferries
+   * @param avoidBadSurfaces   This value is meant to represent how much a cyclist wants to avoid
+   *                           roads with poor surfaces
    * @return the {@link DirectionsResponse} in a Call wrapper
    * @since 1.0.0
    */
@@ -72,6 +79,12 @@ public interface DirectionsService {
     @Query("voice_units") String voiceUnits,
     @Query("exclude") String exclude,
     @Query("approaches") String approaches,
-    @Query("waypoint_names") String waypointNames
+    @Query("waypoint_names") String waypointNames,
+    @Query("bicycle_type") String bicycleType,
+    @Query("cycling_speed") Float cyclingSpeed,
+    @Query("use_roads") Float useRoads,
+    @Query("use_hills") Float useHills,
+    @Query("use_ferry") Float useFerry,
+    @Query("avoid_bad_surfaces") Float avoidBadSurfaces
   );
 }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
@@ -54,6 +54,7 @@ public interface DirectionsService {
    * @param useFerry           This value indicates the willingness to take ferries
    * @param avoidBadSurfaces   This value is meant to represent how much a cyclist wants to avoid
    *                           roads with poor surfaces
+   * @param waypointTypes      types for waypoints
    * @return the {@link DirectionsResponse} in a Call wrapper
    * @since 1.0.0
    */
@@ -85,6 +86,7 @@ public interface DirectionsService {
     @Query("use_roads") Float useRoads,
     @Query("use_hills") Float useHills,
     @Query("use_ferry") Float useFerry,
-    @Query("avoid_bad_surfaces") Float avoidBadSurfaces
+    @Query("avoid_bad_surfaces") Float avoidBadSurfaces,
+    @Query("waypoint_types") String waypointTypes
   );
 }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
 import com.mapbox.api.directions.v5.DirectionsCriteria.AnnotationCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.ExcludeCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.GeometriesCriteria;
@@ -87,7 +88,13 @@ public abstract class MapboxDirections extends
       voiceUnits(),
       exclude(),
       approaches(),
-      waypointNames());
+      waypointNames(),
+      bicycleType(),
+      cyclingSpeed(),
+      useRoads(),
+      useHills(),
+      useFerry(),
+      avoidBadSurfaces());
   }
 
   @Override
@@ -206,6 +213,12 @@ public abstract class MapboxDirections extends
           .profile(profile())
           .coordinates(coordinates())
           .waypointNames(waypointNames())
+          .bicycleType(bicycleType())
+          .cyclingSpeed(cyclingSpeed())
+          .useRoads(useRoads())
+          .useHills(useHills())
+          .useFerry(useFerry())
+          .avoidBadSurfaces(avoidBadSurfaces())
           .continueStraight(continueStraight())
           .annotations(annotation())
           .approaches(approaches())
@@ -308,6 +321,93 @@ public abstract class MapboxDirections extends
 
   @Nullable
   abstract String waypointNames();
+
+  /**
+   * The type of bicycle, either `Road`, `Hybrid`, `City`, `Cross`, `Mountain`. The default type is
+   * Hybrid.
+   *
+   * @return the type of bicycle
+   * @since 4.1.0
+   */
+  @SerializedName("bicycle_type")
+  @DirectionsCriteria.BicycleType
+  @Nullable
+  abstract String bicycleType();
+
+  /**
+   * Cycling speed is the average travel speed along smooth, flat roads. This is meant to be the
+   * speed a rider can comfortably maintain over the desired distance of the route. It can be
+   * modified (in the costing method) by surface type in conjunction with bicycle type and
+   * (coming soon) by hilliness of the road section. When no speed is specifically provided, the
+   * default speed is determined by the bicycle type and are as follows: Road = 25 KPH (15.5 MPH),
+   * Cross = 20 KPH (13 MPH), Hybrid/City = 18 KPH (11.5 MPH), and Mountain = 16 KPH (10 MPH).
+   *
+   * @return the cycling speed in kmh
+   * @since 4.1.0
+   */
+  @SerializedName("cycling_speed")
+  @Nullable
+  abstract Float cyclingSpeed();
+
+  /**
+   * A cyclist's propensity to use roads alongside other vehicles. This is a range of values from 0
+   * to 1, where 0 attempts to avoid roads and stay on cycleways and paths, and 1 indicates the
+   * rider is more comfortable riding on roads. Based on the use_roads factor, roads with certain
+   * classifications and higher speeds are penalized in an attempt to avoid them when finding the
+   * best path. The default value is 0.5.
+   *
+   * @return a cyclist's propensity to use roads alongside other vehicles
+   * @since 4.1.0
+   */
+  @SerializedName("use_roads")
+  @Nullable
+  abstract Float useRoads();
+
+  /**
+   * A cyclist's desire to tackle hills in their routes. This is a range of values from 0 to 1,
+   * where 0 attempts to avoid hills and steep grades even if it means a longer (time and
+   * distance) path, while 1 indicates the rider does not fear hills and steeper grades. Based on
+   * the use_hills factor, penalties are applied to roads based on elevation change and grade.
+   * These penalties help the path avoid hilly roads in favor of flatter roads or less steep
+   * grades where available. Note that it is not always possible to find alternate paths to avoid
+   * hills (for example when route locations are in mountainous areas). The default value is 0.5.
+   *
+   * @return a cyclist's desire to tackle hills in their routes
+   * @since 4.1.0
+   */
+  @SerializedName("use_hills")
+  @Nullable
+  abstract Float useHills();
+
+  /**
+   * This value indicates the willingness to take ferries. This is a range of values between 0 and
+   * 1. Values near 0 attempt to avoid ferries and values near 1 will favor ferries. Note that
+   * sometimes ferries are required to complete a route so values of 0 are not guaranteed to avoid
+   * ferries entirely.
+   * The default value is 0.5.
+   *
+   * @return the willingness to take ferries
+   * @since 4.1.0
+   */
+  @SerializedName("use_ferry")
+  @Nullable
+  abstract Float useFerry();
+
+  /**
+   * This value is meant to represent how much a cyclist wants to avoid roads with poor surfaces
+   * relative to the bicycle type being used. This is a range of values between 0 and 1. When the
+   * value is 0, there is no penalization of roads with different surface types; only bicycle
+   * speed on each surface is taken into account. As the value approaches 1, roads with poor
+   * surfaces for the bike are penalized heavier so that they are only taken if they
+   * significantly improve travel time. When the value is equal to 1, all bad surfaces are
+   * completely disallowed from routing, including start and end points. The default value is 0.25.
+   *
+   * @return how much a cyclist wants to avoid roads with poor surfaces
+   * @since 4.1.0
+   */
+  @SerializedName("avoid_bad_surfaces")
+  @Nullable
+  abstract Float avoidBadSurfaces();
 
   /**
    * Build a new {@link MapboxDirections} object with the initial values set for
@@ -728,6 +828,97 @@ public abstract class MapboxDirections extends
     }
 
     abstract Builder waypointNames(@Nullable String waypointNames);
+
+    /**
+     * The type of bicycle, either `Road`, `Hybrid`, `City`, `Cross`, `Mountain`. The default type
+     * is Hybrid.
+     *
+     * @param bicycleType the type of bicycle
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder bicycleType(
+            @DirectionsCriteria.BicycleType @Nullable String bicycleType);
+
+    /**
+     * Cycling speed is the average travel speed along smooth, flat roads. This is meant to be the
+     * speed a rider can comfortably maintain over the desired distance of the route. It can be
+     * modified (in the costing method) by surface type in conjunction with bicycle type and
+     * (coming soon) by hilliness of the road section. When no speed is specifically provided,
+     * the default speed is determined by the bicycle type and are as follows: Road = 25 KPH (15
+     * .5 MPH), Cross = 20 KPH (13 MPH), Hybrid/City = 18 KPH (11.5 MPH), and Mountain = 16 KPH
+     * (10 MPH).
+     *
+     * @param cyclingSpeed in kmh
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder cyclingSpeed(
+            @Nullable @FloatRange(from = 5, to = 60) Float cyclingSpeed);
+
+    /**
+     * A cyclist's propensity to use roads alongside other vehicles. This is a range of values from
+     * 0 to 1, where 0 attempts to avoid roads and stay on cycleways and paths, and 1 indicates
+     * the rider is more comfortable riding on roads. Based on the use_roads factor, roads with
+     * certain classifications and higher speeds are penalized in an attempt to avoid them when
+     * finding the best path. The default value is 0.5.
+     *
+     * @param useRoads a cyclist's propensity to use roads alongside other vehicles
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder useRoads(@Nullable @FloatRange(from = 0.0, to = 1.0) Float useRoads);
+
+    /**
+     * A cyclist's desire to tackle hills in their routes. This is a range of values from 0 to 1,
+     * where 0 attempts to avoid hills and steep grades even if it means a longer (time and
+     * distance) path, while 1 indicates the rider does not fear hills and steeper grades. Based
+     * on the use_hills factor, penalties are applied to roads based on elevation change and
+     * grade. These penalties help the path avoid hilly roads in favor of flatter roads or less
+     * steep grades where available. Note that it is not always possible to find alternate paths
+     * to avoid hills (for example when route locations are in mountainous areas). The default
+     * value is 0.5.
+     *
+     * @param useHills a cyclist's desire to tackle hills in their routes
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder useHills(@Nullable @FloatRange(from = 0.0, to = 1.0) Float useHills);
+
+    /**
+     * This value indicates the willingness to take ferries. This is a range of values between 0 and
+     * 1. Values near 0 attempt to avoid ferries and values near 1 will favor ferries. Note that
+     * sometimes ferries are required to complete a route so values of 0 are not guaranteed to
+     * avoid ferries entirely. The default value is 0.5.
+     *
+     * @param useFerry the willingness to take ferries
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder useFerry(@Nullable @FloatRange(from = 0.0, to = 1.0) Float useFerry);
+
+    /**
+     * This value is meant to represent how much a cyclist wants to avoid roads with poor surfaces
+     * relative to the bicycle type being used. This is a range of values between 0 and 1. When
+     * the value is 0, there is no penalization of roads with different surface types; only
+     * bicycle speed on each surface is taken into account. As the value approaches 1, roads with
+     * poor surfaces for the bike are penalized heavier so that they are only taken if they
+     * significantly improve travel time. When the value is equal to 1, all bad surfaces are
+     * completely disallowed from routing, including start and end points. The default value is 0
+     * .25.
+     *
+     * @param avoidBadSurfaces how much a cyclist wants to avoid roads with poor surfaces
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder avoidBadSurfaces(
+            @Nullable @FloatRange(from = 0.0, to = 1.0) Float avoidBadSurfaces);
 
     abstract MapboxDirections autoBuild();
 

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -1,5 +1,6 @@
 package com.mapbox.api.directions.v5.models;
 
+import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -272,12 +273,99 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * each separated by  ; . Values can be any string and total number of all characters cannot
    * exceed 500. If provided, the list of waypoint_names must be the same length as the list of
    * coordinates, but you can skip a coordinate and show its position with the  ; separator.
-   * @return  a string representing names for each waypoint
+   *
+   * @return a string representing names for each waypoint
    * @since 3.3.0
    */
   @SerializedName("waypoint_names")
   @Nullable
   public abstract String waypointNames();
+
+  /**
+   * The type of bicycle, either `Road`, `Hybrid`, `City`, `Cross`, `Mountain`. The default type is
+   * Hybrid.
+   *
+   * @return the type of bicycle
+   * @since 4.1.0
+   */
+  @SerializedName("bicycle_type")
+  @Nullable
+  public abstract String bicycleType();
+
+  /**
+   * Cycling speed is the average travel speed along smooth, flat roads. This is meant to be the
+   * speed a rider can comfortably maintain over the desired distance of the route. It can be
+   * modified (in the costing method) by surface type in conjunction with bicycle type and
+   * (coming soon) by hilliness of the road section. When no speed is specifically provided, the
+   * default speed is determined by the bicycle type and are as follows: Road = 25 KPH (15.5 MPH),
+   * Cross = 20 KPH (13 MPH), Hybrid/City = 18 KPH (11.5 MPH), and Mountain = 16 KPH (10 MPH).
+   *
+   * @return the cycling speed in kmh
+   * @since 4.1.0
+   */
+  @SerializedName("cycling_speed")
+  @Nullable
+  public abstract Float cyclingSpeed();
+
+  /**
+   * A cyclist's propensity to use roads alongside other vehicles. This is a range of values from 0
+   * to 1, where 0 attempts to avoid roads and stay on cycleways and paths, and 1 indicates the
+   * rider is more comfortable riding on roads. Based on the use_roads factor, roads with certain
+   * classifications and higher speeds are penalized in an attempt to avoid them when finding the
+   * best path. The default value is 0.5.
+   *
+   * @return a cyclist's propensity to use roads alongside other vehicles
+   * @since 4.1.0
+   */
+  @SerializedName("use_roads")
+  @Nullable
+  public abstract Float useRoads();
+
+  /**
+   * A cyclist's desire to tackle hills in their routes. This is a range of values from 0 to 1,
+   * where 0 attempts to avoid hills and steep grades even if it means a longer (time and
+   * distance) path, while 1 indicates the rider does not fear hills and steeper grades. Based on
+   * the use_hills factor, penalties are applied to roads based on elevation change and grade.
+   * These penalties help the path avoid hilly roads in favor of flatter roads or less steep
+   * grades where available. Note that it is not always possible to find alternate paths to avoid
+   * hills (for example when route locations are in mountainous areas). The default value is 0.5.
+   *
+   * @return a cyclist's desire to tackle hills in their routes
+   * @since 4.1.0
+   */
+  @SerializedName("use_hills")
+  @Nullable
+  public abstract Float useHills();
+
+  /**
+   * This value indicates the willingness to take ferries. This is a range of values between 0 and
+   * 1. Values near 0 attempt to avoid ferries and values near 1 will favor ferries. Note that
+   * sometimes ferries are required to complete a route so values of 0 are not guaranteed to avoid
+   * ferries entirely.
+   * The default value is 0.5.
+   *
+   * @return the willingness to take ferries
+   * @since 4.1.0
+   */
+  @SerializedName("use_ferry")
+  @Nullable
+  public abstract Float useFerry();
+
+  /**
+   * This value is meant to represent how much a cyclist wants to avoid roads with poor surfaces
+   * relative to the bicycle type being used. This is a range of values between 0 and 1. When the
+   * value is 0, there is no penalization of roads with different surface types; only bicycle
+   * speed on each surface is taken into account. As the value approaches 1, roads with poor
+   * surfaces for the bike are penalized heavier so that they are only taken if they
+   * significantly improve travel time. When the value is equal to 1, all bad surfaces are
+   * completely disallowed from routing, including start and end points. The default value is 0.25.
+   *
+   * @return how much a cyclist wants to avoid roads with poor surfaces
+   * @since 4.1.0
+   */
+  @SerializedName("avoid_bad_surfaces")
+  @Nullable
+  public abstract Float avoidBadSurfaces();
 
 
   /**
@@ -521,7 +609,6 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 3.2.0
      */
-
     @Nullable
     public abstract Builder approaches(String approaches);
 
@@ -532,9 +619,98 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 3.3.0
      */
-
     @Nullable
     public abstract Builder waypointNames(@Nullable String waypointNames);
+
+    /**
+     * The type of bicycle, either `Road`, `Hybrid`, `City`, `Cross`, `Mountain`. The default type
+     * is Hybrid.
+     *
+     * @param bicycleType the type of bicycle
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder bicycleType(@Nullable String bicycleType);
+
+    /**
+     * Cycling speed is the average travel speed along smooth, flat roads. This is meant to be the
+     * speed a rider can comfortably maintain over the desired distance of the route. It can be
+     * modified (in the costing method) by surface type in conjunction with bicycle type and
+     * (coming soon) by hilliness of the road section. When no speed is specifically provided,
+     * the default speed is determined by the bicycle type and are as follows: Road = 25 KPH (15
+     * .5 MPH), Cross = 20 KPH (13 MPH), Hybrid/City = 18 KPH (11.5 MPH), and Mountain = 16 KPH
+     * (10 MPH).
+     *
+     * @param cyclingSpeed in kmh
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder cyclingSpeed(
+            @Nullable @FloatRange(from = 5, to = 60) Float cyclingSpeed);
+
+    /**
+     * A cyclist's propensity to use roads alongside other vehicles. This is a range of values from
+     * 0 to 1, where 0 attempts to avoid roads and stay on cycleways and paths, and 1 indicates
+     * the rider is more comfortable riding on roads. Based on the use_roads factor, roads with
+     * certain classifications and higher speeds are penalized in an attempt to avoid them when
+     * finding the best path. The default value is 0.5.
+     *
+     * @param useRoads a cyclist's propensity to use roads alongside other vehicles
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder useRoads(@Nullable @FloatRange(from = 0.0, to = 1.0) Float useRoads);
+
+    /**
+     * A cyclist's desire to tackle hills in their routes. This is a range of values from 0 to 1,
+     * where 0 attempts to avoid hills and steep grades even if it means a longer (time and
+     * distance) path, while 1 indicates the rider does not fear hills and steeper grades. Based
+     * on the use_hills factor, penalties are applied to roads based on elevation change and
+     * grade. These penalties help the path avoid hilly roads in favor of flatter roads or less
+     * steep grades where available. Note that it is not always possible to find alternate paths
+     * to avoid hills (for example when route locations are in mountainous areas). The default
+     * value is 0.5.
+     *
+     * @param useHills a cyclist's desire to tackle hills in their routes
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder useHills(@Nullable @FloatRange(from = 0.0, to = 1.0) Float useHills);
+
+    /**
+     * This value indicates the willingness to take ferries. This is a range of values between 0 and
+     * 1. Values near 0 attempt to avoid ferries and values near 1 will favor ferries. Note that
+     * sometimes ferries are required to complete a route so values of 0 are not guaranteed to
+     * avoid ferries entirely. The default value is 0.5.
+     *
+     * @param useFerry the willingness to take ferries
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder useFerry(@Nullable @FloatRange(from = 0.0, to = 1.0) Float useFerry);
+
+    /**
+     * This value is meant to represent how much a cyclist wants to avoid roads with poor surfaces
+     * relative to the bicycle type being used. This is a range of values between 0 and 1. When
+     * the value is 0, there is no penalization of roads with different surface types; only
+     * bicycle speed on each surface is taken into account. As the value approaches 1, roads with
+     * poor surfaces for the bike are penalized heavier so that they are only taken if they
+     * significantly improve travel time. When the value is equal to 1, all bad surfaces are
+     * completely disallowed from routing, including start and end points. The default value is 0
+     * .25.
+     *
+     * @param avoidBadSurfaces how much a cyclist wants to avoid roads with poor surfaces
+     * @return this builder for chaining options together
+     * @since 4.1.0
+     */
+    @Nullable
+    public abstract Builder avoidBadSurfaces(
+            @Nullable @FloatRange(from = 0.0, to = 1.0) Float avoidBadSurfaces);
 
     /**
      * Builds a new instance of the {@link RouteOptions} object.

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -367,6 +367,20 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   @Nullable
   public abstract Float avoidBadSurfaces();
 
+  /**
+   * Type of location, accepts  break (default), through or null. A break is a stop,
+   * so the first and last locations must be of type break. A through location is one
+   * that the route path travels through, and is useful to force a route to go through location.
+   * The path is not allowed to reverse direction at the through locations.
+   * If no type is provided, the type is assumed to be a break.
+   * If provided, the list of waypoint types must be the same length as the list of waypoints.
+   * However, you can skip a coordinate and show its position in the list with the ; separator.
+   *
+   * @return a string representing waypoint types for each waypoint
+   */
+  @SerializedName("waypoint_types")
+  @Nullable
+  public abstract String waypointTypes();
 
   /**
    * Gson type adapter for parsing Gson to this class.
@@ -711,6 +725,15 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     @Nullable
     public abstract Builder avoidBadSurfaces(
             @Nullable @FloatRange(from = 0.0, to = 1.0) Float avoidBadSurfaces);
+
+    /**
+     * The same waypoint types the user originally made when the request was made.
+     *
+     * @param waypointTypes break, through or omitted (;)
+     * @return this builder for chaining options together
+     */
+    @Nullable
+    public abstract Builder waypointTypes(@Nullable String waypointTypes);
 
     /**
      * Builds a new instance of the {@link RouteOptions} object.

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -24,6 +24,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import retrofit2.Response;
 
+import static com.mapbox.api.directions.v5.DirectionsCriteria.ROAD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -190,6 +191,119 @@ public class RouteOptionsTest extends TestUtils {
     DirectionsRoute route = response.body().routes().get(0);
 
     assertEquals(DirectionsCriteria.OVERVIEW_SIMPLIFIED, route.routeOptions().overview());
+  }
+
+  @Test
+  public void directionsRequestResult_doesContainBicycleType() throws Exception {
+    Response<DirectionsResponse> response = MapboxDirections.builder()
+            .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
+            .baseUrl(mockUrl.toString())
+            .accessToken(ACCESS_TOKEN)
+            .origin(Point.fromLngLat(1.0, 1.0))
+            .destination(Point.fromLngLat(5.0, 5.0))
+            .profile(DirectionsCriteria.PROFILE_WALKING)
+            .continueStraight(false)
+            .language(Locale.CANADA)
+            .bicycleType(ROAD)
+            .alternatives(true).build().executeCall();
+    DirectionsRoute route = response.body().routes().get(0);
+
+    assertEquals(ROAD, route.routeOptions().bicycleType());
+  }
+
+  @Test
+  public void directionsRequestResult_doesContainCyclingSpeed() throws Exception {
+    Float cyclingSpeed = 10f;
+    Response<DirectionsResponse> response = MapboxDirections.builder()
+            .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
+            .baseUrl(mockUrl.toString())
+            .accessToken(ACCESS_TOKEN)
+            .origin(Point.fromLngLat(1.0, 1.0))
+            .destination(Point.fromLngLat(5.0, 5.0))
+            .profile(DirectionsCriteria.PROFILE_WALKING)
+            .continueStraight(false)
+            .language(Locale.CANADA)
+            .cyclingSpeed(cyclingSpeed)
+            .alternatives(true).build().executeCall();
+    DirectionsRoute route = response.body().routes().get(0);
+
+    assertEquals(cyclingSpeed, route.routeOptions().cyclingSpeed());
+  }
+
+  @Test
+  public void directionsRequestResult_doesContainUseRoads() throws Exception {
+    Float useRoads = .5f;
+    Response<DirectionsResponse> response = MapboxDirections.builder()
+            .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
+            .baseUrl(mockUrl.toString())
+            .accessToken(ACCESS_TOKEN)
+            .origin(Point.fromLngLat(1.0, 1.0))
+            .destination(Point.fromLngLat(5.0, 5.0))
+            .profile(DirectionsCriteria.PROFILE_WALKING)
+            .continueStraight(false)
+            .language(Locale.CANADA)
+            .useRoads(useRoads)
+            .alternatives(true).build().executeCall();
+    DirectionsRoute route = response.body().routes().get(0);
+
+    assertEquals(useRoads, route.routeOptions().useRoads());
+  }
+
+  @Test
+  public void directionsRequestResult_doesContainUseHills() throws Exception {
+    Float useHills = .5f;
+    Response<DirectionsResponse> response = MapboxDirections.builder()
+            .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
+            .baseUrl(mockUrl.toString())
+            .accessToken(ACCESS_TOKEN)
+            .origin(Point.fromLngLat(1.0, 1.0))
+            .destination(Point.fromLngLat(5.0, 5.0))
+            .profile(DirectionsCriteria.PROFILE_WALKING)
+            .continueStraight(false)
+            .language(Locale.CANADA)
+            .useHills(useHills)
+            .alternatives(true).build().executeCall();
+    DirectionsRoute route = response.body().routes().get(0);
+
+    assertEquals(useHills, route.routeOptions().useHills());
+  }
+
+  @Test
+  public void directionsRequestResult_doesContainUseFerry() throws Exception {
+    Float useFerry = .5f;
+    Response<DirectionsResponse> response = MapboxDirections.builder()
+            .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
+            .baseUrl(mockUrl.toString())
+            .accessToken(ACCESS_TOKEN)
+            .origin(Point.fromLngLat(1.0, 1.0))
+            .destination(Point.fromLngLat(5.0, 5.0))
+            .profile(DirectionsCriteria.PROFILE_WALKING)
+            .continueStraight(false)
+            .language(Locale.CANADA)
+            .useFerry(useFerry)
+            .alternatives(true).build().executeCall();
+    DirectionsRoute route = response.body().routes().get(0);
+
+    assertEquals(useFerry, route.routeOptions().useFerry());
+  }
+
+  @Test
+  public void directionsRequestResult_doesContainAvoidBadSurfaces() throws Exception {
+    Float avoidBadSurfaces = .5f;
+    Response<DirectionsResponse> response = MapboxDirections.builder()
+            .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
+            .baseUrl(mockUrl.toString())
+            .accessToken(ACCESS_TOKEN)
+            .origin(Point.fromLngLat(1.0, 1.0))
+            .destination(Point.fromLngLat(5.0, 5.0))
+            .profile(DirectionsCriteria.PROFILE_WALKING)
+            .continueStraight(false)
+            .language(Locale.CANADA)
+            .avoidBadSurfaces(avoidBadSurfaces)
+            .alternatives(true).build().executeCall();
+    DirectionsRoute route = response.body().routes().get(0);
+
+    assertEquals(avoidBadSurfaces, route.routeOptions().avoidBadSurfaces());
   }
 
   @Test


### PR DESCRIPTION
This is a WIP for adding bicycle route options, but I think we need to get the backend for live requests running first because bicycle costing options are currently only working on offline (So they wouldn't even go through MAS as far as I know).

Closes #900