### PR TITLE
Fix walking options serialization

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/WalkingOptions.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/WalkingOptions.java
@@ -7,6 +7,7 @@ import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Class for specifying options for use with the walking profile.
@@ -22,6 +23,7 @@ public abstract class WalkingOptions {
    * @return walkingSpeed in meters per second
    * @since 4.8.0
    */
+  @SerializedName("walking_speed")
   @Nullable
   public abstract Double walkingSpeed();
 
@@ -34,6 +36,7 @@ public abstract class WalkingOptions {
    * @return walkwayBias bias to prefer or avoid walkways
    * @since 4.8.0
    */
+  @SerializedName("walkway_bias")
   @Nullable
   public abstract Double walkwayBias();
 
@@ -45,6 +48,7 @@ public abstract class WalkingOptions {
    * @return alleyBias bias to prefer or avoid alleys
    * @since 4.8.0
    */
+  @SerializedName("alley_bias")
   @Nullable
   public abstract Double alleyBias();
 

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -180,15 +180,39 @@ public class MapboxDirectionsTest extends TestUtils {
   }
 
   @Test
-  public void build_walkingOptions() {
+  public void build_walkingWalkingSpeedOptions() {
     MapboxDirections directions = MapboxDirections.builder()
       .destination(Point.fromLngLat(13.4930, 9.958))
       .origin(Point.fromLngLat(1.234, 2.345))
       .accessToken(ACCESS_TOKEN)
       .profile(DirectionsCriteria.PROFILE_WALKING)
-      .walkingOptions(WalkingOptions.builder().alleyBias(2d).build())
+      .walkingOptions(WalkingOptions.builder().walkingSpeed(1d).build())
       .build();
-    assertTrue(directions.cloneCall().request().url().toString().contains("alley_bias=2.0"));
+    assertTrue(directions.cloneCall().request().url().toString().contains("walking_speed=1.0"));
+  }
+
+  @Test
+  public void build_walkingWalkwayBiasOptions() {
+    MapboxDirections directions = MapboxDirections.builder()
+      .destination(Point.fromLngLat(13.4930, 9.958))
+      .origin(Point.fromLngLat(1.234, 2.345))
+      .accessToken(ACCESS_TOKEN)
+      .profile(DirectionsCriteria.PROFILE_WALKING)
+      .walkingOptions(WalkingOptions.builder().walkwayBias(1d).build())
+      .build();
+    assertTrue(directions.cloneCall().request().url().toString().contains("walkway_bias=1.0"));
+  }
+
+  @Test
+  public void build_walkingAlleyBiasOptions() {
+    MapboxDirections directions = MapboxDirections.builder()
+      .destination(Point.fromLngLat(13.4930, 9.958))
+      .origin(Point.fromLngLat(1.234, 2.345))
+      .accessToken(ACCESS_TOKEN)
+      .profile(DirectionsCriteria.PROFILE_WALKING)
+      .walkingOptions(WalkingOptions.builder().alleyBias(1d).build())
+      .build();
+    assertTrue(directions.cloneCall().request().url().toString().contains("alley_bias=1.0"));
   }
 
   @Test

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -245,7 +245,8 @@ public class RouteOptionsTest extends TestUtils {
       "\"voice_instructions\": true," +
       "\"banner_instructions\": true," +
       "\"voice_units\": \"imperial\"," +
-      "\"uuid\": \"uuid1\"" +
+      "\"uuid\": \"uuid1\"," +
+      "\"walkingOptions\": { \"walking_speed\": 1.0, \"walkway_bias\": 0.6, \"alley_bias\": 0.7 }" +
       "}";
 
     RouteOptions routeOptions = RouteOptions.fromJson(jsonString);
@@ -267,6 +268,9 @@ public class RouteOptionsTest extends TestUtils {
     assertEquals(true, routeOptions.bannerInstructions());
     assertEquals("imperial", routeOptions.voiceUnits());
     assertEquals("uuid1", routeOptions.requestUuid());
+    assertEquals(1.0, routeOptions.walkingOptions().walkingSpeed(), 0.1);
+    assertEquals(0.6, routeOptions.walkingOptions().walkwayBias(), 0.1);
+    assertEquals(0.7, routeOptions.walkingOptions().alleyBias(), 0.1);
   }
 
   @Test
@@ -290,6 +294,11 @@ public class RouteOptionsTest extends TestUtils {
       .bannerInstructions(true)
       .voiceUnits("imperial")
       .requestUuid("uuid1")
+      .walkingOptions(WalkingOptions.builder()
+        .walkingSpeed(1.0)
+        .walkwayBias(0.6)
+        .alleyBias(0.7)
+        .build())
       .build();
 
     String jsonString = routeOptions.toJson();
@@ -311,7 +320,9 @@ public class RouteOptionsTest extends TestUtils {
       "\"voice_instructions\": true," +
       "\"banner_instructions\": true," +
       "\"voice_units\": \"imperial\"," +
-      "\"uuid\": \"uuid1\"}";
+      "\"uuid\": \"uuid1\"," +
+      "\"walkingOptions\": { \"walking_speed\": 1.0, \"walkway_bias\": 0.6, \"alley_bias\": 0.7 }" +
+      "}";
     compareJson(expectedJsonString, jsonString);
   }
 }

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/models/WalkingOptionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/models/WalkingOptionsTest.java
@@ -8,7 +8,7 @@ package com.mapbox.api.directions.v5.models;
   import static org.junit.Assert.assertEquals;
 
 public class WalkingOptionsTest extends TestUtils {
- private static final String JSON = "{\"walkingSpeed\":1.0,\"walkwayBias\":0.6,\"alleyBias\":0" +
+ private static final String JSON = "{\"walking_speed\":1.0,\"walkway_bias\":0.6,\"alley_bias\":0" +
    ".7}";
 
  @Test


### PR DESCRIPTION
- Fixes walking options serialization to match what the service expects / generates

Follow up from https://github.com/mapbox/mapbox-java/pull/991#discussion_r282666632

For when walking options will be included in the `RouteOptions` (for offline) we expect them to be nested as follows 👀 

```json
{
    "baseUrl": "http://localhost:50257/",
    "user": "mapbox",
    "profile": "walking",
    "coordinates": [
        [1.0, 1.0],
        [5.0, 5.0]
    ],
    "alternatives": true,
    "language": "en",
    "continue_straight": false,
    "geometries": "polyline6",
    "overview": "simplified",
    "access_token": "pk.XXX",
    "uuid": "cjhk3ouqm1voa3vp51vsd738n",
    "walkingOptions": {
        "walking_speed": 1.0,
        "walkway_bias": 0.6,
        "alley_bias": 0.7
    }
}
```

```json
"walkingOptions": {
    "walking_speed": 1.0,
    "walkway_bias": 0.6,
    "alley_bias": 0.7
}
```

`walkingOptions` object with the options nested in snake_case

cc @kevinkreiser @kdiluca 