### PR TITLE
fixup bintray publish script, generate sources and javadoc jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,8 @@ def RELEASE_MODULES = ["services",
 
 subprojects { subproject ->
 
-   tasks.withType(Jar) { jarTask ->
-    if (!jarTask.name.endsWith("SourcesJar")) {
+  tasks.withType(Jar) { jarTask ->
+    if (!jarTask.name.endsWith("sourcesJar")) {
       jarTask.exclude("**/*.java")
     }
   }
@@ -106,6 +106,21 @@ subprojects { subproject ->
   if (RELEASE_MODULES.contains(subproject.name)) {
     subproject.apply from: "${rootDir}/gradle/gradle-bintray.gradle"
     subproject.apply from: "${rootDir}/gradle/dependencies-graph.gradle"
+  }
+
+  task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+  }
+
+  task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+  }
+
+  artifacts {
+    archives sourcesJar
+    archives javadocJar
   }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -51,7 +51,6 @@ jobs:
       - image: mbgl/android-ndk-r19:8e91a7ebab
     working_directory: ~/code
     environment:
-    environment:
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
     steps:

--- a/gradle/gradle-bintray.gradle
+++ b/gradle/gradle-bintray.gradle
@@ -13,10 +13,12 @@ publishing {
             artifactId project.ext.mapboxArtifactId
             version project.ext.versionName
 
-            afterEvaluate {
-                artifact("$buildDir/outputs/aar/${project.ext.mapboxArtifactId}-release.aar")
-                artifact sourcesJar
-                artifact javadocJar
+            artifact sourcesJar {
+                classifier "sources"
+            }
+
+            artifact javadocJar {
+                classifier "javadoc"
             }
 
             pom.withXml {


### PR DESCRIPTION
Follow up to https://github.com/mapbox/mapbox-java/pull/1064.

See the following binaries to validate these changes:
> mapbox-sdk-services-4.9.1-20190710.081438-5-javadoc.jar   10-Jul-2019 08:14  597.58 KB
mapbox-sdk-services-4.9.1-20190710.081438-5-sources.jar   10-Jul-2019 08:14  144.96 KB
mapbox-sdk-services-4.9.1-20190710.081438-5.jar           10-Jul-2019 08:14  402.67 KB
mapbox-sdk-services-4.9.1-20190710.081438-5.pom           10-Jul-2019 08:14  1.64 KB

https://oss.jfrog.org/artifactory/oss-snapshot-local/com/mapbox/mapboxsdk/mapbox-sdk-services/4.9.1-SNAPSHOT/

cc @gwimmel 