### PR TITLE
Exclude *.java from being added to library jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,11 @@ def RELEASE_MODULES = ["services",
                        "services-turf"]
 
 subprojects { subproject ->
+
+  tasks.withType(Jar) {
+    exclude "**/*.java"
+  }
+
   if (TESTABLE_MODULES.contains(subproject.name)) {
     subproject.apply plugin: "com.vanniktech.android.junit.jacoco"
     subproject.apply from: "${rootDir}/gradle/jacoco.gradle"


### PR DESCRIPTION
Mapbox java sdk  uses [AutoValue library](https://github.com/google/auto/blob/master/value/userguide/index.md) to generate boilerplate code for  value setters / getters and to generate `equals`, `hashCode` and `toString` methods.

It is a useful tool. However, it was reported that generated `.java` files end up in the library jars. This is undersirable. This PR excludes `.java` files from being added to the library jars.

closes #989 