### PR TITLE
README doc compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.9.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.9.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
This pr makes a small adjustment in the repo's README.  `compile` to `implementation`.