### PR TITLE
TurfMeasurement#envelope

### DIFF
--- a/docs/turf-port.md
+++ b/docs/turf-port.md
@@ -18,7 +18,7 @@ Below's an on going list of the Turf functions which currently exist inside the 
 - [ ] turf-centroid
 - [x] turf-destination
 - [x] turf-distance
-- [ ] turf-envelope
+- [x] turf-envelope
 - [x] turf-length
 - [x] turf-midpoint
 - [ ] turf-point-on-feature

--- a/services-turf/src/test/java/com/mapbox/turf/TurfMeasurementTest.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TurfMeasurementTest.java
@@ -41,6 +41,7 @@ public class TurfMeasurementTest extends TestUtils {
   private static final String TURF_BBOX_POLYGON_LINESTRING = "turf-bbox-polygon/linestring.geojson";
   private static final String TURF_BBOX_POLYGON_MULTIPOLYGON = "turf-bbox-polygon/multipolygon.geojson";
   private static final String TURF_BBOX_POLYGON_MULTI_POINT = "turf-bbox-polygon/multipoint.geojson";
+  private static final String TURF_ENVELOPE_FEATURE_COLLECTION = "turf-envelope/feature-collection.geojson";
   private static final String LINE_DISTANCE_MULTILINESTRING
     = "turf-line-distance/multilinestring.geojson";
 
@@ -353,9 +354,9 @@ public class TurfMeasurementTest extends TestUtils {
     // Use the LineString object to calculate its BoundingBox area
     double[] bbox = TurfMeasurement.bbox(lineString);
 
-   // Use the BoundingBox coordinates to create an actual BoundingBox object
+    // Use the BoundingBox coordinates to create an actual BoundingBox object
     BoundingBox boundingBox = BoundingBox.fromPoints(
-        Point.fromLngLat(bbox[0], bbox[1]), Point.fromLngLat(bbox[2], bbox[3]));
+      Point.fromLngLat(bbox[0], bbox[1]), Point.fromLngLat(bbox[2], bbox[3]));
 
     // Use the BoundingBox object in the TurfMeasurement.bboxPolygon() method.
     Polygon polygonRepresentingBoundingBox = TurfMeasurement.bboxPolygon(boundingBox);
@@ -363,11 +364,11 @@ public class TurfMeasurementTest extends TestUtils {
     assertNotNull(polygonRepresentingBoundingBox);
     assertEquals(0, polygonRepresentingBoundingBox.inner().size());
     assertEquals(5, polygonRepresentingBoundingBox.coordinates().get(0).size());
-    assertEquals(Point.fromLngLat(102.0,-10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(0));
-    assertEquals(Point.fromLngLat(130,-10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(1));
-    assertEquals(Point.fromLngLat(130.0,4.0), polygonRepresentingBoundingBox.coordinates().get(0).get(2));
-    assertEquals(Point.fromLngLat(102.0,4.0), polygonRepresentingBoundingBox.coordinates().get(0).get(3));
-    assertEquals(Point.fromLngLat(102.0,-10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(4));
+    assertEquals(Point.fromLngLat(102.0, -10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(0));
+    assertEquals(Point.fromLngLat(130, -10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(1));
+    assertEquals(Point.fromLngLat(130.0, 4.0), polygonRepresentingBoundingBox.coordinates().get(0).get(2));
+    assertEquals(Point.fromLngLat(102.0, 4.0), polygonRepresentingBoundingBox.coordinates().get(0).get(3));
+    assertEquals(Point.fromLngLat(102.0, -10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(4));
   }
 
   @Test
@@ -388,7 +389,7 @@ public class TurfMeasurementTest extends TestUtils {
     assertNotNull(polygonRepresentingBoundingBox);
     assertEquals(0, polygonRepresentingBoundingBox.inner().size());
     assertEquals(5, polygonRepresentingBoundingBox.coordinates().get(0).size());
-    assertEquals(Point.fromLngLat(100,0.0), polygonRepresentingBoundingBox.coordinates().get(0).get(4));
+    assertEquals(Point.fromLngLat(100, 0.0), polygonRepresentingBoundingBox.coordinates().get(0).get(4));
   }
 
   @Test
@@ -409,5 +410,23 @@ public class TurfMeasurementTest extends TestUtils {
     assertNotNull(polygonRepresentingBoundingBox);
     assertEquals(0, polygonRepresentingBoundingBox.inner().size());
     assertEquals(5, polygonRepresentingBoundingBox.coordinates().get(0).size());
+  }
+
+  @Test
+  public void envelope() throws IOException {
+    FeatureCollection featureCollection = FeatureCollection.fromJson(loadJsonFixture(TURF_ENVELOPE_FEATURE_COLLECTION));
+    Polygon polygon = TurfMeasurement.envelope(featureCollection);
+
+    final List<Point> expectedPoints = new ArrayList<>();
+    expectedPoints.add(Point.fromLngLat(20, -10));
+    expectedPoints.add(Point.fromLngLat(130, -10));
+    expectedPoints.add(Point.fromLngLat(130, 4));
+    expectedPoints.add(Point.fromLngLat(20, 4));
+    expectedPoints.add(Point.fromLngLat(20, -10));
+    List<List<Point>> polygonPoints = new ArrayList<List<Point>>() {{
+      add(expectedPoints);
+    }};
+    Polygon expected = Polygon.fromLngLats(polygonPoints);
+    assertEquals("Polygon should match.", expected, polygon);
   }
 }

--- a/services-turf/src/test/resources/turf-envelope/feature-collection.geojson
+++ b/services-turf/src/test/resources/turf-envelope/feature-collection.geojson
@@ -1,0 +1,39 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [102.0, 0.5]
+            },
+            "properties": {
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [
+          [102.0, -10.0], [103.0, 1.0], [104.0, 0.0], [130.0, 4.0]
+                ]
+            },
+            "properties": {
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+            [20.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0],
+            [100.0, 0.0]
+                    ]
+                ]
+            },
+            "properties": {
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds support for https://turfjs.org/docs/#envelope. It also fixes up bbox implementation by allowing any GeoJson as parameter and add support for feature and feature collection conversions. bboxPolygon has also been updated to allow for double[] which is the actual representation of bbox in turf vs the BoundingBox from geojson. 