### PR TITLE
Adding combine turf method

### DIFF
--- a/docs/turf-port.md
+++ b/docs/turf-port.md
@@ -57,7 +57,7 @@ Below's an on going list of the Turf functions which currently exist inside the 
 - [ ] turf-voronoi
 
 ## Feature Conversion
-- [ ] turf-combine
+- [X] turf-combine
 - [x] turf-explode
 - [ ] turf-flatten
 - [ ] turf-line-to-polygon


### PR DESCRIPTION
This pr ports the combine method to Turf for Java. This method takes a `FeatureCollection` of `Point`, `LineString`, or `Polygon` features and returns a `Geometry`. The returned `Geometry` can be used to create a `MultiPoint`, `MultiLineString`, or `MultiPolygon` feature.

http://turfjs.org/docs/#combine

https://github.com/Turfjs/turf/blob/master/packages/turf-combine/index.ts

`combine(FeatureCollection featureCollection)` is the new method added to the `TurfConversion` class.

<img width="1279" alt="Screen Shot 2019-04-19 at 9 05 10 PM" src="https://user-images.githubusercontent.com/4394910/56460605-01357d80-635a-11e9-943a-b8ab69bce2ae.png">

<img width="1266" alt="Screen Shot 2019-04-20 at 6 53 10 AM" src="https://user-images.githubusercontent.com/4394910/56460604-01357d80-635a-11e9-92a2-d50ab5e48bc9.png">
