### PR TITLE
Fix README's maven central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 <h4 align="center">Build powerful Java apps using Mapbox's tools and services</h4>
 
 <p align="center">
-  <a href="https://maven-badges.herokuapp.com/maven-central/com.mapbox.mapboxsdk/mapbox-android-services">
-    <img src="https://maven-badges.herokuapp.com/maven-central/com.mapbox.mapboxsdk/mapbox-android-services/badge.svg"
+  <a href="https://maven-badges.herokuapp.com/maven-central/com.mapbox.mapboxsdk/mapbox-sdk-services">
+    <img src="https://maven-badges.herokuapp.com/maven-central/com.mapbox.mapboxsdk/mapbox-sdk-services/badge.svg"
          alt="Maven Central">
   </a>
   <a href="https://circleci.com/gh/mapbox/mapbox-java">


### PR DESCRIPTION
Very confusingly, this repo's README still shows `2.2.10` as the latest version of various Java services. It's actually `4.3.0`. This is because the badge was still referencing `mapbox-android-services` in its url. This pr fixes the Maven Central link URL so that the correct # appears.

**Before:**

![screen shot 2018-12-19 at 12 08 05 pm](https://user-images.githubusercontent.com/4394910/50245289-eee50c00-0386-11e9-86cd-a4a24870fe33.png)

**After:**


![screen shot 2018-12-19 at 12 09 12 pm](https://user-images.githubusercontent.com/4394910/50245293-f3a9c000-0386-11e9-924b-6b182d263df1.png)
