### PR TITLE
BannerText, RouteOptions builders: removed nullable annotations

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/models/BannerText.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/models/BannerText.java
@@ -147,7 +147,6 @@ public abstract class BannerText extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 3.0.0
      */
-    @Nullable
     public abstract Builder text(@NonNull String text);
 
     /**
@@ -157,7 +156,6 @@ public abstract class BannerText extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 3.0.0
      */
-    @Nullable
     public abstract Builder components(List<BannerComponents> components);
 
     /**

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -555,7 +555,6 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 3.0.0
      */
-    @Nullable
     public abstract Builder exclude(@NonNull String exclude);
 
     /**
@@ -565,7 +564,6 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 3.2.0
      */
-    @Nullable
     public abstract Builder approaches(String approaches);
 
     /**
@@ -575,7 +573,6 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 4.4.0
      */
-    @Nullable
     public abstract Builder waypointIndices(@Nullable String indices);
 
     /**
@@ -585,7 +582,6 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 3.3.0
      */
-    @Nullable
     public abstract Builder waypointNames(@Nullable String waypointNames);
 
     /**
@@ -595,9 +591,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @return this builder for chaining options together
      * @since 4.3.0
      */
-    @Nullable
     public abstract Builder waypointTargets(@Nullable String waypointTargets);
-
 
     /**
      * To be used to specify settings for use with the walking profile.


### PR DESCRIPTION
Fix: `BannerText`, `RouteOptions` builders return nullable itself with in some cases