### PR TITLE
Porting TurfMeasurement.center

### DIFF
--- a/docs/turf-port.md
+++ b/docs/turf-port.md
@@ -12,7 +12,7 @@ Below's an on going list of the Turf functions which currently exist inside the 
 - [x] turf-bbox
 - [x] turf-bbox-polygon
 - [x] turf-bearing
-- [ ] turf-center
+- [x] turf-center
 - [ ] turf-center-of-mass
 - [ ] turf-centroid
 - [x] turf-destination

--- a/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java
@@ -631,7 +631,7 @@ public final class TurfMeasurement {
   }
 
   /**
-   * Takes one {@link Geometry} and returns it's area in square meters.
+   * Takes one {@link Geometry} and returns its area in square meters.
    *
    * @param geometry input {@link Geometry}
    * @return area in square meters
@@ -718,5 +718,65 @@ public final class TurfMeasurement {
 
   private static double rad(double num) {
     return num * Math.PI / 180;
+  }
+
+  /**
+   * Takes a {@link Feature} and returns the absolute center of the {@link Feature}.
+   *
+   * @param feature the single {@link Feature} to find the center of.
+   * @param properties a optional {@link JsonObject} containing the properties that should be
+   *                   placed in the returned {@link Feature}.
+   * @param id  an optional common identifier that should be placed in the returned {@link Feature}.
+   * @return a {@link Feature} with a {@link Point} geometry type.
+   * @since 5.3.0
+   */
+  public static Feature center(Feature feature,
+                               @Nullable JsonObject properties,
+                               @Nullable String id) {
+    return center(FeatureCollection.fromFeature(feature), properties, id);
+  }
+
+  /**
+   * Takes a {@link Feature} and returns the absolute center of the {@link Feature}.
+   *
+   * @param feature the single {@link Feature} to find the center of.
+   * @return a {@link Feature} with a {@link Point} geometry type.
+   * @since 5.3.0
+   */
+  public static Feature center(Feature feature) {
+    return center(FeatureCollection.fromFeature(feature), null, null);
+  }
+
+  /**
+   * Takes {@link FeatureCollection} and returns the absolute center
+   * of the {@link Feature}s in the {@link FeatureCollection}.
+   *
+   * @param featureCollection the single {@link FeatureCollection} to find the center of.
+   * @param properties a optional {@link JsonObject} containing the properties that should be
+   *                   placed in the returned {@link Feature}.
+   * @param id  an optional common identifier that should be placed in the returned {@link Feature}.
+   * @return a {@link Feature} with a {@link Point} geometry type.
+   * @since 5.3.0
+   */
+  public static Feature center(FeatureCollection featureCollection,
+                               @Nullable JsonObject properties,
+                               @Nullable String id) {
+    double[] ext = bbox(featureCollection);
+    double finalCenterLongitude = (ext[0] + ext[2]) / 2;
+    double finalCenterLatitude = (ext[1] + ext[3]) / 2;
+    return Feature.fromGeometry(Point.fromLngLat(finalCenterLongitude, finalCenterLatitude),
+        properties, id);
+  }
+
+  /**
+   * Takes {@link FeatureCollection} and returns the absolute center
+   * of the {@link Feature}s in the {@link FeatureCollection}.
+   *
+   * @param featureCollection the single {@link FeatureCollection} to find the center of.
+   * @return a {@link Feature} with a {@link Point} geometry type.
+   * @since 5.3.0
+   */
+  public static Feature center(FeatureCollection featureCollection) {
+    return center(featureCollection, null, null);
   }
 }

--- a/services-turf/src/test/java/com/mapbox/turf/TurfMeasurementTest.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TurfMeasurementTest.java
@@ -1,5 +1,6 @@
 package com.mapbox.turf;
 
+import com.google.gson.JsonObject;
 import com.mapbox.geojson.BoundingBox;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
@@ -25,6 +26,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TurfMeasurementTest extends TestUtils {
 
@@ -507,5 +509,52 @@ public class TurfMeasurementTest extends TestUtils {
     assertEquals(expected, TurfMeasurement.area(FeatureCollection.fromJson(loadJsonFixture(TURF_AREA_FEATURECOLLECTION_POLYGON_GEOJSON))), 1);
   }
 
+  @Test
+  public void centerFeature() {
+    Feature expectedFeature = Feature.fromGeometry(Point.fromLngLat(133.5, -27.0));
+    Feature inputFeature = Feature.fromJson(loadJsonFixture(TURF_AREA_POLYGON_GEOJSON));
+    assertEquals(expectedFeature, TurfMeasurement.center(inputFeature, null, null));
+  }
 
+  @Test
+  public void centerFeatureWithProperties() {
+    JsonObject properties = new JsonObject();
+    properties.addProperty("key", "value");
+    Feature inputFeature = Feature.fromJson(loadJsonFixture(TURF_AREA_POLYGON_GEOJSON));
+    Feature returnedCenterFeature = TurfMeasurement.center(inputFeature, properties, null);
+    Point returnedPoint = (Point) returnedCenterFeature.geometry();
+    if (returnedPoint != null) {
+      assertEquals(133.5, returnedPoint.longitude(), 0);
+      assertEquals(-27.0, returnedPoint.latitude(), 0);
+      if (returnedCenterFeature.properties() != null) {
+        assertTrue(returnedCenterFeature.properties().toString().contains("{\"key\":\"value\"}"));
+      }
+    }
+  }
+
+  @Test
+  public void centerFeatureWithId() {
+    final String testIdString = "testId";
+    Feature inputFeature = Feature.fromJson(loadJsonFixture(TURF_AREA_POLYGON_GEOJSON));
+    Feature returnedCenterFeature = TurfMeasurement.center(inputFeature, null, testIdString);
+    Point returnedPoint = (Point) returnedCenterFeature.geometry();
+    if (returnedPoint != null) {
+      assertEquals(133.5, returnedPoint.longitude(), 0);
+      assertEquals(-27.0, returnedPoint.latitude(), 0);
+      if (returnedCenterFeature.id() != null) {
+        assertEquals(returnedCenterFeature.id(), testIdString);
+      }
+    }
+  }
+
+  @Test
+  public void centerFeatureCollection() {
+    FeatureCollection inputFeatureCollection = FeatureCollection.fromJson(loadJsonFixture(TURF_AREA_FEATURECOLLECTION_POLYGON_GEOJSON));
+    Feature returnedCenterFeature = TurfMeasurement.center(inputFeatureCollection, null, null);
+    Point returnedPoint = (Point) returnedCenterFeature.geometry();
+    if (returnedPoint != null) {
+      assertEquals(4.1748046875, returnedPoint.longitude(), DELTA);
+      assertEquals(47.214224817196836, returnedPoint.latitude(), DELTA);
+    }
+  }
 }


### PR DESCRIPTION
This pr ports http://turfjs.org/docs/#center (https://github.com/Turfjs/turf/blob/master/packages/turf-center/index.ts) to the Mapbox Java SDK. 

Having `TurfMeasurement.center()` inches us one step closer to porting http://turfjs.org/docs/#buffer. The center method is declared [here](https://github.com/Turfjs/turf/blob/master/packages/turf-buffer/index.js#L1) in the turf.js buffer file. Buffer porting is being tracked at https://github.com/mapbox/mapbox-java/issues/987.