### PR TITLE
Added @Keep annotation to ease integration of geojson library

### DIFF
--- a/services-geojson/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/services-geojson/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -16,6 +16,8 @@
 
 package com.google.gson.typeadapters;
 
+import android.support.annotation.Keep;
+
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -125,6 +127,7 @@ import com.google.gson.stream.JsonWriter;
  * @param <T> base type for this factory
  * @since 4.6.0
  */
+@Keep
 public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   private final Class<?> baseType;
   private final String typeFieldName;

--- a/services-geojson/src/main/java/com/mapbox/geojson/BaseCoordinatesTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/BaseCoordinatesTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -19,6 +21,7 @@ import java.util.List;
  * @param <T> Type of coordinates
  * @since 4.6.0
  */
+@Keep
 abstract class BaseCoordinatesTypeAdapter<T> extends TypeAdapter<T> {
 
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/BaseGeometryTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/BaseGeometryTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
@@ -18,6 +20,7 @@ import java.io.IOException;
  * @param <T> Type of coordinates
  * @since 4.6.0
  */
+@Keep
 abstract class BaseGeometryTypeAdapter<G, T> extends TypeAdapter<G> {
 
   private volatile TypeAdapter<String> stringAdapter;

--- a/services-geojson/src/main/java/com/mapbox/geojson/BoundingBox.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/BoundingBox.java
@@ -4,6 +4,7 @@ import static com.mapbox.geojson.constants.GeoJsonConstants.MIN_LATITUDE;
 import static com.mapbox.geojson.constants.GeoJsonConstants.MIN_LONGITUDE;
 
 import android.support.annotation.FloatRange;
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -28,6 +29,7 @@ import java.io.Serializable;
  *
  * @since 3.0.0
  */
+@Keep
 public class BoundingBox implements Serializable {
 
   private final Point southwest;

--- a/services-geojson/src/main/java/com/mapbox/geojson/CoordinateContainer.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/CoordinateContainer.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 /**
  * Each of the s geometries which make up GeoJson implement this interface and consume a varying
  * dimension of {@link Point} list. Since this is varying, each geometry object fulfills the
@@ -8,6 +10,7 @@ package com.mapbox.geojson;
  * @param <T> a generic allowing varying dimensions for each GeoJson geometry
  * @since 3.0.0
  */
+@Keep
 public interface CoordinateContainer<T> extends Geometry {
 
   /**

--- a/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.gson.Gson;
@@ -46,6 +47,7 @@ import java.io.IOException;
  *
  * @since 1.0.0
  */
+@Keep
 public final class Feature implements GeoJson {
 
   private static final String TYPE = "Feature";

--- a/services-geojson/src/main/java/com/mapbox/geojson/FeatureCollection.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/FeatureCollection.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.gson.Gson;
@@ -37,6 +38,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@Keep
 public final class FeatureCollection implements GeoJson {
 
   private static final String TYPE = "FeatureCollection";

--- a/services-geojson/src/main/java/com/mapbox/geojson/GeoJson.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/GeoJson.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 /**
  * Generic implementation for all GeoJson objects defining common traits that each GeoJson object
  * has. This logic is carried over to {@link Geometry} which is an interface which all seven GeoJson
@@ -7,6 +9,7 @@ package com.mapbox.geojson;
  *
  * @since 1.0.0
  */
+@Keep
 public interface GeoJson {
 
   /**

--- a/services-geojson/src/main/java/com/mapbox/geojson/Geometry.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Geometry.java
@@ -1,11 +1,14 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 /**
  * Each of the six geometries and {@link GeometryCollection}
  * which make up GeoJson implement this interface.
  *
  * @since 1.0.0
  */
+@Keep
 public interface Geometry extends GeoJson {
 
 }

--- a/services-geojson/src/main/java/com/mapbox/geojson/GeometryAdapterFactory.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/GeometryAdapterFactory.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.TypeAdapterFactory;
 
 import com.google.gson.typeadapters.RuntimeTypeAdapterFactory;
@@ -8,6 +10,7 @@ import com.google.gson.typeadapters.RuntimeTypeAdapterFactory;
  * A Geometry type adapter factory for convenience for serialization/deserialization.
  * @since 4.6.0
  */
+@Keep
 public abstract class GeometryAdapterFactory implements TypeAdapterFactory  {
 
   private static TypeAdapterFactory geometryTypeFactory;

--- a/services-geojson/src/main/java/com/mapbox/geojson/GeometryCollection.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/GeometryCollection.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -59,6 +60,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@Keep
 public final class GeometryCollection implements Geometry, Serializable {
 
   private static final String TYPE = "GeometryCollection";

--- a/services-geojson/src/main/java/com/mapbox/geojson/LineString.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/LineString.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.gson.Gson;
@@ -48,6 +49,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@Keep
 public final class LineString implements CoordinateContainer<List<Point>>, Serializable {
 
   private static final String TYPE = "LineString";

--- a/services-geojson/src/main/java/com/mapbox/geojson/ListOfDoublesCoordinatesTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/ListOfDoublesCoordinatesTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
@@ -11,6 +13,7 @@ import java.util.List;
  *
  * @since 4.6.0
  */
+@Keep
 class ListOfDoublesCoordinatesTypeAdapter extends BaseCoordinatesTypeAdapter<List<Double>> {
 
   @Override

--- a/services-geojson/src/main/java/com/mapbox/geojson/ListOfListOfPointCoordinatesTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/ListOfListOfPointCoordinatesTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
@@ -15,6 +17,7 @@ import java.util.List;
  *
  * @since 4.6.0
  */
+@Keep
 class ListOfListOfPointCoordinatesTypeAdapter
         extends BaseCoordinatesTypeAdapter<List<List<Point>>> {
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/ListOfPointCoordinatesTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/ListOfPointCoordinatesTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
@@ -14,6 +16,7 @@ import java.util.List;
  *
  * @since 4.6.0
  */
+@Keep
 class ListOfPointCoordinatesTypeAdapter extends BaseCoordinatesTypeAdapter<List<Point>> {
 
   @Override

--- a/services-geojson/src/main/java/com/mapbox/geojson/ListofListofListOfPointCoordinatesTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/ListofListofListOfPointCoordinatesTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
@@ -15,6 +17,7 @@ import java.util.List;
  *
  * @since 4.6.0
  */
+@Keep
 class ListofListofListOfPointCoordinatesTypeAdapter
         extends BaseCoordinatesTypeAdapter<List<List<List<Point>>>> {
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/MultiLineString.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/MultiLineString.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.gson.Gson;
@@ -49,6 +50,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@Keep
 public final class MultiLineString
   implements CoordinateContainer<List<List<Point>>>, Serializable {
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/MultiPoint.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/MultiPoint.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.gson.Gson;
@@ -34,6 +35,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@Keep
 public final class MultiPoint implements CoordinateContainer<List<Point>>, Serializable {
 
   private static final String TYPE = "MultiPoint";

--- a/services-geojson/src/main/java/com/mapbox/geojson/MultiPolygon.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/MultiPolygon.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.gson.Gson;
@@ -67,6 +68,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@Keep
 public final class MultiPolygon
   implements CoordinateContainer<List<List<List<Point>>>>, Serializable {
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/Point.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Point.java
@@ -6,6 +6,7 @@ import static com.mapbox.geojson.constants.GeoJsonConstants.MIN_LATITUDE;
 import static com.mapbox.geojson.constants.GeoJsonConstants.MIN_LONGITUDE;
 
 import android.support.annotation.FloatRange;
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.gson.Gson;
@@ -51,6 +52,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@Keep
 public final class Point implements CoordinateContainer<List<Double>>, Serializable {
 
   private static final String TYPE = "Point";

--- a/services-geojson/src/main/java/com/mapbox/geojson/PointAsCoordinatesTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/PointAsCoordinatesTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
@@ -11,6 +13,7 @@ import java.io.IOException;
  *
  * @since 4.6.0
  */
+@Keep
 public class PointAsCoordinatesTypeAdapter extends BaseCoordinatesTypeAdapter<Point> {
 
   @Override

--- a/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
@@ -55,6 +56,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@Keep
 public final class Polygon implements CoordinateContainer<List<List<Point>>>, Serializable {
 
   private static final String TYPE = "Polygon";

--- a/services-geojson/src/main/java/com/mapbox/geojson/gson/BoundingBoxTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/gson/BoundingBoxTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson.gson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -18,6 +20,7 @@ import java.util.List;
  *
  * @since 4.6.0
  */
+@Keep
 public class BoundingBoxTypeAdapter extends TypeAdapter<BoundingBox> {
 
   @Override

--- a/services-geojson/src/main/java/com/mapbox/geojson/gson/GeoJsonAdapterFactory.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/gson/GeoJsonAdapterFactory.java
@@ -1,5 +1,7 @@
 package com.mapbox.geojson.gson;
 
+import android.support.annotation.Keep;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
@@ -21,6 +23,7 @@ import com.mapbox.geojson.Polygon;
  *
  * @since 3.0.0
  */
+@Keep
 public abstract class GeoJsonAdapterFactory implements TypeAdapterFactory {
 
   /**

--- a/services-geojson/src/main/java/com/mapbox/geojson/gson/GeometryGeoJson.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/gson/GeometryGeoJson.java
@@ -1,5 +1,6 @@
 package com.mapbox.geojson.gson;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 
 import com.google.gson.GsonBuilder;
@@ -10,6 +11,7 @@ import com.mapbox.geojson.GeometryAdapterFactory;
  * This is a utility class that helps create a Geometry instance from a JSON string.
  * @since 4.0.0
  */
+@Keep
 public class GeometryGeoJson {
 
   /**


### PR DESCRIPTION
This PR adds `@Keep` annotation to model and gson related classes in  geojson library. This should simplify the integration of geojson library when proguard is enabled.

closes #980 