### PR TITLE
Fix waypoints APIs naming for map matching and directions services

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
@@ -31,14 +31,15 @@ public interface DirectionsService {
    * @param steps              define if you'd like the route steps
    * @param bearings           used to filter the road segment the waypoint will be placed on by
    *                           direction and dictates the angle of approach
-   * @param continueStraight   define whether the route should continue straight even if the route
-   *                           will be slower
+   * @param continueStraight   define whether the route should continue straight even if the
+   *                           route will be slower
    * @param annotations        an annotations object that contains additional details about each
-   *                           line segment along the route geometry. Each entry in an annotations
-   *                           field corresponds to a coordinate along the route geometry
+   *                           line segment along the route geometry. Each entry in an
+   *                           annotations field corresponds to a coordinate along the route
+   *                           geometry
    * @param language           language of returned turn-by-turn text instructions
-   * @param roundaboutExits    Add extra step when roundabouts occur with additional information for
-   *                           the user
+   * @param roundaboutExits    Add extra step when roundabouts occur with additional information
+   *                           for the user
    * @param voiceInstructions  request that the response contain voice instruction information,
    *                           useful for navigation
    * @param bannerInstructions request that the response contain banner instruction information,
@@ -46,7 +47,8 @@ public interface DirectionsService {
    * @param voiceUnits         voice units
    * @param exclude            exclude tolls, motorways or more along your route
    * @param approaches         which side of the road to approach a waypoint
-   * @param viaWayPoints       which input coordinates should be treated as via waypoints
+   * @param waypointIndices    which input coordinates should be treated as waypoints/separate legs.
+   *                           Note: coordinate indices not added here act as silent waypoints
    * @param waypointNames      custom names for waypoints used for the arrival instruction
    * @param waypointTargets    list of coordinate pairs for drop-off locations
    * @return the {@link DirectionsResponse} in a Call wrapper
@@ -74,7 +76,7 @@ public interface DirectionsService {
     @Query("voice_units") String voiceUnits,
     @Query("exclude") String exclude,
     @Query("approaches") String approaches,
-    @Query("waypoints") String viaWayPoints,
+    @Query("waypoints") String waypointIndices,
     @Query("waypoint_names") String waypointNames,
     @Query("waypoint_targets") String waypointTargets
   );

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -268,7 +268,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   public abstract String approaches();
 
   /**
-   * Indicates which input coordinates should be treated as via way points.
+   * Indicates which input coordinates should be treated as waypoints.
    * <p>
    * Most useful in combination with  steps=true and requests based on traces
    * with high sample rates. Can be an index corresponding to any of the input coordinates,
@@ -276,12 +276,12 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * {@link #steps()}
    * </p>
    *
-   * @return a string representing indices to be used as via way points
+   * @return a string representing indices to be used as waypoints
    * @since 4.4.0
    */
   @SerializedName("waypoints")
   @Nullable
-  public abstract String viaWayPoints();
+  public abstract String waypointIndices();
 
   /**
    * Custom names for waypoints used for the arrival instruction in banners and voice instructions,
@@ -558,15 +558,15 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     public abstract Builder approaches(String approaches);
 
     /**
-     * The same via way points the user originally made when the request was made.
+     * The same waypoint indices the user originally made when the request was made.
      *
-     * @param indices to be used as via way points
+     * @param indices to be used as waypoints
      * @return this builder for chaining options together
      * @since 4.4.0
      */
 
     @Nullable
-    public abstract Builder viaWayPoints(@Nullable String indices);
+    public abstract Builder waypointIndices(@Nullable String indices);
 
     /**
      * The same waypoint names the user originally made when the request was made.

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -231,12 +231,12 @@ public class MapboxDirectionsTest extends TestUtils {
   }
 
   @Test
-  public void waypoints_doesGetFormattedInUrlCorrectly() throws Exception {
+  public void waypoints_doesGetFormattedInUrlCorrectly() {
     MapboxDirections directions = MapboxDirections.builder()
       .destination(Point.fromLngLat(13.4930, 9.958))
       .addWaypoint(Point.fromLngLat(4.56, 7.89))
       .origin(Point.fromLngLat(1.234, 2.345))
-      .addViaWayPoints(0, 2)
+      .addWaypointIndices(0, 2)
       .accessToken(ACCESS_TOKEN)
       .build();
     String semicolon = "%3B";
@@ -673,7 +673,7 @@ public class MapboxDirectionsTest extends TestUtils {
     MapboxDirections.builder()
             .origin(Point.fromLngLat(2.0, 2.0))
             .destination(Point.fromLngLat(4.0, 4.0))
-            .addViaWayPoints(0)
+            .addWaypointIndices(0)
             .baseUrl("https://foobar.com")
             .accessToken(ACCESS_TOKEN)
             .build();
@@ -685,7 +685,7 @@ public class MapboxDirectionsTest extends TestUtils {
             .origin(Point.fromLngLat(2.0, 2.0))
             .addWaypoint(Point.fromLngLat(3.0, 3.0))
             .destination(Point.fromLngLat(4.0, 4.0))
-            .addViaWayPoints(1, 2)
+            .addWaypointIndices(1, 2)
             .baseUrl("https://foobar.com")
             .accessToken(ACCESS_TOKEN)
             .build();
@@ -697,7 +697,7 @@ public class MapboxDirectionsTest extends TestUtils {
             .origin(Point.fromLngLat(2.0, 2.0))
             .addWaypoint(Point.fromLngLat(3.0, 3.0))
             .destination(Point.fromLngLat(4.0, 4.0))
-            .addViaWayPoints(0, 1)
+            .addWaypointIndices(0, 1)
             .baseUrl("https://foobar.com")
             .accessToken(ACCESS_TOKEN)
             .build();
@@ -709,7 +709,7 @@ public class MapboxDirectionsTest extends TestUtils {
             .origin(Point.fromLngLat(2.0, 2.0))
             .addWaypoint(Point.fromLngLat(3.0, 3.0))
             .destination(Point.fromLngLat(4.0, 4.0))
-            .addViaWayPoints(0, 3, 2)
+            .addWaypointIndices(0, 3, 2)
             .baseUrl("https://foobar.com")
             .accessToken(ACCESS_TOKEN)
             .build();
@@ -728,22 +728,6 @@ public class MapboxDirectionsTest extends TestUtils {
     assertNotNull(mapboxDirections);
     assertEquals("Home;Store;Work",
       mapboxDirections.cloneCall().request().url().queryParameter("waypoint_names"));
-  }
-
-  @Test
-  public void build_exceptionThrownWhenWaypointNamesDoNotMatchCoordinates() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Number of waypoint names must match"));
-    MapboxDirections mapboxDirections = MapboxDirections.builder()
-      .origin(Point.fromLngLat(2.0, 2.0))
-      .addWaypoint(Point.fromLngLat(2.0, 2.0))
-      .addWaypoint(Point.fromLngLat(3.0, 3.0))
-      .destination(Point.fromLngLat(4.0, 4.0))
-      .addWaypointNames("Home", "Work")
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .build();
   }
 
   @Test

--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapMatchingService.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapMatchingService.java
@@ -59,8 +59,9 @@ public interface MapMatchingService {
    * @param voiceInstructions  whether or not to return
    *                           marked-up text for voice guidance along the route.
    * @param voiceUnits         voice units
-   * @param waypoints          Which input coordinates should be treated as waypoints.
-   * @param waypointNames     wustom names for waypoints used for the arrival instruction.
+   * @param waypointIndices    which input coordinates should be treated as waypoints/separate legs.
+   *                           Note: coordinate indices not added here act as silent waypoints
+   * @param waypointNames      custom names for waypoints used for the arrival instruction.
    * @param approaches         which side of the road to approach a waypoint.
    * @return the MapMatchingResponse in a Call wrapper
    * @since 2.0.0
@@ -84,7 +85,7 @@ public interface MapMatchingService {
     @Query("banner_instructions") Boolean bannerInstructions,
     @Query("voice_instructions") Boolean voiceInstructions,
     @Query("voice_units") String voiceUnits,
-    @Query("waypoints") String waypoints,
+    @Query("waypoints") String waypointIndices,
     @Query("waypoint_names") String waypointNames,
     @Query("approaches") String approaches);
 
@@ -130,8 +131,9 @@ public interface MapMatchingService {
    * @param voiceInstructions  whether or not to return
    *                           marked-up text for voice guidance along the route.
    * @param voiceUnits         voice units
-   * @param waypoints          Which input coordinates should be treated as waypoints.
-   * @param waypointNames     wustom names for waypoints used for the arrival instruction.
+   * @param waypointIndices    which input coordinates should be treated as waypoints/separate legs.
+   *                           Note: coordinate indices not added here act as silent waypoints
+   * @param waypointNames      custom names for waypoints used for the arrival instruction.
    * @param approaches         which side of the road to approach a waypoint.
    * @return the MapMatchingResponse in a Call wrapper
    * @since 4.4.0
@@ -156,7 +158,7 @@ public interface MapMatchingService {
           @Field("banner_instructions") Boolean bannerInstructions,
           @Field("voice_instructions") Boolean voiceInstructions,
           @Field("voice_units") String voiceUnits,
-          @Field("waypoints") String waypoints,
+          @Field("waypoints") String waypointIndices,
           @Field("waypoint_names") String waypointNames,
           @Field("approaches") String approaches);
 }

--- a/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
+++ b/services-matching/src/test/java/com/mapbox/api/matching/v5/MapboxMapMatchingTest.java
@@ -380,72 +380,60 @@ public class MapboxMapMatchingTest extends TestUtils {
   }
 
 
-  @Test
-  public void build_exceptionThrownWhenLessThanTwoWayPointsProvided() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Waypoints must be a list of at least two indexes separated by"));
-    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
+  @Test(expected = ServicesException.class)
+  public void build_exceptionThrownWhenLessThanTwoSeparatesLegsProvided() {
+    MapboxMapMatching.builder()
       .coordinate(Point.fromLngLat(2.0, 2.0))
       .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(0)
+      .waypointIndices(0)
+      .baseUrl("https://foobar.com")
+      .accessToken(ACCESS_TOKEN)
+      .build();
+  }
+
+  @Test(expected = ServicesException.class)
+  public void build_exceptionThrownWhenSeparatesLegsDoNotStartWith0() {
+    MapboxMapMatching.builder()
+      .coordinate(Point.fromLngLat(2.0, 2.0))
+      .coordinate(Point.fromLngLat(3.0, 3.0))
+      .coordinate(Point.fromLngLat(4.0, 4.0))
+      .waypointIndices(1, 2)
+      .baseUrl("https://foobar.com")
+      .accessToken(ACCESS_TOKEN)
+      .build();
+  }
+
+  @Test(expected = ServicesException.class)
+  public void build_exceptionThrownWhenSeparatesLegsDoNotEndWithLast() {
+    MapboxMapMatching.builder()
+      .coordinate(Point.fromLngLat(2.0, 2.0))
+      .coordinate(Point.fromLngLat(3.0, 3.0))
+      .coordinate(Point.fromLngLat(4.0, 4.0))
+      .waypointIndices(0, 1)
+      .baseUrl("https://foobar.com")
+      .accessToken(ACCESS_TOKEN)
+      .build();
+  }
+
+  @Test(expected = ServicesException.class)
+  public void build_exceptionThrownWhenMiddleSeparatesLegsAreWrong() {
+    MapboxMapMatching.builder()
+      .coordinate(Point.fromLngLat(2.0, 2.0))
+      .coordinate(Point.fromLngLat(3.0, 3.0))
+      .coordinate(Point.fromLngLat(4.0, 4.0))
+      .waypointIndices(0, 3, 2)
       .baseUrl("https://foobar.com")
       .accessToken(ACCESS_TOKEN)
       .build();
   }
 
   @Test
-  public void build_exceptionThrownWhenWaypointsDoNotStartWith0() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Waypoints must contain indices of the first and last coordinates"));
+  public void sanitySeparatesLegs() {
     MapboxMapMatching mapMatching = MapboxMapMatching.builder()
       .coordinate(Point.fromLngLat(2.0, 2.0))
       .coordinate(Point.fromLngLat(3.0, 3.0))
       .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(1, 2)
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .build();
-  }
-
-  @Test
-  public void build_exceptionThrownWhenWaypointDoNotEndWithLast() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Waypoints must contain indices of the first and last coordinates"));
-    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
-      .coordinate(Point.fromLngLat(2.0, 2.0))
-      .coordinate(Point.fromLngLat(3.0, 3.0))
-      .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(0, 1)
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .build();
-  }
-
-  @Test
-  public void build_exceptionThrownWhenMiddleWaypointsAreWrong() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Waypoints index too large (no corresponding coordinate)"));
-    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
-      .coordinate(Point.fromLngLat(2.0, 2.0))
-      .coordinate(Point.fromLngLat(3.0, 3.0))
-      .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(0, 3, 2)
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .build();
-  }
-
-  @Test
-  public void sanityWaypoints() throws Exception {
-    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
-      .coordinate(Point.fromLngLat(2.0, 2.0))
-      .coordinate(Point.fromLngLat(3.0, 3.0))
-      .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(0, 1, 2)
+      .waypointIndices(0, 1, 2)
       .baseUrl("https://foobar.com")
       .accessToken(ACCESS_TOKEN)
       .build();
@@ -616,38 +604,19 @@ public class MapboxMapMatchingTest extends TestUtils {
   }
 
   @Test
-  public void sanityWaypointNamesInstructions() throws Exception {
+  public void sanityWaypointNamesInstructions() {
     MapboxMapMatching mapMatching = MapboxMapMatching.builder()
       .baseUrl("https://foobar.com")
       .accessToken(ACCESS_TOKEN)
       .coordinate(Point.fromLngLat(1.0, 1.0))
       .coordinate(Point.fromLngLat(2.0, 2.0))
       .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(0,1,2)
+      .waypointIndices(0, 1 ,2)
       .addWaypointNames("Home", "Store", "Work")
       .build();
     assertNotNull(mapMatching);
     assertEquals("Home;Store;Work",
       mapMatching.cloneCall().request().url().queryParameter("waypoint_names"));
-  }
-
-  @Test
-  public void build_exceptionThrownWhenWaypointNamesDoNotMatchWaypoints() throws Exception {
-    thrown.expect(ServicesException.class);
-    thrown.expectMessage(
-      startsWith("Number of waypoint names  must match"));
-
-    MapboxMapMatching mapMatching = MapboxMapMatching.builder()
-      .baseUrl("https://foobar.com")
-      .accessToken(ACCESS_TOKEN)
-      .coordinate(Point.fromLngLat(2.0, 2.0))
-      .coordinate(Point.fromLngLat(2.5, 2.5))
-      .coordinate(Point.fromLngLat(3.0, 3.0))
-      .coordinate(Point.fromLngLat(3.5, 3.5))
-      .coordinate(Point.fromLngLat(4.0, 4.0))
-      .waypoints(0, 3, 4)
-      .addWaypointNames("Home", "Work")
-      .build();
   }
 
   @Test
@@ -667,7 +636,7 @@ public class MapboxMapMatchingTest extends TestUtils {
       .steps(true)
       .tidy(true)
       .bannerInstructions(true)
-      .waypoints(0,6)
+      .waypointIndices(0, 6)
       .addWaypointNames("Home", "Work")
       .accessToken(ACCESS_TOKEN)
       .baseUrl(mockUrl.toString())
@@ -687,7 +656,7 @@ public class MapboxMapMatchingTest extends TestUtils {
         .profile(PROFILE_DRIVING)
         .steps(true)
         .tidy(true)
-        .waypoints("0;6")
+        .waypointIndices("0;6")
         .coordinates(Arrays.asList(
             Point.fromLngLat(2.344003915786743,48.85805170891599),
             Point.fromLngLat(2.346750497817993,48.85727523615161),


### PR DESCRIPTION
Follow up PR from latest feedback in https://github.com/mapbox/mapbox-java/pull/961

Edited:
- Fix waypoints APIs naming for map matching and directions services - from `waypoints` to ~`separatesLegs`~ waypoint indices 👀 https://github.com/mapbox/mapbox-java/pull/962#issuecomment-462809409

Noting that for the Map Matching service we're deprecating https://github.com/mapbox/mapbox-java/blob/c834c07361e8b6283b93b098930413a06e933c64/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java#L488 in favor of https://github.com/mapbox/mapbox-java/blob/aba088c98a2bab20c155667eab8d447275cb03e2/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java#L507 to avoid breaking SemVer.

cc @1ec5 