### PR TITLE
correct unit references in turf circle methods

### DIFF
--- a/services-turf/src/main/java/com/mapbox/turf/TurfTransformation.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfTransformation.java
@@ -38,8 +38,7 @@ public final class TurfTransformation {
   }
 
   /**
-   * Takes a {@link Point} and calculates the circle polygon given a radius in degrees, radians,
-   * miles, or kilometers; and steps for precision. This uses the {@link #DEFAULT_STEPS}.
+   * Takes a {@link Point} and calculates the circle polygon given a radius in the provided {@link TurfConstants.TurfUnitCriteria}; and steps for precision. This uses the {@link #DEFAULT_STEPS}.
    *
    * @param center a {@link Point} which the circle will center around
    * @param radius the radius of the circle
@@ -53,8 +52,7 @@ public final class TurfTransformation {
   }
 
   /**
-   * Takes a {@link Point} and calculates the circle polygon given a radius in degrees, radians,
-   * miles, or kilometers; and steps for precision.
+   * Takes a {@link Point} and calculates the circle polygon given a radius in the provided {@link TurfConstants.TurfUnitCriteria}; and steps for precision.
    *
    * @param center a {@link Point} which the circle will center around
    * @param radius the radius of the circle


### PR DESCRIPTION
Noticed that there was more flexibility around unit allowed in code than what was indicated in docs with regards to the `TurfTransformation.circle` methods