### PR TITLE
Added fuzzyMatch support to MapboxGeocoding

### DIFF
--- a/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/GeocodingService.java
+++ b/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/GeocodingService.java
@@ -34,6 +34,7 @@ public interface GeocodingService {
    * @param limit        Optionally pass in a limit the amount of returning results.
    * @param language     The locale in which results should be returned.
    * @param reverseMode  Set the factors that are used to sort nearby results.
+   * @param fuzzyMatch   Set whether to allow the geocoding API to attempt exact matching or not.
    * @return A retrofit Call object
    * @since 1.0.0
    */
@@ -50,7 +51,8 @@ public interface GeocodingService {
     @Query("bbox") String bbox,
     @Query("limit") String limit,
     @Query("language") String language,
-    @Query("reverseMode") String reverseMode);
+    @Query("reverseMode") String reverseMode,
+    @Query("fuzzyMatch") Boolean fuzzyMatch);
 
   /**
    * Constructs the html call using the information passed in through the
@@ -69,6 +71,7 @@ public interface GeocodingService {
    * @param limit        Optionally pass in a limit the amount of returning results.
    * @param language     The locale in which results should be returned.
    * @param reverseMode  Set the factors that are used to sort nearby results.
+   * @param fuzzyMatch   Set whether to allow the geocoding API to attempt exact matching or not.
    * @return A retrofit Call object
    * @since 1.0.0
    */
@@ -85,5 +88,6 @@ public interface GeocodingService {
     @Query("bbox") String bbox,
     @Query("limit") String limit,
     @Query("language") String language,
-    @Query("reverseMode") String reverseMode);
+    @Query("reverseMode") String reverseMode,
+    @Query("fuzzyMatch") Boolean fuzzyMatch);
 }

--- a/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/MapboxGeocoding.java
+++ b/services-geocoding/src/main/java/com/mapbox/api/geocoding/v5/MapboxGeocoding.java
@@ -94,7 +94,8 @@ public abstract class MapboxGeocoding extends MapboxService<GeocodingResponse, G
       bbox(),
       limit(),
       languages(),
-      reverseMode());
+      reverseMode(),
+      fuzzyMatch());
   }
 
   private Call<List<GeocodingResponse>> getBatchCall() {
@@ -119,7 +120,8 @@ public abstract class MapboxGeocoding extends MapboxService<GeocodingResponse, G
       bbox(),
       limit(),
       languages(),
-      reverseMode());
+      reverseMode(),
+      fuzzyMatch());
 
     return batchCall;
   }
@@ -205,6 +207,9 @@ public abstract class MapboxGeocoding extends MapboxService<GeocodingResponse, G
 
   @Nullable
   abstract String reverseMode();
+
+  @Nullable
+  abstract Boolean fuzzyMatch();
 
   @Nullable
   abstract String clientAppName();
@@ -530,6 +535,20 @@ public abstract class MapboxGeocoding extends MapboxService<GeocodingResponse, G
      */
     public abstract Builder reverseMode(
       @Nullable @GeocodingCriteria.GeocodingReverseModeCriteria String reverseMode);
+
+    /**
+     * Specify whether the Geocoding API should attempt approximate, as well as exact,
+     * matching when performing searches (true, default), or whether it should opt out
+     * of this behavior and only attempt exact matching (false). For example, the default
+     * setting might return Washington, DC for a query of <code>wahsington</code>, even
+     * though the query was misspelled.
+     *
+     * @param fuzzyMatch optionally set whether to allow the geocoding API to attempt
+     *                   exact matching or not.
+     * @return this builder for chaining options together
+     * @since 4.9.0
+     */
+    public abstract Builder fuzzyMatch(Boolean fuzzyMatch);
 
     /**
      * Required to call when this is being built. If no access token provided,

--- a/services-geocoding/src/test/java/com/mapbox/api/geocoding/v5/MapboxGeocodingTest.java
+++ b/services-geocoding/src/test/java/com/mapbox/api/geocoding/v5/MapboxGeocodingTest.java
@@ -281,4 +281,30 @@ public class MapboxGeocodingTest extends GeocodingTestUtils {
       .limit(2)
       .build();
   }
+
+  @Test
+  public void fuzzyMatchSanity() throws Exception {
+    MapboxGeocoding mapboxGeocoding = MapboxGeocoding.builder()
+      .accessToken(ACCESS_TOKEN)
+      .query("wahsington")
+      .fuzzyMatch(true)
+      .baseUrl(mockUrl.toString())
+      .build();
+    assertNotNull(mapboxGeocoding);
+    Response<GeocodingResponse> response = mapboxGeocoding.executeCall();
+    assertEquals(200, response.code());
+  }
+
+  @Test
+  public void fuzzyMatch_getsAddedToUrlCorrectly() throws Exception {
+    MapboxGeocoding mapboxGeocoding = MapboxGeocoding.builder()
+      .accessToken(ACCESS_TOKEN)
+      .query("wahsington")
+      .fuzzyMatch(true)
+      .baseUrl(mockUrl.toString())
+      .build();
+    assertNotNull(mapboxGeocoding);
+    assertTrue(mapboxGeocoding.cloneCall().request().url().toString()
+      .contains("fuzzyMatch=true"));
+  }
 }


### PR DESCRIPTION
Resolves #1048 by adding fuzzyMatch support to MapboxGeocoding. 

https://docs.mapbox.com/api/search/#forward-geocoding

![Screen Shot 2019-06-14 at 2 33 25 PM](https://user-images.githubusercontent.com/4394910/59539268-61a3ef80-8eb1-11e9-8f7e-791b837bc60a.png)
