### PR TITLE
Remove waypoint limit check

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -421,10 +421,6 @@ public abstract class MapboxDirections extends
      * @since 3.0.0
      */
     public Builder addWaypoint(@NonNull Point waypoint) {
-      if (coordinates.size() > 23) {
-        throw new ServicesException("A max of 25 coordinates including the origin and destination"
-          + "values can be used inside your request.");
-      }
       coordinates.add(waypoint);
       return this;
     }

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -119,17 +119,6 @@ public class MapboxDirectionsTest extends TestUtils {
   }
 
   @Test
-  public void addWaypoint_maxWaypointsAdded() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage("A max of 25 coordinates including the origin and destination");
-    MapboxDirections.Builder mapboxDirectionsBuilder = MapboxDirections.builder();
-    for (int i = 0; i < 25; i++) {
-      mapboxDirectionsBuilder.addWaypoint(Point.fromLngLat(i, i + 1));
-    }
-    mapboxDirectionsBuilder.accessToken(ACCESS_TOKEN).build().executeCall();
-  }
-
-  @Test
   public void build_noAccessTokenExceptionThrown() throws Exception {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Missing required properties: accessToken");


### PR DESCRIPTION
- Remove waypoint limit check - there is no such a limitation for offline routes (`MapboxDirections` is used to generate offline routes URLs). For online, we're still accounting for that because the Directions API will throw an error which is handled gracefully by `MapboxDirections`.

cc @osana 