### PR TITLE
RouteOptions parsing fixes

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -124,13 +124,9 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return a string representing the radiuses separated by ;.
    * @since 3.0.0
-   * @deprecated use {@link #radiusesList()} ()}
    */
   @Nullable
-  @Deprecated
-  public String radiuses() {
-    return FormatUtils.formatRadiuses(radiusesList());
-  }
+  public abstract String radiuses();
 
   /**
    * The maximum distance a coordinate can be moved to snap to the road network in meters. There
@@ -140,7 +136,9 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * @return a list of radiuses
    */
   @Nullable
-  public abstract List<Double> radiusesList();
+  public List<Double> radiusesList() {
+    return ParseUtils.parseToDoubles(radiuses());
+  }
 
   /**
    * Influences the direction in which a route starts from a waypoint. Used to filter the road
@@ -155,13 +153,9 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * @return a string representing the bearings with the ; separator. Angle and degrees for every
    *   bearing value are comma-separated.
    * @since 3.0.0
-   * @deprecated use {@link #bearingsList()}
    */
   @Nullable
-  @Deprecated
-  public String bearings() {
-    return FormatUtils.formatBearings(bearingsList());
-  }
+  public abstract String bearings();
 
   /**
    * Influences the direction in which a route starts from a waypoint. Used to filter the road
@@ -176,9 +170,10 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * @return a List of list of doubles representing the bearings used in the original request.
    *         The first value in the list is the angle, the second one is the degrees.
    */
-  @SerializedName("bearings")
   @Nullable
-  public abstract List<List<Double>> bearingsList();
+  public List<List<Double>> bearingsList() {
+    return ParseUtils.parseToListOfListOfDoubles(bearings());
+  }
 
   /**
    * The allowed direction of travel when departing intermediate waypoints. If true, the route
@@ -260,14 +255,9 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return a string containing any of the annotations that were used during the request
    * @since 3.0.0
-   *
-   * @deprecated use {@link #annotationsList()}
    */
-  @Deprecated
   @Nullable
-  public String annotations() {
-    return FormatUtils.join(";", annotationsList(), true);
-  }
+  public abstract String annotations();
 
   /**
    * A list of annotations. Defines whether to return additional metadata along the
@@ -282,9 +272,10 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return a list of annotations that were used during the request
    */
-  @SerializedName("annotations")
   @Nullable
-  public abstract List<String> annotationsList();
+  public List<String> annotationsList() {
+    return ParseUtils.parseToStrings(annotations(), ",");
+  }
 
   /**
    * Exclude certain road types from routing. The default is to not exclude anything from the
@@ -378,13 +369,9 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return a string representing approaches for each waypoint
    * @since 3.2.0
-   * @deprecated use {@link #approachesList()}
    */
-  @Deprecated
   @Nullable
-  public String approaches() {
-    return FormatUtils.formatApproaches(approachesList());
-  }
+  public abstract String approaches();
 
   /**
    * Indicates from which side of the road to approach a waypoint.
@@ -399,9 +386,10 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return a list of strings representing approaches for each waypoint
    */
-  @SerializedName("approaches")
   @Nullable
-  public abstract List<String> approachesList();
+  public List<String> approachesList() {
+    return ParseUtils.parseToStrings(approaches());
+  }
 
   /**
    * Indicates which input coordinates should be treated as waypoints.
@@ -414,13 +402,10 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return a string representing indices to be used as waypoints
    * @since 4.4.0
-   * @deprecated use {@link #waypointIndicesList()}
    */
+  @SerializedName("waypoints")
   @Nullable
-  @Deprecated
-  public String waypointIndices() {
-    return FormatUtils.join(";", waypointIndicesList());
-  }
+  public abstract String waypointIndices();
 
   /**
    * Indicates which input coordinates should be treated as waypoints.
@@ -433,9 +418,10 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return a List of Integers representing indices to be used as waypoints
    */
-  @SerializedName("waypoints")
   @Nullable
-  public abstract List<Integer> waypointIndicesList();
+  public List<Integer> waypointIndicesList() {
+    return ParseUtils.parseToIntegers(waypointIndices());
+  }
 
   /**
    * A semicolon-separated list of custom names for entries in the list of
@@ -447,13 +433,10 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * Must be used in conjunction with {@link RouteOptions#steps()} = true.
    * @return  a string representing names for each waypoint
    * @since 3.3.0
-   * @deprecated use {@link #waypointNamesList()}
    */
+  @SerializedName("waypoint_names")
   @Nullable
-  @Deprecated
-  public String waypointNames() {
-    return FormatUtils.formatWaypointNames(waypointNamesList());
-  }
+  public abstract String waypointNames();
 
   /**
    * A semicolon-separated list of custom names for entries in the list of
@@ -466,10 +449,10 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return  a list of strings representing names for each waypoint
    */
-  @SerializedName("waypoint_names")
   @Nullable
-  public abstract List<String> waypointNamesList();
-
+  public List<String> waypointNamesList() {
+    return ParseUtils.parseToStrings(waypointNames());
+  }
 
   /**
    * A semicolon-separated list of coordinate pairs used to specify drop-off
@@ -637,16 +620,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param radiuses a String of radius values, each separated by ;.
      * @return this builder for chaining options together
      * @since 3.0.0
-     * @deprecated use {@link #radiusesList(List)}
      */
-    @Deprecated
-    public Builder radiuses(@NonNull String radiuses) {
-      List<Double> radiusesList = ParseUtils.parseToDoubles(radiuses);
-      if (radiusesList != null) {
-        radiusesList(radiusesList);
-      }
-      return this;
-    }
+    public abstract Builder radiuses(@NonNull String radiuses);
 
     /**
      * The maximum distance a coordinate can be moved to snap to the road network in meters. There
@@ -656,7 +631,13 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param radiuses a list of radius values
      * @return this builder for chaining options together
      */
-    public abstract Builder radiusesList(@NonNull List<Double> radiuses);
+    public Builder radiusesList(@NonNull List<Double> radiuses) {
+      String result = FormatUtils.formatRadiuses(radiuses);
+      if (result != null) {
+        radiuses(result);
+      }
+      return this;
+    }
 
     /**
      * Influences the direction in which a route starts from a waypoint. Used to filter the road
@@ -673,16 +654,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      *                 for every bearing value are comma-separated.
      * @return this builder for chaining options together
      * @since 3.0.0
-     * @deprecated use {@link #bearingsList(List)}
      */
-    @Deprecated
-    public Builder bearings(@NonNull String bearings) {
-      List<List<Double>> bearingsList = ParseUtils.parseToListOfListOfDoubles(bearings);
-      if (bearingsList != null) {
-        bearingsList(bearingsList);
-      }
-      return this;
-    }
+    public abstract Builder bearings(@NonNull String bearings);
 
     /**
      * Influences the direction in which a route starts from a waypoint. Used to filter the road
@@ -700,7 +673,13 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      *                 degrees.
      * @return this builder for chaining options together
      */
-    public abstract Builder bearingsList(@NonNull List<List<Double>> bearings);
+    public Builder bearingsList(@NonNull List<List<Double>> bearings) {
+      String result = FormatUtils.formatBearings(bearings);
+      if (result != null) {
+        bearings(result);
+      }
+      return this;
+    }
 
     /**
      * Sets the allowed direction of travel when departing intermediate waypoints. If true, the
@@ -787,16 +766,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      *                    requested
      * @return this builder for chaining options together
      * @since 3.0.0
-     * @deprecated use {@link #annotationsList(List)}
      */
-    @Deprecated
-    public Builder annotations(@NonNull String annotations) {
-      List<String>  annotationsList = ParseUtils.parseToStrings(annotations);
-      if (annotationsList != null) {
-        annotationsList(annotationsList);
-      }
-      return this;
-    }
+    public abstract Builder annotations(@NonNull String annotations);
 
     /**
      * Whether to return additional metadata along the route. Possible values are:
@@ -813,7 +784,13 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param annotations a list of annotations
      * @return this builder for chaining options together
      */
-    public abstract Builder annotationsList(@NonNull List<String> annotations);
+    public Builder annotationsList(@NonNull List<String> annotations) {
+      String result = FormatUtils.join(",", annotations);
+      if (result != null) {
+        annotations(result);
+      }
+      return this;
+    }
 
     /**
      * Whether to return SSML marked-up text for voice guidance along the route (true) or not
@@ -906,16 +883,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param approaches unrestricted, curb or omitted (;)
      * @return this builder for chaining options together
      * @since 3.2.0
-     * @deprecated use {@link #approachesList(List)}
      */
-    @Deprecated
-    public Builder approaches(@NonNull String approaches) {
-      List<String>  approachesList = ParseUtils.parseToStrings(approaches);
-      if (approachesList != null) {
-        approachesList(approachesList);
-      }
-      return this;
-    }
+    public abstract Builder approaches(@NonNull String approaches);
 
     /**
      * Indicates from which side of the road to approach a waypoint.
@@ -933,7 +902,13 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param approaches a list of Strings
      * @return this builder for chaining options together
      */
-    public abstract Builder approachesList(@NonNull List<String> approaches);
+    public Builder approachesList(@NonNull List<String> approaches) {
+      String result = FormatUtils.formatApproaches(approaches);
+      if (result != null) {
+        approaches(result);
+      }
+      return this;
+    }
 
     /**
      * Indicates which input coordinates should be treated as waypoints.
@@ -948,16 +923,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param waypointIndices to be used as waypoints
      * @return this builder for chaining options together
      * @since 4.4.0
-     * @deprecated use {@link #waypointIndicesList(List)}
      */
-    @Deprecated
-    public Builder waypointIndices(@NonNull String waypointIndices) {
-      List<Integer> indices = ParseUtils.parseToIntegers(waypointIndices);
-      if (indices != null) {
-        waypointIndicesList(indices);
-      }
-      return this;
-    }
+    public abstract Builder waypointIndices(@NonNull String waypointIndices);
 
     /**
      * Indicates which input coordinates should be treated as waypoints.
@@ -972,7 +939,13 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param indices a list to be used as waypoints
      * @return this builder for chaining options together
      */
-    public abstract Builder waypointIndicesList(@NonNull List<Integer> indices);
+    public Builder waypointIndicesList(@NonNull List<Integer> indices) {
+      String result = FormatUtils.join(";", indices);
+      if (result != null) {
+        waypointIndices(result);
+      }
+      return this;
+    }
 
     /**
      * A semicolon-separated list of custom names for entries in the list of
@@ -987,16 +960,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param waypointNames unrestricted, curb or omitted (;)
      * @return this builder for chaining options together
      * @since 3.3.0
-     * @deprecated use {@link #waypointNamesList(List)}
      */
-    @Deprecated
-    public Builder waypointNames(@NonNull String waypointNames) {
-      List<String> names = ParseUtils.parseToStrings(waypointNames);
-      if (names != null) {
-        waypointNamesList(names);
-      }
-      return this;
-    }
+    public abstract Builder waypointNames(@NonNull String waypointNames);
 
     /**
      * A semicolon-separated list of custom names for entries in the list of
@@ -1011,7 +976,13 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @param waypointNames a list of Strings
      * @return this builder for chaining options together
      */
-    public abstract Builder waypointNamesList(@NonNull List<String> waypointNames);
+    public Builder waypointNamesList(@NonNull List<String> waypointNames) {
+      String result = FormatUtils.formatWaypointNames(waypointNames);
+      if (result != null) {
+        waypointNames(result);
+      }
+      return this;
+    }
 
     /**
      * A semicolon-separated list of coordinate pairs used to specify drop-off

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/utils/ParseUtils.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/utils/ParseUtils.java
@@ -1,5 +1,6 @@
 package com.mapbox.api.directions.v5.utils;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.mapbox.geojson.Point;
 import java.util.ArrayList;
@@ -42,19 +43,31 @@ public class ParseUtils {
   }
 
   /**
-   * Parse a String to a list of Strings.
+   * Parse a String to a list of Strings using ";" as a separator.
    *
    * @param original an original String.
    * @return List of Strings
    */
   @Nullable
   public static List<String> parseToStrings(@Nullable String original) {
+    return parseToStrings(original, SEMICOLON);
+  }
+
+  /**
+   * Parse a String to a list of Strings.
+   *
+   * @param original an original String.
+   * @param separator a String used as a separator.
+   * @return List of Strings
+   */
+  @Nullable
+  public static List<String> parseToStrings(@Nullable String original, @NonNull String separator) {
     if (original == null) {
       return null;
     }
 
     List<String> result = new ArrayList<>();
-    String[] strings = original.split(SEMICOLON);
+    String[] strings = original.split(separator, -1);
     for (String str : strings) {
       if (str != null) {
         if (str.isEmpty()) {
@@ -81,7 +94,7 @@ public class ParseUtils {
     }
 
     List<Point> points = new ArrayList<>();
-    String[] targets = original.split(SEMICOLON);
+    String[] targets = original.split(SEMICOLON, -1);
     for (String target : targets) {
       if (target != null) {
         if (target.isEmpty()) {
@@ -109,7 +122,7 @@ public class ParseUtils {
     }
 
     List<Double> doubles = new ArrayList<>();
-    String[] strings = original.split(SEMICOLON);
+    String[] strings = original.split(SEMICOLON, -1);
     for (String str : strings) {
       if (str != null) {
         if (str.isEmpty()) {

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -16,7 +16,8 @@ import static org.junit.Assert.assertEquals;
 
 public class RouteOptionsTest {
 
-  private static final String ROUTE_OPTIONS_JSON = "{\"baseUrl\":\"base_url\",\"user\":\"user\",\"profile\":\"profile\",\"coordinates\":[[1.0,2.0],[3.0,4.0]],\"access_token\":\"token\",\"uuid\":\"requestUuid\",\"waypoint_targets\":\";33,44;55,66\"}";
+  private static final String ROUTE_OPTIONS_JSON =
+      "{\"baseUrl\":\"https://api.mapbox.com\",\"user\":\"mapbox\",\"profile\":\"driving-traffic\",\"coordinates\":[[-122.4003312,37.7736941],[-122.4187529,37.7689715],[-122.4255172,37.7775835]],\"alternatives\":false,\"language\":\"ru\",\"radiuses\":\";unlimited;100\",\"bearings\":\"0,90;90,0;\",\"continue_straight\":false,\"roundabout_exits\":false,\"geometries\":\"polyline6\",\"overview\":\"full\",\"steps\":true,\"annotations\":\"congestion,distance,duration\",\"exclude\":\"toll\",\"voice_instructions\":true,\"banner_instructions\":true,\"voice_units\":\"metric\",\"access_token\":\"token\",\"uuid\":\"12345543221\",\"approaches\":\";curb;\",\"waypoints\":\"0;1;2\",\"waypoint_names\":\";two;\",\"waypoint_targets\":\";12.2,21.2;\"}";
 
   @Test
   public void toBuilder() {
@@ -49,14 +50,16 @@ public class RouteOptionsTest {
         .radiuses(radiusesStr)
         .build();
 
-    assertEquals(";5.1;;7.4", routeOptions.radiuses());
+    assertEquals(radiusesStr, routeOptions.radiuses());
 
     List<Double> radiuses = routeOptions.radiusesList();
-    assertEquals(4, radiuses.size());
+    assertEquals(6, radiuses.size());
     assertEquals(null, radiuses.get(0));
     assertEquals(Double.valueOf(5.1), radiuses.get(1));
     assertEquals(null, radiuses.get(2));
     assertEquals(Double.valueOf(7.4), radiuses.get(3));
+    assertEquals(null, radiuses.get(4));
+    assertEquals(null, radiuses.get(5));
   }
 
   @Test
@@ -138,15 +141,15 @@ public class RouteOptionsTest {
         .approaches(approachesStr)
         .build();
 
-    assertEquals(";" + APPROACH_CURB + ";" + ";" + APPROACH_UNRESTRICTED,
-        routeOptions.approaches());
+    assertEquals(approachesStr, routeOptions.approaches());
 
     List<String> approaches = routeOptions.approachesList();
-    assertEquals(4, approaches.size());
+    assertEquals(5, approaches.size());
     assertEquals(null, approaches.get(0));
     assertEquals(APPROACH_CURB, approaches.get(1));
     assertEquals(null, approaches.get(2));
     assertEquals(APPROACH_UNRESTRICTED, approaches.get(3));
+    assertEquals(null, approaches.get(4));
   }
 
   @Test
@@ -262,11 +265,14 @@ public class RouteOptionsTest {
     assertEquals("1.2,3.4;;;5.65,7.123;;;", routeOptions.waypointTargets());
 
     List<Point> targets = routeOptions.waypointTargetsList();
-    assertEquals(4, targets.size());
+    assertEquals(7, targets.size());
     assertEquals(Point.fromLngLat(1.2, 3.4), targets.get(0));
     assertEquals(null, targets.get(1));
     assertEquals(null, targets.get(2));
     assertEquals(Point.fromLngLat(5.65, 7.123), targets.get(3));
+    assertEquals(null, targets.get(4));
+    assertEquals(null, targets.get(5));
+    assertEquals(null, targets.get(6));
   }
 
   @Test
@@ -290,14 +296,14 @@ public class RouteOptionsTest {
 
   @Test
   public void annotationsString() {
-    String annotationsStr = ANNOTATION_MAXSPEED + ";" + ANNOTATION_DURATION + ";" + ";";
+    String annotationsStr = ANNOTATION_MAXSPEED + "," + ANNOTATION_DURATION;
 
     RouteOptions routeOptions = routeOptions()
         .toBuilder()
         .annotations(annotationsStr)
         .build();
 
-    assertEquals(ANNOTATION_MAXSPEED + ";" + ANNOTATION_DURATION, routeOptions.annotations());
+    assertEquals(annotationsStr, routeOptions.annotations());
 
     List<String> annotations = routeOptions.annotationsList();
     assertEquals(2, annotations.size());
@@ -312,8 +318,6 @@ public class RouteOptionsTest {
     annotations.add(ANNOTATION_DISTANCE);
     annotations.add(ANNOTATION_MAXSPEED);
     annotations.add(ANNOTATION_SPEED);
-    annotations.add(null);
-    annotations.add(null);
 
     RouteOptions routeOptions = routeOptions()
         .toBuilder()
@@ -321,65 +325,423 @@ public class RouteOptionsTest {
         .build();
 
     assertEquals(annotations, routeOptions.annotationsList());
-    assertEquals("congestion;distance;maxspeed;speed", routeOptions.annotations());
+    assertEquals("congestion,distance,maxspeed,speed", routeOptions.annotations());
   }
 
   @Test
-  public void waypointTargetsStringToJson() {
-    RouteOptions options = routeOptions().toBuilder()
-        .waypointTargets(";33,44;55,66")
-        .build();
+  public void baseUrlIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
 
-    String json = options.toJson();
-
-    assertEquals(ROUTE_OPTIONS_JSON, json);
+    assertEquals("https://api.mapbox.com", routeOptions.baseUrl());
   }
 
   @Test
-  public void waypointTargetsListToJson() {
-    List<Point> waypointTargets = new ArrayList<>();
-    waypointTargets.add(null);
-    waypointTargets.add(Point.fromLngLat(33, 44));
-    waypointTargets.add(Point.fromLngLat(55, 66));
+  public void userIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
 
-    RouteOptions options = routeOptions().toBuilder()
-        .waypointTargetsList(waypointTargets)
-        .build();
-
-    String json = options.toJson();
-
-    assertEquals(ROUTE_OPTIONS_JSON, json);
+    assertEquals("mapbox", routeOptions.user());
   }
 
   @Test
-  public void waypointTargetsStringFromJson() {
+  public void profileIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("driving-traffic", routeOptions.profile());
+  }
+
+  @Test
+  public void coordinatesAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(3, routeOptions.coordinates().size());
+    assertEquals(Point.fromLngLat(-122.4003312, 37.7736941), routeOptions.coordinates().get(0));
+    assertEquals(Point.fromLngLat(-122.4187529, 37.7689715), routeOptions.coordinates().get(1));
+    assertEquals(Point.fromLngLat(-122.4255172, 37.7775835), routeOptions.coordinates().get(2));
+  }
+
+  @Test
+  public void alternativesAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(false, routeOptions.alternatives());
+  }
+
+  @Test
+  public void languageIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("ru", routeOptions.language());
+  }
+
+  @Test
+  public void radiusesAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(";unlimited;100", routeOptions.radiuses());
+  }
+
+  @Test
+  public void radiusesListIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(3, routeOptions.radiusesList().size());
+    assertEquals(null, routeOptions.radiusesList().get(0));
+    assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), routeOptions.radiusesList().get(1));
+    assertEquals(Double.valueOf(100.0), routeOptions.radiusesList().get(2));
+  }
+
+  @Test
+  public void bearingsAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("0,90;90,0;", routeOptions.bearings());
+  }
+
+  @Test
+  public void bearingsListIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(3, routeOptions.bearingsList().size());
+    assertEquals(Double.valueOf(0), routeOptions.bearingsList().get(0).get(0));
+    assertEquals(Double.valueOf(90), routeOptions.bearingsList().get(0).get(1));
+    assertEquals(Double.valueOf(90), routeOptions.bearingsList().get(1).get(0));
+    assertEquals(Double.valueOf(0), routeOptions.bearingsList().get(1).get(1));
+    assertEquals(null, routeOptions.bearingsList().get(2));
+  }
+
+  @Test
+  public void continueStraightIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(false, routeOptions.continueStraight());
+  }
+
+  @Test
+  public void roundaboutExitsIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(false, routeOptions.continueStraight());
+  }
+
+  @Test
+  public void geometriesAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("polyline6", routeOptions.geometries());
+  }
+
+  @Test
+  public void stepsAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(true, routeOptions.steps());
+  }
+
+  @Test
+  public void annotationsAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("congestion,distance,duration", routeOptions.annotations());
+  }
+
+  @Test
+  public void annotationsListIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(3, routeOptions.annotationsList().size());
+    assertEquals("congestion", routeOptions.annotationsList().get(0));
+    assertEquals("distance", routeOptions.annotationsList().get(1));
+    assertEquals("duration", routeOptions.annotationsList().get(2));
+  }
+
+  @Test
+  public void excludeIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("toll", routeOptions.exclude());
+  }
+
+  @Test
+  public void overviewIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("full", routeOptions.overview());
+  }
+
+  @Test
+  public void voiceInstructionsAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(true, routeOptions.voiceInstructions());
+  }
+
+  @Test
+  public void bannerInstructionsAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(true, routeOptions.bannerInstructions());
+  }
+
+  @Test
+  public void voiceUnitsAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("metric", routeOptions.voiceUnits());
+  }
+
+  @Test
+  public void accessTokenIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("token", routeOptions.accessToken());
+  }
+
+  @Test
+  public void uuidIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("12345543221", routeOptions.requestUuid());
+  }
+
+  @Test
+  public void approachesStringIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(";curb;", routeOptions.approaches());
+  }
+
+  @Test
+  public void approachesListIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(3, routeOptions.approachesList().size());
+    assertEquals(null, routeOptions.approachesList().get(0));
+    assertEquals("curb", routeOptions.approachesList().get(1));
+    assertEquals(null, routeOptions.approachesList().get(2));
+  }
+
+  @Test
+  public void waypointIndicesStringIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals("0;1;2", routeOptions.waypointIndices());
+  }
+
+  @Test
+  public void waypointIndicesListIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(3, routeOptions.waypointIndicesList().size());
+    assertEquals(Integer.valueOf(0), routeOptions.waypointIndicesList().get(0));
+    assertEquals(Integer.valueOf(1), routeOptions.waypointIndicesList().get(1));
+    assertEquals(Integer.valueOf(2), routeOptions.waypointIndicesList().get(2));
+  }
+
+  @Test
+  public void waypointNamesStringIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(";two;", routeOptions.waypointNames());
+  }
+
+  @Test
+  public void waypointNamesListIsValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(3, routeOptions.waypointNamesList().size());
+    assertEquals(null, routeOptions.waypointNamesList().get(0));
+    assertEquals("two", routeOptions.waypointNamesList().get(1));
+    assertEquals(null, routeOptions.waypointNamesList().get(2));
+  }
+
+  @Test
+  public void waypointTargetsStringIsValid_fromJson() {
     RouteOptions options = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
 
-    assertEquals(";33,44;55,66", options.waypointTargets());
+    assertEquals(";12.2,21.2;", options.waypointTargets());
   }
 
   @Test
-  public void waypointTargetsListFromJson() {
+  public void waypointTargetsListIsValid_fromJson() {
     RouteOptions options = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
 
     assertEquals(3, options.waypointTargetsList().size());
     assertEquals(null, options.waypointTargetsList().get(0));
-    assertEquals(Point.fromLngLat(33, 44), options.waypointTargetsList().get(1));
-    assertEquals(Point.fromLngLat(55, 66), options.waypointTargetsList().get(2));
+    assertEquals(Point.fromLngLat(12.2, 21.2), options.waypointTargetsList().get(1));
+    assertEquals(null, options.waypointTargetsList().get(2));
+  }
+
+  @Test
+  public void routeOptions_toJson() {
+    RouteOptions options = routeOptions();
+
+    assertEquals(ROUTE_OPTIONS_JSON, options.toJson());
+  }
+
+  @Test
+  public void radiusesList_toJson() {
+    RouteOptions options = routeOptions().toBuilder()
+        .radiuses("")
+        .build();
+
+    List<Double> radiuses = new ArrayList<>();
+    radiuses.add(null);
+    radiuses.add(Double.POSITIVE_INFINITY);
+    radiuses.add(100.0);
+
+    RouteOptions finalOptions = options.toBuilder()
+        .radiusesList(radiuses)
+        .build();
+
+    assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
+  }
+
+  @Test
+  public void bearingsList_toJson() {
+    RouteOptions options = routeOptions().toBuilder()
+        .bearings("")
+        .build();
+
+    List<Double> originBearing = new ArrayList<>();
+    originBearing.add(0.0);
+    originBearing.add(90.0);
+    List<Double> waypointBearing = new ArrayList<>();
+    waypointBearing.add(90.0);
+    waypointBearing.add(0.0);
+
+    List<List<Double>> bearings = new ArrayList<>();
+    bearings.add(originBearing);
+    bearings.add(waypointBearing);
+    bearings.add(null);
+
+    RouteOptions finalOptions = options.toBuilder()
+        .bearingsList(bearings)
+        .build();
+
+    assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
+  }
+
+  @Test
+  public void annotationsList_toJson() {
+    RouteOptions options = routeOptions().toBuilder()
+        .annotations("")
+        .build();
+
+    List<String> annotations = new ArrayList<>();
+    annotations.add("congestion");
+    annotations.add("distance");
+    annotations.add("duration");
+
+    RouteOptions finalOptions = options.toBuilder()
+        .annotationsList(annotations)
+        .build();
+
+    assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
+  }
+
+  @Test
+  public void approachesList_toJson() {
+    RouteOptions options = routeOptions().toBuilder()
+        .approaches("")
+        .build();
+
+    List<String> approaches = new ArrayList<>();
+    approaches.add(null);
+    approaches.add("curb");
+    approaches.add(null);
+
+    RouteOptions finalOptions = options.toBuilder()
+        .approachesList(approaches)
+        .build();
+
+    assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
+  }
+
+  @Test
+  public void waypointIndicesList_toJson() {
+    RouteOptions options = routeOptions().toBuilder()
+        .waypointIndices("")
+        .build();
+
+    List<Integer> waypoints = new ArrayList<>();
+    waypoints.add(0);
+    waypoints.add(1);
+    waypoints.add(2);
+
+    RouteOptions finalOptions = options.toBuilder()
+        .waypointIndicesList(waypoints)
+        .build();
+
+    assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
+  }
+
+  @Test
+  public void waypointNamesList_toJson() {
+    RouteOptions options = routeOptions().toBuilder()
+        .waypointNames("")
+        .build();
+
+    List<String> waypointNames = new ArrayList<>();
+    waypointNames.add(null);
+    waypointNames.add("two");
+    waypointNames.add(null);
+
+    RouteOptions finalOptions = options.toBuilder()
+        .waypointNamesList(waypointNames)
+        .build();
+
+    assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
+  }
+
+  @Test
+  public void waypointTargetsList_toJson() {
+    RouteOptions options = routeOptions().toBuilder()
+        .waypointTargets("")
+        .build();
+
+    List<Point> waypointTargets = new ArrayList<>();
+    waypointTargets.add(null);
+    waypointTargets.add(Point.fromLngLat(12.2, 21.2));
+    waypointTargets.add(null);
+
+    RouteOptions finalOptions = options.toBuilder()
+        .waypointTargetsList(waypointTargets)
+        .build();
+
+    assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
   }
 
   private RouteOptions routeOptions() {
     List<Point> coordinates = new ArrayList<>();
-    coordinates.add(Point.fromLngLat(1.0, 2.0));
-    coordinates.add(Point.fromLngLat(3.0, 4.0));
+    coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
+    coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
+    coordinates.add(Point.fromLngLat(-122.4255172, 37.7775835));
 
     return RouteOptions.builder()
-        .accessToken("token")
-        .baseUrl("base_url")
+        .baseUrl("https://api.mapbox.com")
+        .user("mapbox")
+        .profile("driving-traffic")
         .coordinates(coordinates)
-        .user("user")
-        .profile("profile")
-        .requestUuid("requestUuid")
+        .alternatives(false)
+        .language("ru")
+        .radiuses(";unlimited;100")
+        .bearings("0,90;90,0;")
+        .continueStraight(false)
+        .roundaboutExits(false)
+        .geometries("polyline6")
+        .overview("full")
+        .steps(true)
+        .annotations("congestion,distance,duration")
+        .exclude("toll")
+        .voiceInstructions(true)
+        .bannerInstructions(true)
+        .voiceUnits("metric")
+        .accessToken("token")
+        .requestUuid("12345543221")
+        .approaches(";curb;")
+        .waypointIndices("0;1;2")
+        .waypointNames(";two;")
+        .waypointTargets(";12.2,21.2;")
         .build();
   }
 }


### PR DESCRIPTION
closes #1122 

Changed `RouteOptions` to store data in Strings (not in Lists). It had to be done to save semver.

So, if you pass a list of radiuses for example, it will be stored as a String.
If you want to get a list of radiuses, inner String will be converted to a returned list.

Removed any extra logic from String <-> List converting.
So, you you pass a list with null values, they won't be removed
`set radiusesList(listOf(1, 2, null, null))` -> `"1;2;;"`
get radiusesList() from `"1;2;;"` -> `[1, 2, null, null]`

Also changed parsing logic for `annotations`. They have to be separated with `comma`, not `semicolon`.