### PR TITLE
expose intersection's `geometry_index`

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
@@ -136,6 +136,17 @@ public abstract class StepIntersection extends DirectionsJsonObject {
   public abstract String tunnelName();
 
   /**
+   * The zero-based index for the intersection.
+   * This value can be used to apply the duration annotation that corresponds with the intersection.
+   * Only available on the driving profile.
+   *
+   * @return index for the intersection
+   */
+  @Nullable
+  @SerializedName("geometry_index")
+  public abstract Integer geometryIndex();
+
+  /**
    * Convert the current {@link StepIntersection} to its builder holding the currently assigned
    * values. This allows you to modify a single property and then rebuild the object resulting in
    * an updated and modified {@link StepIntersection}.
@@ -261,6 +272,17 @@ public abstract class StepIntersection extends DirectionsJsonObject {
      * @return this builder for chaining options together
      */
     public abstract Builder tunnelName(@Nullable String tunnelName);
+
+    /**
+     * The zero-based index for the intersection.
+     * This value can be used to apply the duration annotation
+     * that corresponds with the intersection.
+     * Only available on the driving profile.
+     *
+     * @param geometryIndex index for the intersection
+     * @return this builder for chaining options together
+     */
+    public abstract Builder geometryIndex(@Nullable Integer geometryIndex);
 
     /**
      * The rawLocation as a double array. Once the {@link StepIntersection} object's created,

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
@@ -44,6 +44,7 @@ public class StepIntersectionTest extends TestUtils {
       .bearings(Arrays.asList(125))
       .rawLocation(new double[]{13.426579, 52.508068})
       .tunnelName("test tunnel")
+      .geometryIndex(123)
       .build();
 
     String jsonString = intersection.toJson();
@@ -74,10 +75,12 @@ public class StepIntersectionTest extends TestUtils {
   public void testFromJson() {
     String stepIntersectionJsonString = "{\"out\": 0, \"entry\": [true], \"bearings\": [ 125 ], "
     + "\"tunnel_name\": \"test tunnel name\","
+    + "\"geometry_index\": 123,"
     + "\"location\": [ 13.426579, 52.508068 ] }";
 
     StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
     Assert.assertEquals("test tunnel name", stepIntersection.tunnelName());
+    Assert.assertEquals(123, stepIntersection.geometryIndex().intValue());
 
     Point location = stepIntersection.location();
     Assert.assertEquals(13.426579, location.longitude(), 0.0001);


### PR DESCRIPTION
Exposes already available `geometry_index` property of the step intersections.