### PR TITLE
Adding code coverage report generation and upload to Codecov

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
     classpath pluginDependencies.errorprone
     classpath pluginDependencies.sonarqube
     classpath pluginDependencies.buildConfig
+    classpath pluginDependencies.jacoco
   }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,12 @@ jobs:
           path: mapbox/app/build/reports
           destination: reports
       - store_test_results:
-          path: mapbox/app/build/test-results
+          path: mapbox/app/build/test-results    
+      - run:
+          name: Post code coverage report to Codecov.io
+          command: |
+            bash <(curl -s https://codecov.io/bash)
+
 
 # ------------------------------------------------------------------------------
   release:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@ ext {
 
   pluginVersion = [
       checkstyle : '8.11.0',
-      jacoco     : '0.8.1',
+      jacoco     : '0.13.0',
       errorprone : '0.0.14',
       spotbugs   : '1.3',
       sonarqube  : '2.5',
@@ -46,6 +46,7 @@ ext {
       sonarqube  : "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${pluginVersion.sonarqube}",
       errorprone : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
       buildConfig: "gradle.plugin.de.fuerstenau:BuildConfigPlugin:${pluginVersion.buildConfig}",
-      dependencyGraph: "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}"
+      dependencyGraph: "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
+      jacoco     : "com.vanniktech:gradle-android-junit-jacoco-plugin:${pluginVersion.jacoco}"
   ]
 }

--- a/services-core/build.gradle
+++ b/services-core/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'de.fuerstenau.buildconfig'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 configurations {
   testOutput

--- a/services-directions/build.gradle
+++ b/services-directions/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
   api project(":services-core")

--- a/services-geocoding/build.gradle
+++ b/services-geocoding/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
 

--- a/services-geojson/build.gradle
+++ b/services-geojson/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
   // Gson

--- a/services-matching/build.gradle
+++ b/services-matching/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
   api project(":services-directions")

--- a/services-matrix/build.gradle
+++ b/services-matrix/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
   api project(":services-directions")

--- a/services-optimization/build.gradle
+++ b/services-optimization/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
   api project(":services-directions")

--- a/services-route-tiles/build.gradle
+++ b/services-route-tiles/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
     api project(":services-core")

--- a/services-speech/build.gradle
+++ b/services-speech/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
     api project(":services-core")

--- a/services-staticmap/build.gradle
+++ b/services-staticmap/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
   api project(":services-core")

--- a/services-tilequery/build.gradle
+++ b/services-tilequery/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
     api project(":services-core")

--- a/services-turf/build.gradle
+++ b/services-turf/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 dependencies {
   api project(":services-core")

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 sourceSets {
     main.java.srcDirs = ['../services-directions/src/main/java', '../services-geocoding/src/main/java',


### PR DESCRIPTION
cc @springmeyer 

This pr adds the ability to generate code coverage reports and then upload those reports to our [Codecov](https://codecov.io/) account.

Running `./gradlew jacocoTestReport` was already possible on `master`, but that Gradle command didn't produce any code coverage reports. This pr implements https://github.com/vanniktech/gradle-android-junit-jacoco-plugin to successfully generate JaCoCo test reports 👇 . This Gradle plugin is the same one that easily creates reports in the China plugin repo.

<img width="475" alt="screen shot 2018-11-27 at 4 25 08 pm" src="https://user-images.githubusercontent.com/4394910/49120358-169df400-f261-11e8-8650-1a100d365feb.png">
<img width="1181" alt="screen shot 2018-11-27 at 4 25 26 pm" src="https://user-images.githubusercontent.com/4394910/49120359-1998e480-f261-11e8-8d71-ebf46ba700a2.png">
<img width="1154" alt="screen shot 2018-11-27 at 4 26 08 pm" src="https://user-images.githubusercontent.com/4394910/49120378-2c131e00-f261-11e8-823a-e41e9f04deb2.png">


<img width="1153" alt="screen shot 2018-11-27 at 4 32 14 pm" src="https://user-images.githubusercontent.com/4394910/49120573-0a666680-f262-11e8-81ac-99fa6a62822a.png">

