### PR TITLE
Feature.get*Property should return null for non-existent property

### DIFF
--- a/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
@@ -358,7 +358,8 @@ public final class Feature implements GeoJson {
    * @since 1.0.0
    */
   public String getStringProperty(String key) {
-    return properties().get(key).getAsString();
+    JsonElement propertyKey = properties().get(key);
+    return propertyKey == null ? null : propertyKey.getAsString();
   }
 
   /**
@@ -369,7 +370,8 @@ public final class Feature implements GeoJson {
    * @since 1.0.0
    */
   public Number getNumberProperty(String key) {
-    return properties().get(key).getAsNumber();
+    JsonElement propertyKey = properties().get(key);
+    return propertyKey == null ? null : propertyKey.getAsNumber();
   }
 
   /**
@@ -380,7 +382,8 @@ public final class Feature implements GeoJson {
    * @since 1.0.0
    */
   public Boolean getBooleanProperty(String key) {
-    return properties().get(key).getAsBoolean();
+    JsonElement propertyKey = properties().get(key);
+    return propertyKey == null ? null : propertyKey.getAsBoolean();
   }
 
   /**
@@ -391,7 +394,8 @@ public final class Feature implements GeoJson {
    * @since 1.0.0
    */
   public Character getCharacterProperty(String key) {
-    return properties().get(key).getAsCharacter();
+    JsonElement propertyKey = properties().get(key);
+    return propertyKey == null ? null : propertyKey.getAsCharacter();
   }
 
   /**

--- a/services-geojson/src/test/java/com/mapbox/geojson/FeatureTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/FeatureTest.java
@@ -218,4 +218,46 @@ public class FeatureTest extends TestUtils {
 
     compareJson(jsonString, jsonStringFromFeature);
   }
+
+  @Test
+  public void feature_getProperty_empty_property() throws IOException {
+    final String jsonString =
+            "{\"type\":\"Feature\"," +
+                    " \"geometry\":"
+                    + "{\"type\":\"LineString\",\"coordinates\":[[1.0,2.0],[2.0,3.0]]}}";
+
+    Feature feature = Feature.fromJson(jsonString);
+    Object value = feature.getStringProperty("does_not_exist");
+    assertNull(value);
+
+    value = feature.getBooleanProperty("does_not_exist");
+    assertNull(value);
+
+    value = feature.getNumberProperty("does_not_exist");
+    assertNull(value);
+
+    value = feature.getCharacterProperty("does_not_exist");
+    assertNull(value);
+  }
+
+  @Test
+  public void feature_property_doesnotexist() throws IOException {
+    final String jsonString =
+            "{ \"type\": \"Feature\"," +
+                    "\"geometry\": { \"type\": \"LineString\", \"coordinates\": [[1,1],[2,2],[3,3]]}," +
+                    "\"properties\": {\"some_name\": \"some_value\" }}";
+    Feature feature = Feature.fromJson(jsonString);
+    Object value = feature.getStringProperty("does_not_exist");
+    assertNull(value);
+
+    value = feature.getBooleanProperty("does_not_exist");
+    assertNull(value);
+
+    value = feature.getNumberProperty("does_not_exist");
+    assertNull(value);
+
+    value = feature.getCharacterProperty("does_not_exist");
+    assertNull(value);
+
+  }
 }


### PR DESCRIPTION
This PR make `Feature.get*Property()` methods return null if there is no property with a passed in key. This is exactly what corresponding javadoc is stating.

This PR also has tests to varify all `get*Property()` methods in the Feature

closes #902 