### PR TITLE
DirectionRoute: added `durationTypical` for Route, Leg and Step; VERSION_NAME: updated to `5.4.1-SNAPSHOT`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project-wide Gradle settings.
-VERSION_NAME=5.1.0-SNAPSHOT
+VERSION_NAME=5.4.1-SNAPSHOT
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsRoute.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsRoute.java
@@ -60,6 +60,19 @@ public abstract class DirectionsRoute extends DirectionsJsonObject {
   public abstract Double duration();
 
   /**
+   * The typical travel time from this route's origin to destination. There's a delay along
+   * this route if you subtract this durationTypical() value from the route's duration()
+   * value and the resulting difference is greater than 0. The delay is because of any
+   * number of real-world situations (road repair, traffic jam, etc).
+   *
+   * @return a double number with unit seconds
+   * @since 5.5.0
+   */
+  @Nullable
+  @SerializedName("duration_typical")
+  public abstract Double durationTypical();
+
+  /**
    * Gives the geometry of the route. Commonly used to draw the route on the map view.
    *
    * @return an encoded polyline string
@@ -184,6 +197,18 @@ public abstract class DirectionsRoute extends DirectionsJsonObject {
      * @since 3.0.0
      */
     public abstract Builder duration(@NonNull Double duration);
+
+    /**
+     * The typical travel time from this route's origin to destination. There's a delay along
+     * this route if you subtract this durationTypical() value from the route's duration()
+     * value and the resulting difference is greater than 0. The delay is because of any
+     * number of real-world situations (road repair, traffic jam, etc).
+     *
+     * @param durationTypical a double number with unit seconds
+     * @return this builder for chaining options together
+     * @since 5.5.0
+     */
+    public abstract Builder durationTypical(@Nullable Double durationTypical);
 
     /**
      * Gives the geometry of the route. Commonly used to draw the route on the map view.

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/LegStep.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/LegStep.java
@@ -47,6 +47,19 @@ public abstract class LegStep extends DirectionsJsonObject {
   public abstract double duration();
 
   /**
+   * The typical travel time for traversing this LegStep. There's a delay along the LegStep
+   * if you subtract this durationTypical() value from the LegStep duration() value and
+   * the resulting difference is greater than 0. The delay is because of any number
+   * of real-world situations (road repair, traffic jam, etc).
+   *
+   * @return a double number with unit seconds
+   * @since 5.5.0
+   */
+  @Nullable
+  @SerializedName("duration_typical")
+  public abstract Double durationTypical();
+
+  /**
    * Gives the geometry of the leg step.
    *
    * @return an encoded polyline string
@@ -262,6 +275,18 @@ public abstract class LegStep extends DirectionsJsonObject {
      * @since 3.0.0
      */
     public abstract Builder duration(double duration);
+
+    /**
+     * The typical travel time for traversing this LegStep. There's a delay along the LegStep
+     * if you subtract this durationTypical() value from the LegStep duration() value and
+     * the resulting difference is greater than 0. The delay is because of any number
+     * of real-world situations (road repair, traffic jam, etc).
+     *
+     * @param durationTypical a double number with unit seconds
+     * @return this builder for chaining options together
+     * @since 5.5.0
+     */
+    public abstract Builder durationTypical(@Nullable Double durationTypical);
 
     /**
      * Gives the geometry of the leg step.

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteLeg.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteLeg.java
@@ -5,6 +5,7 @@ import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.SerializedName;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 
 import java.util.List;
@@ -44,6 +45,19 @@ public abstract class RouteLeg extends DirectionsJsonObject {
    */
   @Nullable
   public abstract Double duration();
+
+  /**
+   * The typical travel time for traversing this RouteLeg. There's a delay along the RouteLeg
+   * if you subtract this durationTypical() value from the RouteLeg duration() value and
+   * the resulting difference is greater than 0. The delay is because of any number
+   * of real-world situations (road repair, traffic jam, etc).
+   *
+   * @return a double number with unit seconds
+   * @since 5.5.0
+   */
+  @Nullable
+  @SerializedName("duration_typical")
+  public abstract Double durationTypical();
 
   /**
    * A short human-readable summary of major roads traversed. Useful to distinguish alternatives.
@@ -136,6 +150,18 @@ public abstract class RouteLeg extends DirectionsJsonObject {
      * @since 1.0.0
      */
     public abstract Builder duration(@Nullable Double duration);
+
+    /**
+     * The typical travel time for traversing this RouteLeg. There's a delay along the RouteLeg
+     * if you subtract this durationTypical() value from the RouteLeg duration() value and
+     * the resulting difference is greater than 0. The delay is because of any number
+     * of real-world situations (road repair, traffic jam, etc).
+     *
+     * @param durationTypical a double number with unit seconds
+     * @return this builder for chaining options together
+     * @since 5.5.0
+     */
+    public abstract Builder durationTypical(@Nullable Double durationTypical);
 
     /**
      * A short human-readable summary of major roads traversed. Useful to distinguish alternatives.


### PR DESCRIPTION
Added `durationTypical` field for road([DirectionsRoute](https://github.com/mapbox/mapbox-java/blob/master/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsRoute.java)), road's leg([RouteLeg](https://github.com/mapbox/mapbox-java/blob/master/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteLeg.java)) and leg's step([LegStep](https://github.com/mapbox/mapbox-java/blob/master/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/LegStep.java)). It shows up duration of turn-by-turn navigation including delays(like a traffic jam)

VERSION_NAME updated `5.1.0-SNAPSHOT` -> `5.4.1-SNAPSHOT`