### PR TITLE
Archive stale issues and pull request

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+exemptProjects: false
+exemptMilestones: false
+
+staleLabel: Archived
+
+limitPerRun: 1
+
+pulls:
+  daysUntilStale: 60
+  closeComment: >
+    This pull request has been automatically detected as stale because it has not had
+    recent activity and will be archived. Thank you for your contributions.
+
+issues:
+  daysUntilStale: 180
+  closeComment: >
+    This issue has been automatically detected as stale because it has not had
+    recent activity and will be archived. Thank you for your contributions.


### PR DESCRIPTION
Enable a bot that will automatically archive issues older than 6 months or PR older than 2 months.

The bot will run every our and will archive one single issue per hour.

Archived issues will be labeled as "archived" and can be reopened if needed. Commenting on the issue or PR or simply updating the PR branch is enough to count as "activity" and reset the stale counter.