### PR TITLE
Adjustments to TurfMeasurement#bboxPolygon() to return a Feature instead of Polygon

### DIFF
--- a/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java
@@ -5,7 +5,9 @@ import static com.mapbox.turf.TurfConversion.radiansToDegrees;
 
 import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
+import com.google.gson.JsonObject;
 import com.mapbox.geojson.BoundingBox;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
@@ -457,38 +459,71 @@ public final class TurfMeasurement {
    * geometry.
    *
    * @param boundingBox a {@link BoundingBox} object to calculate with
-   * @return a {@link Polygon} object
+   * @return a {@link Feature} object
    * @see <a href="http://turfjs.org/docs/#bboxPolygon">Turf BoundingBox Polygon documentation</a>
-   * @since 4.7.0
+   * @since 4.9.0
    */
-  public static Polygon bboxPolygon(@NonNull BoundingBox boundingBox) {
-    return Polygon.fromLngLats(
+  public static Feature bboxPolygon(@NonNull BoundingBox boundingBox) {
+    return bboxPolygon(boundingBox, null, null);
+  }
+
+  /**
+   * Takes a {@link BoundingBox} and uses its coordinates to create a {@link Polygon}
+   * geometry.
+   *
+   * @param boundingBox a {@link BoundingBox} object to calculate with
+   * @param properties a {@link JsonObject} containing the feature properties
+   * @param id  common identifier of this feature
+   * @return a {@link Feature} object
+   * @see <a href="http://turfjs.org/docs/#bboxPolygon">Turf BoundingBox Polygon documentation</a>
+   * @since 4.9.0
+   */
+  public static Feature bboxPolygon(@NonNull BoundingBox boundingBox,
+                                    @Nullable JsonObject properties,
+                                    @Nullable String id) {
+    return Feature.fromGeometry(Polygon.fromLngLats(
       Collections.singletonList(
         Arrays.asList(
           Point.fromLngLat(boundingBox.west(), boundingBox.south()),
           Point.fromLngLat(boundingBox.east(), boundingBox.south()),
           Point.fromLngLat(boundingBox.east(), boundingBox.north()),
           Point.fromLngLat(boundingBox.west(), boundingBox.north()),
-          Point.fromLngLat(boundingBox.west(), boundingBox.south()))));
+          Point.fromLngLat(boundingBox.west(), boundingBox.south())))), properties, id);
   }
 
   /**
    * Takes a bbox and uses its coordinates to create a {@link Polygon} geometry.
    *
    * @param bbox a double[] object to calculate with
-   * @return a {@link Polygon} object
+   * @return a {@link Feature} object
    * @see <a href="http://turfjs.org/docs/#bboxPolygon">Turf BoundingBox Polygon documentation</a>
    * @since 4.9.0
    */
-  public static Polygon bboxPolygon(@NonNull double[] bbox) {
-    return Polygon.fromLngLats(
+  public static Feature bboxPolygon(@NonNull double[] bbox) {
+    return bboxPolygon(bbox, null, null);
+  }
+
+  /**
+   * Takes a bbox and uses its coordinates to create a {@link Polygon} geometry.
+   *
+   * @param bbox a double[] object to calculate with
+   * @param properties a {@link JsonObject} containing the feature properties
+   * @param id  common identifier of this feature
+   * @return a {@link Feature} object
+   * @see <a href="http://turfjs.org/docs/#bboxPolygon">Turf BoundingBox Polygon documentation</a>
+   * @since 4.9.0
+   */
+  public static Feature bboxPolygon(@NonNull double[] bbox,
+                                    @Nullable JsonObject properties,
+                                    @Nullable String id) {
+    return Feature.fromGeometry(Polygon.fromLngLats(
       Collections.singletonList(
         Arrays.asList(
           Point.fromLngLat(bbox[0], bbox[1]),
           Point.fromLngLat(bbox[2], bbox[1]),
           Point.fromLngLat(bbox[2], bbox[3]),
           Point.fromLngLat(bbox[0], bbox[3]),
-          Point.fromLngLat(bbox[0], bbox[1]))));
+          Point.fromLngLat(bbox[0], bbox[1])))), properties, id);
   }
 
   /**
@@ -499,9 +534,8 @@ public final class TurfMeasurement {
    * @since 4.9.0
    */
   public static Polygon envelope(GeoJson geoJson) {
-    return bboxPolygon(bbox(geoJson));
+    return (Polygon) bboxPolygon(bbox(geoJson)).geometry();
   }
-
 
   /**
    * Takes a bounding box and calculates the minimum square bounding box

--- a/services-turf/src/test/java/com/mapbox/turf/TurfMeasurementTest.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TurfMeasurementTest.java
@@ -359,11 +359,40 @@ public class TurfMeasurementTest extends TestUtils {
       Point.fromLngLat(bbox[0], bbox[1]), Point.fromLngLat(bbox[2], bbox[3]));
 
     // Use the BoundingBox object in the TurfMeasurement.bboxPolygon() method.
-    Polygon polygonRepresentingBoundingBox = TurfMeasurement.bboxPolygon(boundingBox);
+    Feature featureRepresentingBoundingBox = TurfMeasurement.bboxPolygon(boundingBox);
+
+    Polygon polygonRepresentingBoundingBox = (Polygon) featureRepresentingBoundingBox.geometry();
 
     assertNotNull(polygonRepresentingBoundingBox);
     assertEquals(0, polygonRepresentingBoundingBox.inner().size());
     assertEquals(5, polygonRepresentingBoundingBox.coordinates().get(0).size());
+    assertEquals(Point.fromLngLat(102.0, -10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(0));
+    assertEquals(Point.fromLngLat(130, -10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(1));
+    assertEquals(Point.fromLngLat(130.0, 4.0), polygonRepresentingBoundingBox.coordinates().get(0).get(2));
+    assertEquals(Point.fromLngLat(102.0, 4.0), polygonRepresentingBoundingBox.coordinates().get(0).get(3));
+    assertEquals(Point.fromLngLat(102.0, -10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(4));
+  }
+
+  @Test
+  public void bboxPolygonFromLineStringWithId() throws IOException, TurfException {
+    // Create a LineString
+    LineString lineString = LineString.fromJson(loadJsonFixture(TURF_BBOX_POLYGON_LINESTRING));
+
+    // Use the LineString object to calculate its BoundingBox area
+    double[] bbox = TurfMeasurement.bbox(lineString);
+
+    // Use the BoundingBox coordinates to create an actual BoundingBox object
+    BoundingBox boundingBox = BoundingBox.fromPoints(
+      Point.fromLngLat(bbox[0], bbox[1]), Point.fromLngLat(bbox[2], bbox[3]));
+
+    // Use the BoundingBox object in the TurfMeasurement.bboxPolygon() method.
+    Feature featureRepresentingBoundingBox = TurfMeasurement.bboxPolygon(boundingBox, null, "TEST_ID");
+    Polygon polygonRepresentingBoundingBox = (Polygon) featureRepresentingBoundingBox.geometry();
+
+    assertNotNull(polygonRepresentingBoundingBox);
+    assertEquals(0, polygonRepresentingBoundingBox.inner().size());
+    assertEquals(5, polygonRepresentingBoundingBox.coordinates().get(0).size());
+    assertEquals("TEST_ID", featureRepresentingBoundingBox.id());
     assertEquals(Point.fromLngLat(102.0, -10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(0));
     assertEquals(Point.fromLngLat(130, -10.0), polygonRepresentingBoundingBox.coordinates().get(0).get(1));
     assertEquals(Point.fromLngLat(130.0, 4.0), polygonRepresentingBoundingBox.coordinates().get(0).get(2));
@@ -384,7 +413,9 @@ public class TurfMeasurementTest extends TestUtils {
       Point.fromLngLat(bbox[0], bbox[1]), Point.fromLngLat(bbox[2], bbox[3]));
 
     // Use the BoundingBox object in the TurfMeasurement.bboxPolygon() method.
-    Polygon polygonRepresentingBoundingBox = TurfMeasurement.bboxPolygon(boundingBox);
+    Feature featureRepresentingBoundingBox = TurfMeasurement.bboxPolygon(boundingBox);
+
+    Polygon polygonRepresentingBoundingBox = (Polygon) featureRepresentingBoundingBox.geometry();
 
     assertNotNull(polygonRepresentingBoundingBox);
     assertEquals(0, polygonRepresentingBoundingBox.inner().size());
@@ -405,7 +436,9 @@ public class TurfMeasurementTest extends TestUtils {
       Point.fromLngLat(bbox[0], bbox[1]), Point.fromLngLat(bbox[2], bbox[3]));
 
     // Use the BoundingBox object in the TurfMeasurement.bboxPolygon() method.
-    Polygon polygonRepresentingBoundingBox = TurfMeasurement.bboxPolygon(boundingBox);
+    Feature featureRepresentingBoundingBox = TurfMeasurement.bboxPolygon(boundingBox);
+
+    Polygon polygonRepresentingBoundingBox = (Polygon) featureRepresentingBoundingBox.geometry();
 
     assertNotNull(polygonRepresentingBoundingBox);
     assertEquals(0, polygonRepresentingBoundingBox.inner().size());


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-java/issues/1042 by adjusting and adding TurfMeasurement#bboxPolygon() methods so that a `Feature` is returned instead of a `Polygon`. This pr also exposes properties and id parameters.