### PR TITLE
Fix tests running locally

### DIFF
--- a/services-turf/src/test/java/com/mapbox/turf/TestUtils.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TestUtils.java
@@ -8,18 +8,19 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestUtils {
 
@@ -32,10 +33,14 @@ public class TestUtils {
   }
 
   protected String loadJsonFixture(String filename) {
-    ClassLoader classLoader = getClass().getClassLoader();
-    InputStream inputStream = classLoader.getResourceAsStream(filename);
-    Scanner scanner = new Scanner(inputStream, UTF_8.name()).useDelimiter("\\A");
-    return scanner.hasNext() ? scanner.next() : "";
+    try {
+      String filepath = "src/test/resources/" + filename;
+      byte[] encoded = Files.readAllBytes(Paths.get(filepath));
+      return new String(encoded, UTF_8);
+    } catch (IOException e) {
+      fail("Unable to load " + filename);
+      return "";
+    }
   }
 
   public static <T extends Serializable> byte[] serialize(T obj)


### PR DESCRIPTION
Tests in this repository have never worked for me. I've relied on CircleCI to work correctly. Here is the error I get.

```
java.lang.NullPointerException: source

    at java.util.Objects.requireNonNull(Objects.java:228)
    at java.util.Scanner.init(Scanner.java:578)
    at com.mapbox.core.TestUtils.loadJsonFixture(TestUtils.java:33)
..
```

I kind of like what this person says on the internet. "You don't need to mess with class loaders. In fact it's a bad habit to get into because class loader resources are not java.io.File objects when they are in a jar archive."
https://stackoverflow.com/questions/28673651/how-to-get-the-path-of-src-test-resources-directory-in-junit

After taking that approach, all these tests work locally. (ignore the ignored tests, not addressing that right now 😄 )
![Screen Shot 2020-05-14 at 4 41 06 PM](https://user-images.githubusercontent.com/3021882/81996388-b8560400-9601-11ea-8b3d-d9f33227b4ed.png)
