### PR TITLE
- RouteOptions: added `departAt` and `arriveBy`; - Direction Request: arriveBy and departAt params

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -15,6 +15,7 @@ import com.mapbox.api.directions.v5.utils.FormatUtils;
 import com.mapbox.api.directions.v5.utils.ParseUtils;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.PointAsCoordinatesTypeAdapter;
+
 import java.util.List;
 
 /**
@@ -73,7 +74,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * <tt>MapboxDirections</tt> requesting object doesn't specifically set a profile.
    *
    * @return string value representing the profile defined in
-   *         {@link DirectionsCriteria.ProfileCriteria}
+   *   {@link DirectionsCriteria.ProfileCriteria}
    * @since 3.0.0
    */
   @NonNull
@@ -280,16 +281,16 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   /**
    * Exclude certain road types from routing. The default is to not exclude anything from the
    * profile selected. The following exclude flags are available for each profile:
-   *
+   * <p>
    * {@link DirectionsCriteria#PROFILE_DRIVING}: One of {@link DirectionsCriteria#EXCLUDE_TOLL},
    * {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or {@link DirectionsCriteria#EXCLUDE_FERRY}.
-   *
+   * <p>
    * {@link DirectionsCriteria#PROFILE_DRIVING_TRAFFIC}: One of
    * {@link DirectionsCriteria#EXCLUDE_TOLL}, {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or
    * {@link DirectionsCriteria#EXCLUDE_FERRY}.
-   *
+   * <p>
    * {@link DirectionsCriteria#PROFILE_WALKING}: No excludes supported
-   *
+   * <p>
    * {@link DirectionsCriteria#PROFILE_CYCLING}: {@link DirectionsCriteria#EXCLUDE_FERRY}
    *
    * @return a string matching one of the {@link DirectionsCriteria.ExcludeCriteria} exclusions
@@ -431,7 +432,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * coordinates. The first value in the list corresponds to the route origin, not the first
    * destination.
    * Must be used in conjunction with {@link RouteOptions#steps()} = true.
-   * @return  a string representing names for each waypoint
+   *
+   * @return a string representing names for each waypoint
    * @since 3.3.0
    */
   @SerializedName("waypoint_names")
@@ -447,7 +449,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * destination.
    * Must be used in conjunction with {@link RouteOptions#steps()} = true.
    *
-   * @return  a list of strings representing names for each waypoint
+   * @return a list of strings representing names for each waypoint
    */
   @Nullable
   public List<String> waypointNamesList() {
@@ -462,7 +464,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * The maneuver.modifier, banner and voice instructions will be updated with the computed
    * side of street. The number of waypoint targets must be the same as the number of coordinates.
    * Must be used with {@link RouteOptions#steps()} = true.
-   * @return  a list of Points representing coordinate pairs for drop-off locations
+   *
+   * @return a list of Points representing coordinate pairs for drop-off locations
    * @since 4.3.0
    */
   @SerializedName("waypoint_targets")
@@ -477,7 +480,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * The maneuver.modifier, banner and voice instructions will be updated with the computed
    * side of street. The number of waypoint targets must be the same as the number of coordinates.
    * Must be used with {@link RouteOptions#steps()} = true.
-   * @return  a list of Points representing coordinate pairs for drop-off locations
+   *
+   * @return a list of Points representing coordinate pairs for drop-off locations
    */
   @Nullable
   public List<Point> waypointTargetsList() {
@@ -492,6 +496,32 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    */
   @Nullable
   public abstract WalkingOptions walkingOptions();
+
+  /**
+   * The departure time, the local time at the route <b>origin</b>.
+   * The travel time returned in duration is a prediction for travel time based
+   * on historical travel data. The route is calculated in a time-dependent manner.
+   * <p>For example, a trip that takes two hours will consider changing historic traffic conditions
+   * across the two-hour window, instead of only at the specified {@link #departAt()} time.
+   * <p>The route takes timed turn restrictions and conditional access restrictions into account
+   * based on the requested departure time.
+   */
+  @SerializedName("depart_at")
+  @Nullable
+  public abstract String departAt();
+
+  /**
+   * The desired arrival time, the local time at the route <b>destination</b>.
+   * The travel time returned in duration is a prediction for travel
+   * time based on historical travel data. The route is calculated in a time-dependent manner.
+   * <p>For example, a trip that takes two hours will consider changing historic traffic conditions
+   * across the two-hour window.
+   * <p>The route takes timed turn restrictions and conditional access
+   * restrictions into account based on the requested arrival time.
+   */
+  @SerializedName("arrive_by")
+  @Nullable
+  public abstract String arriveBy();
 
   /**
    * Gson type adapter for parsing Gson to this class.
@@ -721,7 +751,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @since 3.1.0
      */
     public abstract Builder geometries(
-        @NonNull @DirectionsCriteria.GeometriesCriteria String geometries);
+      @NonNull @DirectionsCriteria.GeometriesCriteria String geometries);
 
     /**
      * Displays the requested type of overview geometry. Can be
@@ -776,7 +806,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * {@link DirectionsCriteria#ANNOTATION_SPEED}
      * {@link DirectionsCriteria#ANNOTATION_CONGESTION}
      * {@link DirectionsCriteria#ANNOTATION_MAXSPEED}
-     *
+     * <p>
      * See the {@link RouteLeg} object for more details on what is included with
      * annotations.
      * Must be used in conjunction with overview=full.
@@ -848,16 +878,16 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     /**
      * Exclude certain road types from routing. The default is to not exclude anything from the
      * profile selected. The following exclude flags are available for each profile:
-     *
+     * <p>
      * {@link DirectionsCriteria#PROFILE_DRIVING}: One of {@link DirectionsCriteria#EXCLUDE_TOLL},
      * {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or {@link DirectionsCriteria#EXCLUDE_FERRY}.
-     *
+     * <p>
      * {@link DirectionsCriteria#PROFILE_DRIVING_TRAFFIC}: One of
      * {@link DirectionsCriteria#EXCLUDE_TOLL}, {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or
      * {@link DirectionsCriteria#EXCLUDE_FERRY}.
-     *
+     * <p>
      * {@link DirectionsCriteria#PROFILE_WALKING}: No excludes supported
-     *
+     * <p>
      * {@link DirectionsCriteria#PROFILE_CYCLING}: {@link DirectionsCriteria#EXCLUDE_FERRY}
      *
      * @param exclude a string matching one of the {@link DirectionsCriteria.ExcludeCriteria}
@@ -1028,6 +1058,35 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @since 4.8.0
      */
     public abstract Builder walkingOptions(@NonNull WalkingOptions walkingOptions);
+
+    /**
+     * The departure time, the local time at the route <b>origin</b>.
+     * The travel time returned in duration is a prediction for travel time based
+     * on historical travel data. The route is calculated in a time-dependent manner.
+     * <p>For example, a trip that takes two hours will consider changing historic traffic
+     * conditions across the two-hour window, instead of only at the specified
+     * {@link #departAt(String)} time.
+     * <p>The route takes timed turn restrictions and conditional access restrictions into account
+     * based on the requested departure time.
+     *
+     * @param departAt departure time ISO8601, see {@link FormatUtils#ISO_8601_PATTERN}
+     * @return this builder for chaining options together
+     */
+    public abstract Builder departAt(@Nullable String departAt);
+
+    /**
+     * The desired arrival time, the local time at the route <b>destination</b>.
+     * The travel time returned in duration is a prediction for travel
+     * time based on historical travel data. The route is calculated in a time-dependent manner.
+     * <p>For example, a trip that takes two hours will consider changing historic traffic
+     * conditions across the two-hour window.
+     * <p>The route takes timed turn restrictions and conditional access
+     * restrictions into account based on the requested arrival time.
+     *
+     * @param arriveBy arrive time ISO8601, see {@link FormatUtils#ISO_8601_PATTERN}
+     * @return this builder for chaining options together
+     */
+    public abstract Builder arriveBy(@Nullable String arriveBy);
 
     /**
      * Builds a new instance of the {@link RouteOptions} object.

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/utils/FormatUtils.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/utils/FormatUtils.java
@@ -5,7 +5,9 @@ import androidx.annotation.Nullable;
 import com.mapbox.geojson.Point;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -13,6 +15,12 @@ import java.util.Locale;
  * Methods to convert models to Strings.
  */
 public class FormatUtils {
+
+  /**
+   * Date-time <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a> pattern.
+   */
+  public static final String ISO_8601_PATTERN = "yyyy-MM-dd'T'HH:mm";
+
   /**
    * Returns a string containing the tokens joined by delimiters. Doesn't remove trailing nulls.
    *
@@ -253,5 +261,21 @@ public class FormatUtils {
       }
     }
     return join(";", coordinatesToJoin);
+  }
+
+  /**
+   * Format {@link Date} to <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO-8601</a>
+   * Date-Time format.
+   *
+   * @param date that has to be formatted
+   * @see #ISO_8601_PATTERN
+   */
+  @Nullable
+  public static String formatDateToIso8601(@Nullable Date date) {
+    if (date == null) {
+      return null;
+    } else {
+      return new SimpleDateFormat(ISO_8601_PATTERN).format(date);
+    }
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -1,9 +1,26 @@
 package com.mapbox.api.directions.v5.models;
 
+import androidx.annotation.NonNull;
+import com.mapbox.api.directions.v5.utils.FormatUtils;
 import com.mapbox.geojson.Point;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static com.mapbox.api.directions.v5.DirectionsCriteria.ANNOTATION_CONGESTION;
 import static com.mapbox.api.directions.v5.DirectionsCriteria.ANNOTATION_DISTANCE;
@@ -13,11 +30,24 @@ import static com.mapbox.api.directions.v5.DirectionsCriteria.ANNOTATION_SPEED;
 import static com.mapbox.api.directions.v5.DirectionsCriteria.APPROACH_CURB;
 import static com.mapbox.api.directions.v5.DirectionsCriteria.APPROACH_UNRESTRICTED;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RouteOptionsTest {
 
   private static final String ROUTE_OPTIONS_JSON =
-      "{\"baseUrl\":\"https://api.mapbox.com\",\"user\":\"mapbox\",\"profile\":\"driving-traffic\",\"coordinates\":[[-122.4003312,37.7736941],[-122.4187529,37.7689715],[-122.4255172,37.7775835]],\"alternatives\":false,\"language\":\"ru\",\"radiuses\":\";unlimited;100\",\"bearings\":\"0,90;90,0;\",\"continue_straight\":false,\"roundabout_exits\":false,\"geometries\":\"polyline6\",\"overview\":\"full\",\"steps\":true,\"annotations\":\"congestion,distance,duration\",\"exclude\":\"toll\",\"voice_instructions\":true,\"banner_instructions\":true,\"voice_units\":\"metric\",\"access_token\":\"token\",\"uuid\":\"12345543221\",\"approaches\":\";curb;\",\"waypoints\":\"0;1;2\",\"waypoint_names\":\";two;\",\"waypoint_targets\":\";12.2,21.2;\"}";
+    "{\"baseUrl\":\"https://api.mapbox.com\",\"user\":\"mapbox\",\"profile\":\"driving-traffic\",\"coordinates\":[[-122.4003312,37.7736941],[-122.4187529,37.7689715],[-122.4255172,37.7775835]],\"alternatives\":false,\"language\":\"ru\",\"radiuses\":\";unlimited;100\",\"bearings\":\"0,90;90,0;\",\"continue_straight\":false,\"roundabout_exits\":false,\"geometries\":\"polyline6\",\"overview\":\"full\",\"steps\":true,\"annotations\":\"congestion,distance,duration\",\"exclude\":\"toll\",\"voice_instructions\":true,\"banner_instructions\":true,\"voice_units\":\"metric\",\"access_token\":\"token\",\"uuid\":\"12345543221\",\"approaches\":\";curb;\",\"waypoints\":\"0;1;2\",\"waypoint_names\":\";two;\",\"waypoint_targets\":\";12.2,21.2;\",\"depart_at\":\"2020-09-22T06:48\",\"arrive_by\":\"2020-09-22T06:40\"}";
+
+  private Date arriveBy;
+  private Date departAt;
+
+  @Before
+  public void setup() {
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(2020, Calendar.SEPTEMBER, 22, 6, 40); // 2020 Sep 22, 06:40:03
+    arriveBy = calendar.getTime();
+    calendar.set(2020, Calendar.SEPTEMBER, 22, 6, 48); // 2020 Sep 22, 06:48:01
+    departAt = calendar.getTime();
+  }
 
   @Test
   public void toBuilder() {
@@ -27,9 +57,9 @@ public class RouteOptionsTest {
     String url = "new_base_url";
 
     RouteOptions updatedOptions = routeOptions.toBuilder()
-        .language(language)
-        .baseUrl(url)
-        .build();
+      .language(language)
+      .baseUrl(url)
+      .build();
 
     assertEquals(language, updatedOptions.language());
     assertEquals(url, updatedOptions.baseUrl());
@@ -46,9 +76,9 @@ public class RouteOptionsTest {
     String radiusesStr = ";5.1;;7.4;;";
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .radiuses(radiusesStr)
-        .build();
+      .toBuilder()
+      .radiuses(radiusesStr)
+      .build();
 
     assertEquals(radiusesStr, routeOptions.radiuses());
 
@@ -75,9 +105,9 @@ public class RouteOptionsTest {
     radiuses.add(null);
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .radiusesList(radiuses)
-        .build();
+      .toBuilder()
+      .radiusesList(radiuses)
+      .build();
 
     assertEquals(radiuses, routeOptions.radiusesList());
     assertEquals(";;5.7;;4.4;9.9;;", routeOptions.radiuses());
@@ -88,9 +118,9 @@ public class RouteOptionsTest {
     String bearingsString = ";5.1,7.4;;";
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .bearings(bearingsString)
-        .build();
+      .toBuilder()
+      .bearings(bearingsString)
+      .build();
 
     List<Double> bearing = new ArrayList<>();
     bearing.add(5.1);
@@ -124,9 +154,9 @@ public class RouteOptionsTest {
     bearings.add(null);
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .bearingsList(bearings)
-        .build();
+      .toBuilder()
+      .bearingsList(bearings)
+      .build();
 
     assertEquals(bearings, routeOptions.bearingsList());
     assertEquals(";;1.1,2.2;7.7,8.8;", routeOptions.bearings());
@@ -137,9 +167,9 @@ public class RouteOptionsTest {
     String approachesStr = ";" + APPROACH_CURB + ";" + ";" + APPROACH_UNRESTRICTED + ";";
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .approaches(approachesStr)
-        .build();
+      .toBuilder()
+      .approaches(approachesStr)
+      .build();
 
     assertEquals(approachesStr, routeOptions.approaches());
 
@@ -166,9 +196,9 @@ public class RouteOptionsTest {
     approaches.add(null);
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .approachesList(approaches)
-        .build();
+      .toBuilder()
+      .approachesList(approaches)
+      .build();
 
     assertEquals(approaches, routeOptions.approachesList());
     assertEquals("curb;;;unrestricted;unrestricted;;;curb;", routeOptions.approaches());
@@ -179,9 +209,9 @@ public class RouteOptionsTest {
     String indicesStr = "1;4;5;7;8";
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .waypointIndices(indicesStr)
-        .build();
+      .toBuilder()
+      .waypointIndices(indicesStr)
+      .build();
 
     assertEquals("1;4;5;7;8", routeOptions.waypointIndices());
 
@@ -202,9 +232,9 @@ public class RouteOptionsTest {
     indices.add(7);
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .waypointIndicesList(indices)
-        .build();
+      .toBuilder()
+      .waypointIndicesList(indices)
+      .build();
 
     assertEquals(indices, routeOptions.waypointIndicesList());
     assertEquals("1;5;7", routeOptions.waypointIndices());
@@ -215,9 +245,9 @@ public class RouteOptionsTest {
     String namesStr = "ab;;;cd;ef;;;gh;ij";
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .waypointNames(namesStr)
-        .build();
+      .toBuilder()
+      .waypointNames(namesStr)
+      .build();
 
     assertEquals(namesStr, routeOptions.waypointNames());
 
@@ -245,9 +275,9 @@ public class RouteOptionsTest {
     names.add(null);
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .waypointNamesList(names)
-        .build();
+      .toBuilder()
+      .waypointNamesList(names)
+      .build();
 
     assertEquals(names, routeOptions.waypointNamesList());
     assertEquals(";;abc;;def;;", routeOptions.waypointNames());
@@ -258,9 +288,9 @@ public class RouteOptionsTest {
     String targetsStr = "1.2,3.4;;;5.65,7.123;;;";
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .waypointTargets(targetsStr)
-        .build();
+      .toBuilder()
+      .waypointTargets(targetsStr)
+      .build();
 
     assertEquals("1.2,3.4;;;5.65,7.123;;;", routeOptions.waypointTargets());
 
@@ -286,9 +316,9 @@ public class RouteOptionsTest {
     targets.add(Point.fromLngLat(1.55, 8.99));
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .waypointTargetsList(targets)
-        .build();
+      .toBuilder()
+      .waypointTargetsList(targets)
+      .build();
 
     assertEquals(targets, routeOptions.waypointTargetsList());
     assertEquals(";;5.55,7.77;1.22,3.44;;1.55,8.99", routeOptions.waypointTargets());
@@ -299,9 +329,9 @@ public class RouteOptionsTest {
     String annotationsStr = ANNOTATION_MAXSPEED + "," + ANNOTATION_DURATION;
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .annotations(annotationsStr)
-        .build();
+      .toBuilder()
+      .annotations(annotationsStr)
+      .build();
 
     assertEquals(annotationsStr, routeOptions.annotations());
 
@@ -320,9 +350,9 @@ public class RouteOptionsTest {
     annotations.add(ANNOTATION_SPEED);
 
     RouteOptions routeOptions = routeOptions()
-        .toBuilder()
-        .annotationsList(annotations)
-        .build();
+      .toBuilder()
+      .annotationsList(annotations)
+      .build();
 
     assertEquals(annotations, routeOptions.annotationsList());
     assertEquals("congestion,distance,maxspeed,speed", routeOptions.annotations());
@@ -572,6 +602,27 @@ public class RouteOptionsTest {
   }
 
   @Test
+  public void arriveByIsValid_fromJson() {
+    RouteOptions options = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+
+    assertEquals(
+      FormatUtils.formatDateToIso8601(arriveBy),
+      options.arriveBy()
+    );
+  }
+
+  @Test
+  public void departAtIsValid_fromJson() {
+    RouteOptions options = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(
+      FormatUtils.formatDateToIso8601(departAt),
+      options.departAt()
+    );
+  }
+
+  @Test
   public void routeOptions_toJson() {
     RouteOptions options = routeOptions();
 
@@ -581,8 +632,8 @@ public class RouteOptionsTest {
   @Test
   public void radiusesList_toJson() {
     RouteOptions options = routeOptions().toBuilder()
-        .radiuses("")
-        .build();
+      .radiuses("")
+      .build();
 
     List<Double> radiuses = new ArrayList<>();
     radiuses.add(null);
@@ -590,8 +641,8 @@ public class RouteOptionsTest {
     radiuses.add(100.0);
 
     RouteOptions finalOptions = options.toBuilder()
-        .radiusesList(radiuses)
-        .build();
+      .radiusesList(radiuses)
+      .build();
 
     assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
   }
@@ -599,8 +650,8 @@ public class RouteOptionsTest {
   @Test
   public void bearingsList_toJson() {
     RouteOptions options = routeOptions().toBuilder()
-        .bearings("")
-        .build();
+      .bearings("")
+      .build();
 
     List<Double> originBearing = new ArrayList<>();
     originBearing.add(0.0);
@@ -615,8 +666,8 @@ public class RouteOptionsTest {
     bearings.add(null);
 
     RouteOptions finalOptions = options.toBuilder()
-        .bearingsList(bearings)
-        .build();
+      .bearingsList(bearings)
+      .build();
 
     assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
   }
@@ -624,8 +675,8 @@ public class RouteOptionsTest {
   @Test
   public void annotationsList_toJson() {
     RouteOptions options = routeOptions().toBuilder()
-        .annotations("")
-        .build();
+      .annotations("")
+      .build();
 
     List<String> annotations = new ArrayList<>();
     annotations.add("congestion");
@@ -633,8 +684,8 @@ public class RouteOptionsTest {
     annotations.add("duration");
 
     RouteOptions finalOptions = options.toBuilder()
-        .annotationsList(annotations)
-        .build();
+      .annotationsList(annotations)
+      .build();
 
     assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
   }
@@ -642,8 +693,8 @@ public class RouteOptionsTest {
   @Test
   public void approachesList_toJson() {
     RouteOptions options = routeOptions().toBuilder()
-        .approaches("")
-        .build();
+      .approaches("")
+      .build();
 
     List<String> approaches = new ArrayList<>();
     approaches.add(null);
@@ -651,8 +702,8 @@ public class RouteOptionsTest {
     approaches.add(null);
 
     RouteOptions finalOptions = options.toBuilder()
-        .approachesList(approaches)
-        .build();
+      .approachesList(approaches)
+      .build();
 
     assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
   }
@@ -660,8 +711,8 @@ public class RouteOptionsTest {
   @Test
   public void waypointIndicesList_toJson() {
     RouteOptions options = routeOptions().toBuilder()
-        .waypointIndices("")
-        .build();
+      .waypointIndices("")
+      .build();
 
     List<Integer> waypoints = new ArrayList<>();
     waypoints.add(0);
@@ -669,8 +720,8 @@ public class RouteOptionsTest {
     waypoints.add(2);
 
     RouteOptions finalOptions = options.toBuilder()
-        .waypointIndicesList(waypoints)
-        .build();
+      .waypointIndicesList(waypoints)
+      .build();
 
     assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
   }
@@ -678,8 +729,8 @@ public class RouteOptionsTest {
   @Test
   public void waypointNamesList_toJson() {
     RouteOptions options = routeOptions().toBuilder()
-        .waypointNames("")
-        .build();
+      .waypointNames("")
+      .build();
 
     List<String> waypointNames = new ArrayList<>();
     waypointNames.add(null);
@@ -687,8 +738,8 @@ public class RouteOptionsTest {
     waypointNames.add(null);
 
     RouteOptions finalOptions = options.toBuilder()
-        .waypointNamesList(waypointNames)
-        .build();
+      .waypointNamesList(waypointNames)
+      .build();
 
     assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
   }
@@ -696,8 +747,8 @@ public class RouteOptionsTest {
   @Test
   public void waypointTargetsList_toJson() {
     RouteOptions options = routeOptions().toBuilder()
-        .waypointTargets("")
-        .build();
+      .waypointTargets("")
+      .build();
 
     List<Point> waypointTargets = new ArrayList<>();
     waypointTargets.add(null);
@@ -705,8 +756,8 @@ public class RouteOptionsTest {
     waypointTargets.add(null);
 
     RouteOptions finalOptions = options.toBuilder()
-        .waypointTargetsList(waypointTargets)
-        .build();
+      .waypointTargetsList(waypointTargets)
+      .build();
 
     assertEquals(ROUTE_OPTIONS_JSON, finalOptions.toJson());
   }
@@ -718,30 +769,32 @@ public class RouteOptionsTest {
     coordinates.add(Point.fromLngLat(-122.4255172, 37.7775835));
 
     return RouteOptions.builder()
-        .baseUrl("https://api.mapbox.com")
-        .user("mapbox")
-        .profile("driving-traffic")
-        .coordinates(coordinates)
-        .alternatives(false)
-        .language("ru")
-        .radiuses(";unlimited;100")
-        .bearings("0,90;90,0;")
-        .continueStraight(false)
-        .roundaboutExits(false)
-        .geometries("polyline6")
-        .overview("full")
-        .steps(true)
-        .annotations("congestion,distance,duration")
-        .exclude("toll")
-        .voiceInstructions(true)
-        .bannerInstructions(true)
-        .voiceUnits("metric")
-        .accessToken("token")
-        .requestUuid("12345543221")
-        .approaches(";curb;")
-        .waypointIndices("0;1;2")
-        .waypointNames(";two;")
-        .waypointTargets(";12.2,21.2;")
-        .build();
+      .baseUrl("https://api.mapbox.com")
+      .user("mapbox")
+      .profile("driving-traffic")
+      .coordinates(coordinates)
+      .alternatives(false)
+      .language("ru")
+      .radiuses(";unlimited;100")
+      .bearings("0,90;90,0;")
+      .continueStraight(false)
+      .roundaboutExits(false)
+      .geometries("polyline6")
+      .overview("full")
+      .steps(true)
+      .annotations("congestion,distance,duration")
+      .exclude("toll")
+      .voiceInstructions(true)
+      .bannerInstructions(true)
+      .voiceUnits("metric")
+      .accessToken("token")
+      .requestUuid("12345543221")
+      .approaches(";curb;")
+      .waypointIndices("0;1;2")
+      .waypointNames(";two;")
+      .waypointTargets(";12.2,21.2;")
+      .arriveBy(FormatUtils.formatDateToIso8601(arriveBy))
+      .departAt(FormatUtils.formatDateToIso8601(departAt))
+      .build();
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/utils/FormatUtilsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/utils/FormatUtilsTest.java
@@ -1,0 +1,36 @@
+package com.mapbox.api.directions.v5.utils;
+
+import com.mapbox.core.TestUtils;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.Calendar;
+import java.util.Date;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FormatUtilsTest extends TestUtils {
+
+  @Test
+  public void formatDateTimeToIso8601() throws ParseException {
+    // parse string
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+    Date d1 = df.parse("2010-11-02 16:18");
+    // calendar
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(2013, Calendar.APRIL, 3, 14, 32);
+    Date d2 = calendar.getTime();
+    calendar.set(2016, Calendar.MAY, 1, 8, 45, 44);
+    Date d3 = calendar.getTime();
+    calendar.set(2020, Calendar.DECEMBER, 16, 10, 9, 31);
+    Date d4 = calendar.getTime();
+
+    assertEquals("2010-11-02T16:18", FormatUtils.formatDateToIso8601(d1));
+    assertEquals("2013-04-03T14:32", FormatUtils.formatDateToIso8601(d2));
+    assertEquals("2016-05-01T08:45", FormatUtils.formatDateToIso8601(d3));
+    assertEquals("2020-12-16T10:09", FormatUtils.formatDateToIso8601(d4));
+  }
+}

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsResponseFactory.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsResponseFactory.java
@@ -78,6 +78,8 @@ class DirectionsResponseFactory {
           .requestUuid(response.body().uuid())
           .baseUrl(mapboxDirections.baseUrl())
           .walkingOptions(mapboxDirections.walkingOptions())
+          .departAt(mapboxDirections.departAt())
+          .arriveBy(mapboxDirections.arriveBy())
           .build()
       ).build());
     }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
@@ -59,6 +59,10 @@ public interface DirectionsService {
    * @param walkwayBias         a factor that modifies the cost when encountering roads or paths
    *                            that do not allow vehicles and are set aside for pedestrian use
    * @param alleyBias           a factor that modifies the cost when alleys are encountered
+   * @param arriveBy            the desired arrival time, formatted as a timestamp in ISO-8601
+   *                            format in the local time at the route <b>destination</b>
+   * @param departAt            the departure time, formatted as a timestamp in ISO-8601
+   *                            format in the local time at the route <b>origin</b>
    * @return the {@link DirectionsResponse} in a Call wrapper
    * @since 1.0.0
    */
@@ -90,7 +94,9 @@ public interface DirectionsService {
     @Query("enable_refresh") Boolean enableRefresh,
     @Query("walking_speed") Double walkingSpeed,
     @Query("walkway_bias") Double walkwayBias,
-    @Query("alley_bias") Double alleyBias
+    @Query("alley_bias") Double alleyBias,
+    @Query("arrive_by") String arriveBy,
+    @Query("depart_at") String departAt
   );
 
   /**
@@ -134,6 +140,10 @@ public interface DirectionsService {
    * @param walkwayBias         a factor that modifies the cost when encountering roads or paths
    *                            that do not allow vehicles and are set aside for pedestrian use
    * @param alleyBias           a factor that modifies the cost when alleys are encountered
+   * @param arriveBy            the desired arrival time, formatted as a timestamp in ISO-8601
+   *                            format in the local time at the route <b>destination</b>
+   * @param departAt            the departure time, formatted as a timestamp in ISO-8601
+   *                            format in the local time at the route <b>origin</b>
    * @return the {@link DirectionsResponse} in a Call wrapper
    * @since 4.6.0
    */
@@ -166,6 +176,8 @@ public interface DirectionsService {
     @Field("enable_refresh") Boolean enableRefresh,
     @Field("walking_speed") Double walkingSpeed,
     @Field("walkway_bias") Double walkwayBias,
-    @Field("alley_bias") Double alleyBias
+    @Field("alley_bias") Double alleyBias,
+    @Field("arrive_by") String arriveBy,
+    @Field("depart_at") String departAt
   );
 }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -49,9 +49,9 @@ import retrofit2.Response;
  * </p>
  *
  * @see <a href="https://www.mapbox.com/android-docs/java-sdk/overview/directions/">Android
- * Directions documentation</a>
+ *   Directions documentation</a>
  * @see <a href="https://www.mapbox.com/api-documentation/navigation/#directions">Directions API
- * documentation</a>
+ *   documentation</a>
  * @since 1.0.0
  */
 @AutoValue
@@ -111,7 +111,9 @@ public abstract class MapboxDirections extends
       enableRefresh(),
       walkingSpeed(),
       walkwayBias(),
-      alleyBias()
+      alleyBias(),
+      arriveBy(),
+      departAt()
     );
   }
 
@@ -143,7 +145,9 @@ public abstract class MapboxDirections extends
       enableRefresh(),
       walkingSpeed(),
       walkwayBias(),
-      alleyBias()
+      alleyBias(),
+      arriveBy(),
+      departAt()
     );
   }
 
@@ -310,6 +314,12 @@ public abstract class MapboxDirections extends
 
   @Nullable
   abstract WalkingOptions walkingOptions();
+
+  @Nullable
+  abstract String arriveBy();
+
+  @Nullable
+  abstract String departAt();
 
   @Nullable
   Double walkingSpeed() {
@@ -552,7 +562,7 @@ public abstract class MapboxDirections extends
      *                 written in when returned
      * @return this builder for chaining options together
      * @see <a href="https://www.mapbox.com/api-documentation/navigation/#instructions-languages">Supported
-     * Languages</a>
+     *   Languages</a>
      * @since 2.2.0
      */
     public Builder language(@Nullable Locale language) {
@@ -586,7 +596,7 @@ public abstract class MapboxDirections extends
      *                    or null which will result in no annotations being used
      * @return this builder for chaining options together
      * @see <a href="https://www.mapbox.com/api-documentation/navigation/#route-leg-object">RouteLeg object
-     * documentation</a>
+     *   documentation</a>
      * @since 2.1.0
      * @deprecated use {@link #annotations(List)}
      */
@@ -618,7 +628,7 @@ public abstract class MapboxDirections extends
      * @param annotation string referencing one of the annotation direction criteria's.
      * @return this builder for chaining options together
      * @see <a href="https://www.mapbox.com/api-documentation/navigation/#route-leg-object">RouteLeg object
-     * documentation</a>
+     *   documentation</a>
      * @since 2.1.0
      */
     public Builder addAnnotation(@AnnotationCriteria @NonNull String annotation) {
@@ -667,11 +677,11 @@ public abstract class MapboxDirections extends
      * dictates the angle of approach. This option should always be used in conjunction with the
      * {@link #radiuses} parameter.
      *
-     * @param bearings  a list of list of doubles. Every list has two values:
-     *                  the first is an angle clockwise from true north between 0 and 360. The
-     *                  second is the range of degrees the angle can deviate by. We recommend
-     *                  a value of 45 degrees or 90 degrees for the range, as bearing measurements
-     *                  tend to be inaccurate.
+     * @param bearings a list of list of doubles. Every list has two values:
+     *                 the first is an angle clockwise from true north between 0 and 360. The
+     *                 second is the range of degrees the angle can deviate by. We recommend
+     *                 a value of 45 degrees or 90 degrees for the range, as bearing measurements
+     *                 tend to be inaccurate.
      * @return this builder for chaining options together
      */
     public Builder bearings(@NonNull List<List<Double>> bearings) {
@@ -1068,6 +1078,7 @@ public abstract class MapboxDirections extends
     /**
      * Use POST method to request data.
      * The default is to use GET.
+     *
      * @return this builder for chaining options together
      * @since 4.6.0
      */
@@ -1078,6 +1089,7 @@ public abstract class MapboxDirections extends
 
     /**
      * Use GET method to request data.
+     *
      * @return this builder for chaining options together
      * @since 4.6.0
      */
@@ -1097,6 +1109,41 @@ public abstract class MapboxDirections extends
 
     abstract WalkingOptions walkingOptions();
 
+    /**
+     * The desired arrival time, the local time at the route <b>destination</b>.
+     * The travel time returned in duration is a prediction for travel
+     * time based on historical travel data. The route is calculated in a time-dependent manner.
+     * <p>For example, a trip that takes two hours will consider changing historic traffic
+     * conditions across the two-hour window.
+     * <p>The route takes timed turn restrictions and conditional access
+     * restrictions into account based on the requested arrival time.
+     *
+     * @param arriveBy arrive time ISO8601, see {@link FormatUtils#ISO_8601_PATTERN}
+     * @return this builder for chaining options together
+     */
+    public abstract Builder arriveBy(@Nullable String arriveBy);
+
+    @Nullable
+    abstract String arriveBy();
+
+    /**
+     * The departure time, the local time at the route <b>origin</b>.
+     * The travel time returned in duration is a prediction for travel time based
+     * on historical travel data. The route is calculated in a time-dependent manner.
+     * <p>For example, a trip that takes two hours will consider changing historic traffic
+     * conditions across the two-hour window, instead of only at the specified
+     * {@link #departAt(String)} time.
+     * <p>The route takes timed turn restrictions and conditional access restrictions into account
+     * based on the requested departure time.
+     *
+     * @param departAt departure time ISO8601, see {@link FormatUtils#ISO_8601_PATTERN}
+     * @return this builder for chaining options together
+     */
+    public abstract Builder departAt(@Nullable String departAt);
+
+    @Nullable
+    abstract String departAt();
+
     abstract Builder usePostMethod(@NonNull Boolean usePost);
 
     abstract Boolean usePostMethod();
@@ -1105,8 +1152,8 @@ public abstract class MapboxDirections extends
 
     /**
      * This uses the provided parameters set using the {@link Builder} and first checks that all
-     * values are valid, formats the values as strings for easier consumption by the API, and lastly
-     * creates a new {@link MapboxDirections} object with the values provided.
+     * values are valid, formats the values as strings for easier consumption by the API, and
+     * lastly creates a new {@link MapboxDirections} object with the values provided.
      *
      * @return a new instance of Mapbox Directions
      * @since 2.1.0

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -9,16 +9,16 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.Incident;
 import com.mapbox.api.directions.v5.models.LegAnnotation;
 import com.mapbox.api.directions.v5.models.RouteOptions;
+import com.mapbox.api.directions.v5.utils.FormatUtils;
 import com.mapbox.api.directions.v5.utils.ParseUtils;
 import com.mapbox.core.TestUtils;
 import com.mapbox.core.exceptions.ServicesException;
 import com.mapbox.geojson.Point;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Random;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.*;
+
 import okhttp3.Call;
 import okhttp3.EventListener;
 import okhttp3.HttpUrl;
@@ -230,6 +230,44 @@ public class MapboxDirectionsTest extends TestUtils {
       .walkingOptions(WalkingOptions.builder().alleyBias(1d).build())
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("alley_bias=1.0"));
+  }
+
+  @Test
+  public void build_arrivedByOption(){
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(2020, Calendar.SEPTEMBER, 22, 9, 47);
+    Date arriveBy = calendar.getTime();
+
+    MapboxDirections directions = MapboxDirections.builder()
+      .destination(Point.fromLngLat(13.4930, 9.958))
+      .origin(Point.fromLngLat(1.234, 2.345))
+      .accessToken(ACCESS_TOKEN)
+      .arriveBy(FormatUtils.formatDateToIso8601(arriveBy))
+      .build();
+
+    assertEquals(
+            directions.cloneCall().request().url().queryParameter("arrive_by"),
+            FormatUtils.formatDateToIso8601(arriveBy)
+    );
+  }
+
+  @Test
+  public void build_departAtOption(){
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(2020, Calendar.SEPTEMBER, 22, 9, 48);
+    Date departAt = calendar.getTime();
+
+    MapboxDirections directions = MapboxDirections.builder()
+      .destination(Point.fromLngLat(13.4930, 9.958))
+      .origin(Point.fromLngLat(1.234, 2.345))
+      .accessToken(ACCESS_TOKEN)
+      .departAt(FormatUtils.formatDateToIso8601(departAt))
+      .build();
+
+    assertEquals(
+            directions.cloneCall().request().url().queryParameter("depart_at"),
+            FormatUtils.formatDateToIso8601(departAt)
+    );
   }
 
   @Test


### PR DESCRIPTION
Pull request introduces two new fields to Directions' requests(also to `RouteOptions` as it provides fields for `MapboxDirections`): 
- _arriveBy_: the desired arrival time, formatted as a timestamp in ISO-8601 format in the local time at the route **destination**
- _departAt_: the departure time, formatted as a timestamp in ISO-8601 format in the local time at the route **origin**