### PR TITLE
Removed the last updated line from ported Turf method list

### DIFF
--- a/docs/turf-port.md
+++ b/docs/turf-port.md
@@ -5,7 +5,6 @@ More information about the Turf for Java library can be found at [https://www.ma
 This document tracks the progress being made to port over all of the Turf functionality to Java. This is an on going project and funtions are being added once needed. If you'd like to contribute by adding a Turf function that's missing, please open a GitHub issue still with information relative to why you need this functionality.
 
 Below's an on going list of the Turf functions which currently exist inside the `services-turf` module in this project:
-  (Last updated 05/16/18)
 
 ## Measurement
 - [x] turf-along


### PR DESCRIPTION
This pr removes the last updated line from [the list of ported Turf methods](https://github.com/mapbox/mapbox-java/blob/master/docs/turf-port.md). It was clear that I/we forget to update the line despite adding `x` to recently ported methods. If a reader wants to know the last time the document was updated, the reader can use Github history to do that.