### PR TITLE
Rename references of `mapIds` to `tileSetIds`

### DIFF
--- a/services-tilequery/src/main/java/com/mapbox/api/tilequery/MapboxTilequery.java
+++ b/services-tilequery/src/main/java/com/mapbox/api/tilequery/MapboxTilequery.java
@@ -201,11 +201,11 @@ public abstract class MapboxTilequery extends MapboxService<FeatureCollection, T
      * The ID of the map being queried. If you need to composite multiple layers, the Tilequery
      * API endpoint can also support a comma-separated list of map IDs.
      *
-     * @param mapIds Map ID(s)
+     * @param tileSetIds tile set ID(s)
      * @return this builder for chaining options together
      * @since 3.5.0
      */
-    public abstract Builder mapIds(String mapIds);
+    public abstract Builder mapIds(String tileSetIds);
 
     /**
      * The longitude and latitude to be queried.

--- a/services-tilequery/src/main/java/com/mapbox/api/tilequery/TilequeryService.java
+++ b/services-tilequery/src/main/java/com/mapbox/api/tilequery/TilequeryService.java
@@ -19,7 +19,7 @@ public interface TilequeryService {
   /**
    * Constructs the HTTP request for the specified parameters.
    *
-   * @param mapIds Map ID(s)
+   * @param tileSetIds tile set ID(s)
    * @param query query point
    * @param accessToken Mapbox access token
    * @param radius distance in meters to query for features
@@ -30,9 +30,9 @@ public interface TilequeryService {
    * @return A retrofit Call object
    * @since 3.5.0
    */
-  @GET("/v4/{mapIds}/tilequery/{query}.json")
+  @GET("/v4/{tileSetIds}/tilequery/{query}.json")
   Call<FeatureCollection> getCall(
-    @Path("mapIds") String mapIds,
+    @Path("tileSetIds") String tileSetIds,
     @Path("query") String query,
     @Query("access_token") String accessToken,
     @Query("radius") Integer radius,
@@ -44,7 +44,7 @@ public interface TilequeryService {
   /**
    * Constructs the HTTP request for the specified parameters.
    *
-   * @param mapIds Map ID(s)
+   * @param tileSetIds tile set ID(s)
    * @param query query point
    * @param accessToken Mapbox access token
    * @param radius distance in meters to query for features
@@ -55,9 +55,9 @@ public interface TilequeryService {
    * @return A retrofit Call object
    * @since 3.5.0
    */
-  @GET("/v4/{mapIds}/tilequery/{query}.json")
+  @GET("/v4/{tileSetIds}/tilequery/{query}.json")
   Call<List<FeatureCollection>> getBatchCall(
-    @Path("mapIds") String mapIds,
+    @Path("tileSetIds") String tileSetIds,
     @Path("query") String query,
     @Query("access_token") String accessToken,
     @Query("radius") Integer radius,


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-java/issues/1021 by refactoring references of `mapIds` to `tileSetIds`

cc @1ec5 