### PR TITLE
Remove character waypoint names limit from MapboxMapMatching and MapboxDirections

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -754,9 +754,6 @@ public abstract class MapboxDirections extends
             + " the number of waypoints provided.");
         }
         final String waypointNamesStr = TextUtils.formatWaypointNames(waypointNames);
-        if (!waypointNamesStr.isEmpty() && waypointNamesStr.length() > 500) {
-          throw new ServicesException("Waypoint names exceed 500 character limit.");
-        }
         waypointNames(waypointNamesStr);
       }
 

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -681,37 +681,6 @@ public class MapboxDirectionsTest extends TestUtils {
   }
 
   @Test
-  public void build_exceptionThrownWhenWaypointNamesExceedLimit() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Waypoint names exceed 500 character limit"));
-
-    StringBuilder longWpName = new StringBuilder();
-    for (int i = 0; i < 124; i++) {
-      longWpName.append("Home");
-    }
-    MapboxDirections mapboxDirections = MapboxDirections.builder()
-      .origin(Point.fromLngLat(2.0, 2.0))
-      .destination(Point.fromLngLat(4.0, 4.0))
-      .addWaypointNames(longWpName.toString(), "Work")
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .build();
-
-    assertTrue(mapboxDirections.cloneCall().request().url().toString()
-      .contains("waypoint_names=Home"));
-
-    // one more char results in exception
-    mapboxDirections = MapboxDirections.builder()
-      .origin(Point.fromLngLat(2.0, 2.0))
-      .destination(Point.fromLngLat(4.0, 4.0))
-      .addWaypointNames(longWpName.toString(), "Work1")
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .build();
-  }
-
-  @Test
   public void testWithWaypointNames() throws Exception {
 
     MapboxDirections mapboxDirections = MapboxDirections.builder()

--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
@@ -731,9 +731,6 @@ public abstract class MapboxMapMatching extends
             + " the number of waypoints provided.");
         }
         final String waypointNamesStr = TextUtils.formatWaypointNames(waypointNames);
-        if (!waypointNamesStr.isEmpty() && waypointNamesStr.length() > 500) {
-          throw new ServicesException("Waypoint names exceed 500 character limit.");
-        }
         waypointNames(waypointNamesStr);
       }
 

--- a/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
+++ b/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
@@ -651,39 +651,6 @@ public class MapboxMapMatchingTest extends TestUtils {
   }
 
   @Test
-  public void build_exceptionThrownWhenWaypointNamesExceedLimit() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Waypoint names exceed 500 character limit"));
-
-    StringBuilder longWpName = new StringBuilder();
-    for (int i = 0; i < 124; i++) {
-      longWpName.append("Home");
-    }
-    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .coordinate(Point.fromLngLat(2.0, 2.0))
-      .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(0, 1)
-      .addWaypointNames(longWpName.toString(), "Work")
-      .build();
-
-    assertTrue(mapMatching.cloneCall().request().url().toString()
-      .contains("waypoint_names=Home"));
-
-    // one more char results in exception
-    mapMatching = MapboxMapMatching.builder()
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .coordinate(Point.fromLngLat(2.0, 2.0))
-      .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(0, 1)
-      .addWaypointNames(longWpName.toString(), "Work1") // waypoint ar too long
-      .build();
-  }
-
-  @Test
   public void testWithWaypointNames() throws Exception {
 
     MapboxMapMatching mapMatching = MapboxMapMatching.builder()


### PR DESCRIPTION
- Removes character waypoint names limit from `MapboxMapMatching` and `MapboxDirections`

Refs. https://github.com/mapbox/mapbox-java/pull/940#pullrequestreview-185610135

This PR removes the hard-coded check for a max of 500 characters total for all waypoint names in `MapboxMapMatching` and `MapboxDirections` 👀 https://github.com/mapbox/api-directions/pull/1625

We shouldn't enforce this in the java code - the error code / message will still be returned from the server.

cc @danpaz @danpat 