### PR TITLE
Adding userAgent parameter to Isochrone request retrofit call URL

### DIFF
--- a/services-isochrone/src/main/java/com/mapbox/api/isochrone/IsochroneCriteria.java
+++ b/services-isochrone/src/main/java/com/mapbox/api/isochrone/IsochroneCriteria.java
@@ -14,6 +14,13 @@ public class IsochroneCriteria {
 
 
   /**
+   * Mapbox default username.
+   *
+   * @since 4.7.0
+   */
+  public static final String PROFILE_DEFAULT_USER = "mapbox";
+
+  /**
    * For walking routing. This profile shows routes that are short and safe for cyclist, avoiding
    * highways and preferring streets with bike lanes.
    *

--- a/services-isochrone/src/main/java/com/mapbox/api/isochrone/IsochroneService.java
+++ b/services-isochrone/src/main/java/com/mapbox/api/isochrone/IsochroneService.java
@@ -18,46 +18,102 @@ public interface IsochroneService {
   /**
    * Constructs the HTTP request for the specified parameters.
    *
-   * @param profile A Mapbox Directions routing profile ID. Options are
-   *                {@link IsochroneCriteria#PROFILE_DRIVING} for travel times by car,
-   *                {@link IsochroneCriteria#PROFILE_WALKING} for pedestrian and hiking travel
-   *                times,and {@link IsochroneCriteria#PROFILE_CYCLING} for travel times by bicycle.
-   * @param coordinates    A {@link Point} object which represents a {longitude,latitude} coordinate
-   *                       pair around which to center the isochrone lines.
+   * @param profile         A Mapbox Directions routing profile ID. Options are
+   *                        {@link IsochroneCriteria#PROFILE_DRIVING} for travel
+   *                        times by car, {@link IsochroneCriteria#PROFILE_WALKING}
+   *                        for pedestrian and hiking travel times,and
+   *                        {@link IsochroneCriteria#PROFILE_CYCLING} for travel times
+   *                        by bicycle.
+   * @param coordinates     A {@link Point} object which represents a
+   *                        {longitude,latitude} coordinate pair around which to
+   *                        center the isochrone lines.
    * @param contoursMinutes A single String which has a comma-separated time in minutes to use for
    *                        each isochrone contour.
-   * @param accessToken    A valid Mapbox access token.
-   * @param contoursColors The colors to use for each isochrone contour, specified as hex values
-   *                       without a leading # (for example, ff0000 for red). If this parameter is
-   *                       used, there must be the same number of colors as there are entries in
-   *                       contours_minutes. If no colors are specified, the Isochrone API will
-   *                       assign a default rainbow color scheme to the output.
-   * @param polygons       Specify whether to return the contours as GeoJSON polygons (true) or
-   *                       linestrings (false, default). When polygons=true, any contour that
-   *                       forms a ring is returned as a polygon.
-   * @param denoise        A floating point value from 0.0 to 1.0 that can be used to remove
-   *                       smaller contours. The default is 1.0. A value of 1.0 will only
-   *                       return the largest contour for a given time value. A value of 0.5
-   *                       drops any contours that are less than half the area of the largest
-   *                       contour in the set of contours for that same time value.
-   * @param generalize     A positive floating point value in meters used as the tolerance for
-   *                       Douglas-Peucker generalization. There is no upper bound. If no value is
-   *                       specified in the request, the Isochrone API will choose the most
-   *                       optimized generalization to use for the request. Note that the
-   *                       generalization of contours can lead to self-intersections, as well
-   *                       as intersections of adjacent contours.
-   *
+   * @param accessToken     A valid Mapbox access token.
+   * @param contoursColors  The colors to use for each isochrone contour, specified as hex values
+   *                        without a leading # (for example, ff0000 for red). If this parameter is
+   *                        used, there must be the same number of colors as there are entries in
+   *                        contours_minutes. If no colors are specified, the Isochrone API will
+   *                        assign a default rainbow color scheme to the output.
+   * @param polygons        Specify whether to return the contours as GeoJSON polygons (true) or
+   *                        linestrings (false, default). When polygons=true, any contour that
+   *                        forms a ring is returned as a polygon.
+   * @param denoise         A floating point value from 0.0 to 1.0 that can be used to remove
+   *                        smaller contours. The default is 1.0. A value of 1.0 will only
+   *                        return the largest contour for a given time value. A value of 0.5
+   *                        drops any contours that are less than half the area of the largest
+   *                        contour in the set of contours for that same time value.
+   * @param generalize      A positive floating point value in meters used as the tolerance for
+   *                        Douglas-Peucker generalization. There is no upper bound. If no value is
+   *                        specified in the request, the Isochrone API will choose the most
+   *                        optimized generalization to use for the request. Note that the
+   *                        generalization of contours can lead to self-intersections, as well
+   *                        as intersections of adjacent contours.
    * @return a {@link FeatureCollection} in a Call wrapper
    * @since 4.6.0
+   * @deprecated this method was missing the user parameter. Use the getCall() method below instead.
    */
+  @Deprecated
   @GET("/isochrone/v1/{profile}/{coordinates}")
   Call<FeatureCollection> getCall(
-      @Path("profile") String profile,
-      @Path("coordinates") String coordinates,
-      @Query("contours_minutes") String contoursMinutes,
-      @Query("access_token") String accessToken,
-      @Query("contours_colors") String contoursColors,
-      @Query("polygons") Boolean polygons,
-      @Query("denoise") Float denoise,
-      @Query("generalize") Float generalize);
+    @Path("profile") String profile,
+    @Path("coordinates") String coordinates,
+    @Query("contours_minutes") String contoursMinutes,
+    @Query("access_token") String accessToken,
+    @Query("contours_colors") String contoursColors,
+    @Query("polygons") Boolean polygons,
+    @Query("denoise") Float denoise,
+    @Query("generalize") Float generalize);
+
+
+  /**
+   * Constructs the HTTP request for the specified parameters.
+   *
+   * @param user            The username for the account that the Isochrone engine runs on.
+   *                        In most cases, this should always remain the default value of
+   *                        {@link IsochroneCriteria#PROFILE_DEFAULT_USER}.
+   * @param profile         A Mapbox Directions routing profile ID. Options are
+   *                        {@link IsochroneCriteria#PROFILE_DRIVING} for travel times
+   *                        by car, {@link IsochroneCriteria#PROFILE_WALKING} for pedestrian
+   *                        and hiking travel times,and {@link IsochroneCriteria#PROFILE_CYCLING}
+   *                        for travel times by bicycle.
+   * @param coordinates     A {@link Point} object which represents a
+   *                        {longitude,latitude} coordinate pair around which to center
+   *                        the isochrone lines.
+   * @param contoursMinutes A single String which has a comma-separated time in minutes to use for
+   *                        each isochrone contour.
+   * @param accessToken     A valid Mapbox access token.
+   * @param contoursColors  The colors to use for each isochrone contour, specified as hex values
+   *                        without a leading # (for example, ff0000 for red). If this parameter is
+   *                        used, there must be the same number of colors as there are entries in
+   *                        contours_minutes. If no colors are specified, the Isochrone API will
+   *                        assign a default rainbow color scheme to the output.
+   * @param polygons        Specify whether to return the contours as GeoJSON polygons (true) or
+   *                        linestrings (false, default). When polygons=true, any contour that
+   *                        forms a ring is returned as a polygon.
+   * @param denoise         A floating point value from 0.0 to 1.0 that can be used to remove
+   *                        smaller contours. The default is 1.0. A value of 1.0 will only
+   *                        return the largest contour for a given time value. A value of 0.5
+   *                        drops any contours that are less than half the area of the largest
+   *                        contour in the set of contours for that same time value.
+   * @param generalize      A positive floating point value in meters used as the tolerance for
+   *                        Douglas-Peucker generalization. There is no upper bound. If no value is
+   *                        specified in the request, the Isochrone API will choose the most
+   *                        optimized generalization to use for the request. Note that the
+   *                        generalization of contours can lead to self-intersections, as well
+   *                        as intersections of adjacent contours.
+   * @return a {@link FeatureCollection} in a Call wrapper
+   * @since 4.7.0
+   */
+  @GET("/isochrone/v1/{user}/{profile}/{coordinates}")
+  Call<FeatureCollection> getCall(
+    @Path("user") String user,
+    @Path("profile") String profile,
+    @Path("coordinates") String coordinates,
+    @Query("contours_minutes") String contoursMinutes,
+    @Query("access_token") String accessToken,
+    @Query("contours_colors") String contoursColors,
+    @Query("polygons") Boolean polygons,
+    @Query("denoise") Float denoise,
+    @Query("generalize") Float generalize);
 }

--- a/services-isochrone/src/main/java/com/mapbox/api/isochrone/MapboxIsochrone.java
+++ b/services-isochrone/src/main/java/com/mapbox/api/isochrone/MapboxIsochrone.java
@@ -51,21 +51,22 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
   @Override
   protected GsonBuilder getGsonBuilder() {
     return new GsonBuilder()
-        .registerTypeAdapterFactory(GeoJsonAdapterFactory.create())
-        .registerTypeAdapterFactory(GeometryAdapterFactory.create());
+      .registerTypeAdapterFactory(GeoJsonAdapterFactory.create())
+      .registerTypeAdapterFactory(GeometryAdapterFactory.create());
   }
 
   @Override
   protected Call<FeatureCollection> initializeCall() {
     return getService().getCall(
-        profile(),
-        coordinates(),
-        contoursMinutes(),
-        accessToken(),
-        contoursColors(),
-        polygons(),
-        denoise(),
-        generalize()
+      user(),
+      profile(),
+      coordinates(),
+      contoursMinutes(),
+      accessToken(),
+      contoursColors(),
+      polygons(),
+      denoise(),
+      generalize()
     );
   }
 
@@ -78,7 +79,8 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
    */
   public static Builder builder() {
     return new AutoValue_MapboxIsochrone.Builder()
-        .baseUrl(Constants.BASE_API_URL);
+      .baseUrl(Constants.BASE_API_URL)
+      .user(IsochroneCriteria.PROFILE_DEFAULT_USER);
   }
 
   @NonNull
@@ -87,6 +89,9 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
 
   @NonNull
   abstract String accessToken();
+
+  @NonNull
+  abstract String user();
 
   @NonNull
   abstract String profile();
@@ -145,6 +150,16 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
      */
     public abstract Builder accessToken(@NonNull String accessToken);
 
+    /**
+     * The username for the account that the Isochrone engine runs on. In most cases, this should
+     * always remain the default value of {@link IsochroneCriteria#PROFILE_DEFAULT_USER}.
+     *
+     * @param user a non-null string which will replace the default user used in the Isochrone
+     *             request
+     * @return this builder for chaining options together
+     * @since 4.7.0
+     */
+    public abstract Builder user(@NonNull String user);
 
     /**
      * A Mapbox Directions routing profile ID. Options are
@@ -168,8 +183,8 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
      */
     public Builder coordinates(@NonNull Point queryPoint) {
       coordinates(String.format(Locale.US, "%s,%s",
-          TextUtils.formatCoordinate(queryPoint.longitude()),
-          TextUtils.formatCoordinate(queryPoint.latitude())));
+        TextUtils.formatCoordinate(queryPoint.longitude()),
+        TextUtils.formatCoordinate(queryPoint.latitude())));
       return this;
     }
 
@@ -197,7 +212,7 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
      * @since 4.6.0
      */
     public Builder addContoursMinutes(@NonNull @IntRange(from = 0, to = 60)
-                                          Integer... listOfMinuteValues) {
+                                        Integer... listOfMinuteValues) {
       this.contoursMinutes = listOfMinuteValues;
       return this;
     }
@@ -302,14 +317,14 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
       if (contoursMinutes != null) {
         if (contoursMinutes.length < 1) {
           throw new ServicesException("A query with at least one specified "
-              + "minute amount is required.");
+            + "minute amount is required.");
         }
 
         if (contoursMinutes.length >= 2) {
           for (int x = 0; x < contoursMinutes.length - 1; x++) {
             if (contoursMinutes[x] > contoursMinutes[x + 1]) {
               throw new ServicesException("The minutes must be listed"
-                  + " in order from the lowest number to the highest number.");
+                + " in order from the lowest number to the highest number.");
             }
           }
         }
@@ -321,39 +336,39 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
       }
 
       if (contoursColors != null
-          && contoursMinutes != null
-          && contoursColors.length != contoursMinutes.length) {
+        && contoursMinutes != null
+        && contoursColors.length != contoursMinutes.length) {
         throw new ServicesException("Number of color elements "
-            + "must match number of minute elements provided.");
+          + "must match number of minute elements provided.");
       }
 
       MapboxIsochrone isochrone = autoBuild();
 
       if (!MapboxUtils.isAccessTokenValid(isochrone.accessToken())) {
         throw new ServicesException("Using the Mapbox Isochrone API requires setting "
-            + "a valid access token.");
+          + "a valid access token.");
       }
 
       if (TextUtils.isEmpty(isochrone.coordinates())) {
         throw new ServicesException("A query with longitude and latitude values is "
-            + "required.");
+          + "required.");
       }
 
       if (TextUtils.isEmpty(isochrone.profile())) {
         throw new ServicesException("A query with a set Directions profile (cycling,"
-            + " walking, or driving) is required.");
+          + " walking, or driving) is required.");
       }
 
       if (TextUtils.isEmpty(isochrone.contoursMinutes())) {
         throw new ServicesException("A query with at least one specified minute amount"
-            + " is required.");
+          + " is required.");
       }
 
       if (isochrone.contoursColors() != null) {
         if (isochrone.contoursColors().contains("#")) {
           throw new ServicesException("Make sure that none of the contour color HEX"
-              + " values have a # in front of it. Provide a list of the HEX values "
-              + "without any # symbols.");
+            + " values have a # in front of it. Provide a list of the HEX values "
+            + "without any # symbols.");
         }
       }
       return isochrone;


### PR DESCRIPTION
Resolves #996 by adding a required `/mapbox/` slug to the Isochrone API service's Retrofit request URL. Based on my demo app refactoring work in https://github.com/mapbox/mapbox-android-demo/pull/1029, the #996 bug renders the wrapper unusable. 

The API's docs

<img width="632" alt="Screen Shot 2019-04-11 at 3 57 45 PM" src="https://user-images.githubusercontent.com/4394910/55998305-9659b780-5c72-11e9-988f-46c4f0ff40fe.png">

Totally fine if this is the wrong way to fix the bug. Figured I'd open something to get the conversation started.