### PR TITLE
added overloaded method bbox that takes in a BoundingBox

### DIFF
--- a/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/MapboxGeocoding.java
+++ b/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/MapboxGeocoding.java
@@ -382,6 +382,21 @@ public abstract class MapboxGeocoding extends MapboxService<GeocodingResponse, G
      * limit results to within the bounding box only. If simple biasing is desired rather than a
      * strict region, use proximity instead.
      *
+     * @param bbox the bounding box as a {@link BoundingBox}
+     * @return this builder for chaining options together
+     * @since 4.7.0
+     */
+    public Builder bbox(BoundingBox bbox) {
+      bbox(bbox.southwest().longitude(), bbox.southwest().latitude(),
+           bbox.northeast().longitude(), bbox.northeast().latitude());
+      return this;
+    }
+
+    /**
+     * Limit the results to a defined bounding box. Unlike {@link #proximity()}, this will strictly
+     * limit results to within the bounding box only. If simple biasing is desired rather than a
+     * strict region, use proximity instead.
+     *
      * @param northeast the northeast corner of the bounding box as a {@link Point}
      * @param southwest the southwest corner of the bounding box as a {@link Point}
      * @return this builder for chaining options together

--- a/services-geocoding/src/test/java/com/mapbox/api/geocoding/v5/MapboxGeocodingTest.java
+++ b/services-geocoding/src/test/java/com/mapbox/api/geocoding/v5/MapboxGeocodingTest.java
@@ -3,6 +3,7 @@ package com.mapbox.api.geocoding.v5;
 import com.mapbox.api.geocoding.v5.models.GeocodingResponse;
 import com.mapbox.core.TestUtils;
 import com.mapbox.core.exceptions.ServicesException;
+import com.mapbox.geojson.BoundingBox;
 import com.mapbox.geojson.Point;
 
 import org.hamcrest.junit.ExpectedException;
@@ -184,6 +185,20 @@ public class MapboxGeocodingTest extends GeocodingTestUtils {
 
   @Test
   public void bbox_getsFormattedCorrectlyForUrl() throws Exception {
+    BoundingBox bbox = BoundingBox.fromLngLats(
+            -77.083056, 38.908611, -76.997778, 38.959167);
+    MapboxGeocoding mapboxGeocoding = MapboxGeocoding.builder()
+            .accessToken(ACCESS_TOKEN)
+            .baseUrl(mockUrl.toString())
+            .bbox(bbox)
+            .query("1600 pennsylvania ave nw")
+            .build();
+    assertEquals("-77.083056,38.908611,-76.997778,38.959167",
+            mapboxGeocoding.cloneCall().request().url().queryParameter("bbox"));
+  }
+
+  @Test
+  public void bbox_asPoints_getsFormattedCorrectlyForUrl() throws Exception {
     MapboxGeocoding mapboxGeocoding = MapboxGeocoding.builder()
       .accessToken(ACCESS_TOKEN)
       .baseUrl(mockUrl.toString())


### PR DESCRIPTION
This PR adds a missing overloaded method Geocoder#bbox that takes in a BoundingBox from the geojson package. 

Now MapboxGeocoding#bbox supports:
- `BoundingBox`
- `Point, Point`
- `double, double, double, double`
- `String`

closes #841