### PR TITLE
Remove coordinate limit from MapboxMapMatching

### DIFF
--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
@@ -697,10 +697,6 @@ public abstract class MapboxMapMatching extends
           + " request.");
       }
 
-      if (coordinates.size() > 100) {
-        throw new ServicesException("Maximum of 100 coordinates are allowed for this API.");
-      }
-
       if (radiuses != null && radiuses.length != coordinates.size()) {
         throw new ServicesException(
           "There must be as many radiuses as there are coordinates.");

--- a/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
+++ b/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
@@ -117,23 +117,6 @@ public class MapboxMapMatchingTest extends TestUtils {
   }
 
   @Test
-  public void build_throwsExceptionWhenCoordsOverOneHundred() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Maximum of 100 coordinates are allowed for this API."));
-    List<Point> coordinates = new ArrayList<>();
-    for (int i = 0; i < 101; i++) {
-      coordinates.add(Point.fromLngLat(1.0 + i, 2.0 + i));
-    }
-    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
-      .coordinates(coordinates)
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .build();
-    mapMatching.executeCall();
-  }
-
-  @Test
   public void build_throwsExceptionWhenNotMatchingRadiusesForEachCoord() throws Exception {
     thrown.expect(ServicesException.class);
     thrown.expectMessage(


### PR DESCRIPTION
This PR removes the hard-coded check for a max of 100 coordinates in `MapboxMapMatching`.  Developers are able to pay for and configure higher coordinate limits, so we shouldn't enforce this in the java code - the error code / message will still be returned from the server. 

cc @kbauhaus @Guardiola31337 