### PR TITLE
Adding flexibility to Matrix API builder to set custom max coordinate list size limit

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -382,7 +382,7 @@ public abstract class MapboxDirections extends
    */
   @AutoValue.Builder
   public abstract static class Builder {
-    //TODO change List<Double> to a custom model or to a Pair
+    // TODO: change List<Double> to a custom model or to a Pair
     private List<List<Double>> bearings = new ArrayList<>();
     private List<Point> coordinates = new ArrayList<>();
     private List<String> annotations = new ArrayList<>();

--- a/services-matrix/src/main/java/com/mapbox/api/matrix/v1/MapboxMatrix.java
+++ b/services-matrix/src/main/java/com/mapbox/api/matrix/v1/MapboxMatrix.java
@@ -338,7 +338,7 @@ public abstract class MapboxMatrix extends MapboxService<MatrixResponse, MatrixS
           + "-specific maximum.");
       } else if (coordinateListSizeLimit != null && coordinateListSizeLimit < coordinates.size()) {
         throw new ServicesException("If you're going to use the coordinateListSizeLimit() method,"
-          + " please pass through a number that's greater than the size of"
+          + " please pass through a number that's equal to or greater than the size of"
           + " your coordinate list.");
       }
 

--- a/services-matrix/src/main/java/com/mapbox/api/matrix/v1/MapboxMatrix.java
+++ b/services-matrix/src/main/java/com/mapbox/api/matrix/v1/MapboxMatrix.java
@@ -138,6 +138,7 @@ public abstract class MapboxMatrix extends MapboxService<MatrixResponse, MatrixS
     private String[] approaches;
     private Integer[] destinations;
     private Integer[] sources;
+    private Integer coordinateListSizeLimit;
 
     /**
      * The username for the account that the directions engine runs on. In most cases, this should
@@ -293,6 +294,25 @@ public abstract class MapboxMatrix extends MapboxService<MatrixResponse, MatrixS
      */
     public abstract Builder baseUrl(@NonNull String baseUrl);
 
+    /**
+     * Override the standard maximum coordinate list size of 25 so that you can
+     * make a Matrix API call with a list of coordinates as large as the value you give to
+     * this method.
+     *
+     * You should only use this method if the Mapbox team has enabled your Mapbox
+     * account to be able to request Matrix API information with a list of more than 25
+     * coordinates.
+     *
+     * @param coordinateListSizeLimit the max limit of coordinates used by a single call
+     *
+     * @return this builder for chaining options together
+     * @since 5.1.0
+     */
+    public Builder coordinateListSizeLimit(@NonNull Integer coordinateListSizeLimit) {
+      this.coordinateListSizeLimit = coordinateListSizeLimit;
+      return this;
+    }
+
     abstract MapboxMatrix autoBuild();
 
     /**
@@ -307,8 +327,19 @@ public abstract class MapboxMatrix extends MapboxService<MatrixResponse, MatrixS
       if (coordinates == null || coordinates.size() < 2) {
         throw new ServicesException("At least two coordinates must be provided with your API"
           + " request.");
-      } else if (coordinates.size() > 25) {
-        throw new ServicesException("Maximum of 25 coordinates are allowed for this API.");
+      } else if (coordinateListSizeLimit != null && coordinateListSizeLimit < 0) {
+        throw new ServicesException("If you're going to use the coordinateListSizeLimit() method, "
+          + "please pass through a number that's greater than zero.");
+      } else if (coordinateListSizeLimit == null && coordinates.size() > 25) {
+        throw new ServicesException("A maximum of 25 coordinates is the default "
+          + " allowed for this API. If your Mapbox account has been enabled by the"
+          + " Mapbox team to make a request with more than 25 coordinates, please use"
+          + " the builder's coordinateListSizeLimit() method and pass through your account"
+          + "-specific maximum.");
+      } else if (coordinateListSizeLimit != null && coordinateListSizeLimit < coordinates.size()) {
+        throw new ServicesException("If you're going to use the coordinateListSizeLimit() method,"
+          + " please pass through a number that's greater than the size of"
+          + " your coordinate list.");
       }
 
       coordinates(formatCoordinates(coordinates));

--- a/services-matrix/src/test/java/com/mapbox/api/matrix/v1/MapboxMatrixTest.java
+++ b/services-matrix/src/test/java/com/mapbox/api/matrix/v1/MapboxMatrixTest.java
@@ -260,8 +260,9 @@ public class MapboxMatrixTest extends TestUtils {
     }
 
     thrown.expect(ServicesException.class);
-    thrown.expectMessage("If you're going to use the coordinateListSizeLimit() method," +
-        " please pass through a number that's greater than the size of your coordinate list.");
+    thrown.expectMessage("If you're going to use the coordinateListSizeLimit() method,"
+        + " please pass through a number that's equal to or greater than the size of"
+        + " your coordinate list.");
     MapboxMatrix.builder()
         .accessToken(ACCESS_TOKEN)
         .coordinateListSizeLimit(20)


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-java/issues/1124 by adding support for Matrix API calls with a coordinate list size that's greater than 25. 

After approval from the Mapbox team, a Mapbox account can make Matrix API calls with a coordinate list that's larger than the default of 25. This pr unblocks users from using the Java SDK's `MapboxMatrix.builder()` to make those 26+ calls.

This pr introduces a `.coordinateListSizeLimit()` method, which takes an `Integer` parameter. The parameter represents the new max number of coordinates per call. If the number passed through is higher than what the Mapbox account is allowed (e.g. passing `.coordinateListSizeLimit(50)` when 25 is still the max limit for that Mapbox account/token), the backend API response will respond with an error message. However, at least the Matrix API call will now be allowed/made by the Java SDK rather than an exception being thrown before the call is even made.

cc @juliawinder @chloekraw @brandihaskins @zugaldia 