### PR TITLE
Making GeoJson extend Serializable

### DIFF
--- a/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/models/CarmenFeature.java
+++ b/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/models/CarmenFeature.java
@@ -17,7 +17,6 @@ import com.mapbox.geojson.GeometryAdapterFactory;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.gson.BoundingBoxTypeAdapter;
 
-import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -39,7 +38,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @AutoValue
-public abstract class CarmenFeature implements GeoJson, Serializable {
+public abstract class CarmenFeature implements GeoJson {
 
   private static final String TYPE = "Feature";
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/GeoJson.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/GeoJson.java
@@ -2,6 +2,8 @@ package com.mapbox.geojson;
 
 import android.support.annotation.Keep;
 
+import java.io.Serializable;
+
 /**
  * Generic implementation for all GeoJson objects defining common traits that each GeoJson object
  * has. This logic is carried over to {@link Geometry} which is an interface which all seven GeoJson
@@ -10,7 +12,7 @@ import android.support.annotation.Keep;
  * @since 1.0.0
  */
 @Keep
-public interface GeoJson {
+public interface GeoJson extends Serializable {
 
   /**
    * This describes the type of GeoJson geometry, Feature, or FeatureCollection this object is.

--- a/services-geojson/src/main/java/com/mapbox/geojson/GeometryCollection.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/GeometryCollection.java
@@ -14,7 +14,6 @@ import com.google.gson.stream.JsonWriter;
 import com.mapbox.geojson.gson.GeoJsonAdapterFactory;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,7 +60,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Keep
-public final class GeometryCollection implements Geometry, Serializable {
+public final class GeometryCollection implements Geometry {
 
   private static final String TYPE = "GeometryCollection";
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/LineString.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/LineString.java
@@ -12,7 +12,6 @@ import com.mapbox.geojson.gson.GeoJsonAdapterFactory;
 import com.mapbox.geojson.utils.PolylineUtils;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,7 +49,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Keep
-public final class LineString implements CoordinateContainer<List<Point>>, Serializable {
+public final class LineString implements CoordinateContainer<List<Point>> {
 
   private static final String TYPE = "LineString";
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/MultiLineString.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/MultiLineString.java
@@ -11,7 +11,6 @@ import com.google.gson.stream.JsonWriter;
 import com.mapbox.geojson.gson.GeoJsonAdapterFactory;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -52,7 +51,7 @@ import java.util.List;
  */
 @Keep
 public final class MultiLineString
-  implements CoordinateContainer<List<List<Point>>>, Serializable {
+  implements CoordinateContainer<List<List<Point>>> {
 
   private static final String TYPE = "MultiLineString";
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/MultiPoint.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/MultiPoint.java
@@ -11,7 +11,6 @@ import com.google.gson.stream.JsonWriter;
 import com.mapbox.geojson.gson.GeoJsonAdapterFactory;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,7 +35,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Keep
-public final class MultiPoint implements CoordinateContainer<List<Point>>, Serializable {
+public final class MultiPoint implements CoordinateContainer<List<Point>> {
 
   private static final String TYPE = "MultiPoint";
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/MultiPolygon.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/MultiPolygon.java
@@ -11,7 +11,6 @@ import com.google.gson.stream.JsonWriter;
 import com.mapbox.geojson.gson.GeoJsonAdapterFactory;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -70,7 +69,7 @@ import java.util.List;
  */
 @Keep
 public final class MultiPolygon
-  implements CoordinateContainer<List<List<List<Point>>>>, Serializable {
+  implements CoordinateContainer<List<List<List<Point>>>> {
 
   private static final String TYPE = "MultiPolygon";
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/Point.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Point.java
@@ -18,7 +18,6 @@ import com.mapbox.geojson.gson.GeoJsonAdapterFactory;
 import com.mapbox.geojson.shifter.CoordinateShifterManager;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -53,7 +52,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Keep
-public final class Point implements CoordinateContainer<List<Double>>, Serializable {
+public final class Point implements CoordinateContainer<List<Double>> {
 
   private static final String TYPE = "Point";
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
@@ -14,7 +14,6 @@ import com.mapbox.geojson.exception.GeoJsonException;
 import com.mapbox.geojson.gson.GeoJsonAdapterFactory;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +56,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Keep
-public final class Polygon implements CoordinateContainer<List<List<Point>>>, Serializable {
+public final class Polygon implements CoordinateContainer<List<List<Point>>> {
 
   private static final String TYPE = "Polygon";
 


### PR DESCRIPTION
This PR makes `GeoJson` extend `Serializable`. 
Feature and FeatureCollection are now Serializable.

This was suggested by @LukasPaczos at
https://github.com/mapbox/mapbox-java/pull/1025#discussion_r283379248