### PR TITLE
Add possibility to set empty arrays to MapboxDirections builder.

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -910,7 +910,8 @@ public abstract class MapboxDirections extends
           + " directions API request.");
       }
 
-      if (waypointIndices != null) {
+      boolean isWaypointIndicesEmpty = waypointIndices == null || waypointIndices.length == 0;
+      if (!isWaypointIndicesEmpty) {
         if (waypointIndices.length < 2) {
           throw new ServicesException(
             "Waypoints must be a list of at least two indexes separated by ';'");
@@ -929,30 +930,34 @@ public abstract class MapboxDirections extends
         }
       }
 
-      if (waypointNames != null) {
-        final String waypointNamesStr = TextUtils.formatWaypointNames(waypointNames);
-        waypointNames(waypointNamesStr);
-      }
-
-      if (waypointTargets != null) {
-        if (waypointTargets.length != coordinates.size()) {
-          throw new ServicesException("Number of waypoint targets must match "
-            + " the number of waypoints provided.");
+      if (waypointNames != null && waypointNames.length != 0) {
+        if (isWaypointIndicesEmpty || waypointNames.length != waypointIndices.length) {
+          throw new ServicesException("Number of waypoint names elements must match "
+            + "number of waypoints provided.");
         }
-
-        waypointTargets(formatWaypointTargets(waypointTargets));
+        String formattedWaypointNames = TextUtils.formatWaypointNames(waypointNames);
+        waypointNames(formattedWaypointNames);
       }
 
-      if (approaches != null) {
-        if (approaches.length != coordinates.size()) {
+      if (approaches != null && approaches.length != 0) {
+        if (isWaypointIndicesEmpty || approaches.length != waypointIndices.length) {
           throw new ServicesException("Number of approach elements must match "
-            + "number of coordinates provided.");
+            + "number of waypoints provided.");
         }
         String formattedApproaches = TextUtils.formatApproaches(approaches);
         if (formattedApproaches == null) {
           throw new ServicesException("All approaches values must be one of curb, unrestricted");
         }
         approaches(formattedApproaches);
+      }
+
+      if (waypointTargets != null) {
+        if (waypointTargets.length != coordinates.size()) {
+          throw new ServicesException("Number of waypoint targets must match "
+            + " the number of coordinates provided.");
+        }
+
+        waypointTargets(formatWaypointTargets(waypointTargets));
       }
 
       coordinates(coordinates);

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -854,6 +854,7 @@ public abstract class MapboxDirections extends
     /**
      * Use POST method to request data.
      * The default is to use GET.
+     *
      * @return this builder for chaining options together
      * @since 4.6.0
      */
@@ -864,6 +865,7 @@ public abstract class MapboxDirections extends
 
     /**
      * Use GET method to request data.
+     *
      * @return this builder for chaining options together
      * @since 4.6.0
      */
@@ -910,8 +912,7 @@ public abstract class MapboxDirections extends
           + " directions API request.");
       }
 
-      boolean isWaypointIndicesEmpty = waypointIndices == null || waypointIndices.length == 0;
-      if (!isWaypointIndicesEmpty) {
+      if (waypointIndices != null && waypointIndices.length > 0) {
         if (waypointIndices.length < 2) {
           throw new ServicesException(
             "Waypoints must be a list of at least two indexes separated by ';'");
@@ -930,31 +931,39 @@ public abstract class MapboxDirections extends
         }
       }
 
-      if (waypointNames != null && waypointNames.length != 0) {
-        if (isWaypointIndicesEmpty || waypointNames.length != waypointIndices.length) {
+      if (waypointNames != null && waypointNames.length > 0) {
+        if (waypointNames.length < 2) {
+          throw new ServicesException(
+            "Waypoint names must be a list of at least two indexes separated by ';'");
+        }
+        if (waypointNames.length != coordinates.size()) {
           throw new ServicesException("Number of waypoint names elements must match "
             + "number of waypoints provided.");
         }
-        String formattedWaypointNames = TextUtils.formatWaypointNames(waypointNames);
+        final String formattedWaypointNames = TextUtils.formatWaypointNames(waypointNames);
         waypointNames(formattedWaypointNames);
       }
 
-      if (approaches != null && approaches.length != 0) {
-        if (isWaypointIndicesEmpty || approaches.length != waypointIndices.length) {
+      if (approaches != null && approaches.length > 0) {
+        if (approaches.length < 2) {
+          throw new ServicesException(
+            "Approaches must be a list of at least two indexes separated by ';'");
+        }
+        if (approaches.length != coordinates.size()) {
           throw new ServicesException("Number of approach elements must match "
             + "number of waypoints provided.");
         }
-        String formattedApproaches = TextUtils.formatApproaches(approaches);
+        final String formattedApproaches = TextUtils.formatApproaches(approaches);
         if (formattedApproaches == null) {
           throw new ServicesException("All approaches values must be one of curb, unrestricted");
         }
         approaches(formattedApproaches);
       }
 
-      if (waypointTargets != null) {
+      if (waypointTargets != null && waypointTargets.length > 0) {
         if (waypointTargets.length != coordinates.size()) {
           throw new ServicesException("Number of waypoint targets must match "
-            + " the number of coordinates provided.");
+            + " the number of waypoints provided.");
         }
 
         waypointTargets(formatWaypointTargets(waypointTargets));

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -644,14 +644,29 @@ public class MapboxDirectionsTest extends TestUtils {
   }
 
   @Test
+  public void build_exceptionThrownWhenLessThanTwoApproachesProvided() throws Exception {
+    thrown.expect(ServicesException.class);
+    thrown.expectMessage(
+      startsWith("Approaches must be a list of at least two"));
+    MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .origin(Point.fromLngLat(2.0, 2.0))
+      .destination(Point.fromLngLat(4.0, 4.0))
+      .addApproaches(APPROACH_UNRESTRICTED)
+      .baseUrl("https://foobar.com")
+      .accessToken(ACCESS_TOKEN)
+      .build();
+  }
+
+  @Test
   public void build_exceptionThrownWhenNumApproachesDoesNotMatchCoordinates() throws Exception {
     thrown.expect(ServicesException.class);
     thrown.expectMessage(
       startsWith("Number of approach elements must match"));
     MapboxDirections mapboxDirections = MapboxDirections.builder()
       .origin(Point.fromLngLat(2.0, 2.0))
+      .addWaypoint(Point.fromLngLat(3.0, 3.0))
       .destination(Point.fromLngLat(4.0, 4.0))
-      .addApproaches(APPROACH_UNRESTRICTED)
+      .addApproaches(APPROACH_UNRESTRICTED, APPROACH_CURB)
       .baseUrl("https://foobar.com")
       .accessToken(ACCESS_TOKEN)
       .build();
@@ -768,6 +783,35 @@ public class MapboxDirectionsTest extends TestUtils {
     assertNotNull(mapboxDirections);
     assertEquals("Home;Store;Work",
       mapboxDirections.cloneCall().request().url().queryParameter("waypoint_names"));
+  }
+
+  @Test
+  public void build_exceptionThrownWhenLessThanTwoWaypointNamesProvided() throws Exception {
+    thrown.expect(ServicesException.class);
+    thrown.expectMessage(
+      startsWith("Waypoint names must be a list of at least two"));
+    MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .origin(Point.fromLngLat(2.0, 2.0))
+      .destination(Point.fromLngLat(4.0, 4.0))
+      .addWaypointNames("Home")
+      .baseUrl("https://foobar.com")
+      .accessToken(ACCESS_TOKEN)
+      .build();
+  }
+
+  @Test
+  public void build_exceptionThrownWhenNumWaypointNamesDoesNotMatchCoordinates() throws Exception {
+    thrown.expect(ServicesException.class);
+    thrown.expectMessage(
+      startsWith("Number of waypoint names elements must match"));
+    MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .origin(Point.fromLngLat(2.0, 2.0))
+      .addWaypoint(Point.fromLngLat(3.0, 3.0))
+      .destination(Point.fromLngLat(4.0, 4.0))
+      .addWaypointNames("Home", "Work")
+      .baseUrl("https://foobar.com")
+      .accessToken(ACCESS_TOKEN)
+      .build();
   }
 
   @Test


### PR DESCRIPTION
Fix MapboxDirections builder to allow setting empty arrays to `waypointIndices`, `waypointNames`, `approaches`.
Fix exception messages.

[issue link](https://github.com/mapbox/mapbox-java/issues/1081)