### PR TITLE
Removed exclusion of files that end in .java (fixing empty sources.jar)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,10 +86,6 @@ def RELEASE_MODULES = ["services",
 
 subprojects { subproject ->
 
-  tasks.withType(Jar) {
-    exclude "**/*.java"
-  }
-
   if (TESTABLE_MODULES.contains(subproject.name)) {
     subproject.apply plugin: "com.vanniktech.android.junit.jacoco"
     subproject.apply from: "${rootDir}/gradle/jacoco.gradle"


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-java/issues/1053 and undos https://github.com/mapbox/mapbox-java/commit/be2f75ce8506120d44b6f752a0a8650818e155c1#diff-c197962302397baf3a4cc36463dce5ea

cc @gwimmel, who originally reported #1053 