### PR TITLE
Expose border crossings, rest stops and toll collection

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/Admin.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/Admin.java
@@ -1,0 +1,103 @@
+package com.mapbox.api.directions.v5.models;
+
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
+
+/**
+ * An objects describing the administrative boundaries the route leg travels through.
+ */
+@AutoValue
+public abstract class Admin extends DirectionsJsonObject {
+
+  /**
+   * Contains the 2 character ISO 3166-1 alpha-2 code that applies to a country boundary.
+   * Example: `"US"`.
+   */
+  @Nullable
+  @SerializedName("iso_3166_1")
+  public abstract String countryCode();
+
+  /**
+   * Contains the 3 character ISO 3166-1 alpha-3 code that applies to a country boundary.
+   * Example: `"USA"`.
+   */
+  @Nullable
+  @SerializedName("iso_3166_1_alpha3")
+  public abstract String countryCodeAlpha3();
+
+  /**
+   * Create a new instance of this class by using the {@link Builder} class.
+   *
+   * @return this classes {@link Builder} for creating a new instance
+   */
+  public static Builder builder() {
+    return new AutoValue_Admin.Builder();
+  }
+
+  /**
+   * Convert the current {@link Admin} to its builder holding the currently assigned
+   * values. This allows you to modify a single property and then rebuild the object resulting in
+   * an updated and modified {@link Admin}.
+   *
+   * @return a {@link Builder} with the same values set to match the ones defined in this {@link
+   * Admin}
+   */
+  public abstract Builder toBuilder();
+
+  /**
+   * Gson type adapter for parsing Gson to this class.
+   *
+   * @param gson the built {@link Gson} object
+   * @return the type adapter for this class
+   */
+  public static TypeAdapter<Admin> typeAdapter(Gson gson) {
+    return new AutoValue_Admin.GsonTypeAdapter(gson);
+  }
+
+  /**
+   * Create a new instance of this class by passing in a formatted valid JSON String.
+   *
+   * @param json a formatted valid JSON string defining an Incident
+   * @return a new instance of this class defined by the values passed in the method
+   */
+  public static Admin fromJson(String json) {
+    GsonBuilder gson = new GsonBuilder();
+    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
+    return gson.create().fromJson(json, Admin.class);
+  }
+
+  /**
+   * This builder can be used to set the values describing the {@link Admin}.
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    /**
+     * The 2 character ISO 3166-1 alpha-2 code that applies to a country boundary.
+     * Example: `"US"`.
+     *
+     * @param countryCode 2 character ISO 3166-1 alpha-2 code
+     */
+    public abstract Builder countryCode(@Nullable String countryCode);
+
+    /**
+     * The 3 character ISO 3166-1 alpha-3 code that applies to a country boundary.
+     * Example: `"USA"`.
+     *
+     * @param countryCodeAlpha3 3 character ISO 3166-1 alpha-3 code
+     */
+    public abstract Builder countryCodeAlpha3(@Nullable String countryCodeAlpha3);
+
+    /**
+     * Build a new {@link Admin} object.
+     *
+     * @return a new {@link Admin} using the provided values in this builder
+     */
+    public abstract Admin build();
+  }
+}

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/MapboxStreetsV8.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/MapboxStreetsV8.java
@@ -17,9 +17,13 @@ import com.mapbox.api.directions.v5.DirectionsCriteria;
 @AutoValue
 public abstract class MapboxStreetsV8 extends DirectionsJsonObject {
 
-  // TODO update docs below
   /**
-   * Class of the road exiting the intersection.
+   * The road class of the road exiting the intersection as defined by the
+   *<a href="https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#--road---class-text">
+   *   Mapbox Streets v8 road class specification</a>.
+   * Valid values are the same as those supported by Mapbox Streets v8.
+   * Examples include: `motorway`, `motorway_link`, `primary`, and `street`.
+   * Note that adding new possible values is not considered a breaking change.
    *
    * @return class of the road.
    */

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RestStop.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RestStop.java
@@ -1,31 +1,28 @@
 package com.mapbox.api.directions.v5.models;
 
 import androidx.annotation.Nullable;
+
 import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.SerializedName;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 
 /**
- * An object containing detailed information about the road exiting the intersection along the
- * route.
+ * An object containing information about passing rest stops along the route.
  * Only available on the {@link DirectionsCriteria#PROFILE_DRIVING} profile.
  */
 @AutoValue
-public abstract class MapboxStreetsV8 extends DirectionsJsonObject {
+public abstract class RestStop extends DirectionsJsonObject {
 
-  // TODO update docs below
   /**
-   * Class of the road exiting the intersection.
-   *
-   * @return class of the road.
+   * The type of rest stop, either `rest_area` (includes parking only) or `service_area`
+   * (includes amenities such as gas or restaurants).
+   * Note that adding new possible types is not considered a breaking change.
    */
   @Nullable
-  @SerializedName("class")
-  public abstract String roadClass();
+  public abstract String type();
 
   /**
    * Create a new instance of this class by using the {@link Builder} class.
@@ -33,16 +30,16 @@ public abstract class MapboxStreetsV8 extends DirectionsJsonObject {
    * @return this classes {@link Builder} for creating a new instance
    */
   public static Builder builder() {
-    return new AutoValue_MapboxStreetsV8.Builder();
+    return new AutoValue_RestStop.Builder();
   }
 
   /**
-   * Convert the current {@link MapboxStreetsV8} to its builder holding the currently assigned
+   * Convert the current {@link RestStop} to its builder holding the currently assigned
    * values. This allows you to modify a single property and then rebuild the object resulting in
-   * an updated and modified {@link MapboxStreetsV8}.
+   * an updated and modified {@link RestStop}.
    *
    * @return a {@link Builder} with the same values set to match the ones defined in this {@link
-   * MapboxStreetsV8}
+   * RestStop}
    */
   public abstract Builder toBuilder();
 
@@ -52,8 +49,8 @@ public abstract class MapboxStreetsV8 extends DirectionsJsonObject {
    * @param gson the built {@link Gson} object
    * @return the type adapter for this class
    */
-  public static TypeAdapter<MapboxStreetsV8> typeAdapter(Gson gson) {
-    return new AutoValue_MapboxStreetsV8.GsonTypeAdapter(gson);
+  public static TypeAdapter<RestStop> typeAdapter(Gson gson) {
+    return new AutoValue_RestStop.GsonTypeAdapter(gson);
   }
 
   /**
@@ -62,31 +59,32 @@ public abstract class MapboxStreetsV8 extends DirectionsJsonObject {
    * @param json a formatted valid JSON string defining an Incident
    * @return a new instance of this class defined by the values passed in the method
    */
-  public static MapboxStreetsV8 fromJson(String json) {
+  public static RestStop fromJson(String json) {
     GsonBuilder gson = new GsonBuilder();
     gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
-    return gson.create().fromJson(json, MapboxStreetsV8.class);
+    return gson.create().fromJson(json, RestStop.class);
   }
 
   /**
-   * This builder can be used to set the values describing the {@link MapboxStreetsV8}.
+   * This builder can be used to set the values describing the {@link RestStop}.
    */
   @AutoValue.Builder
   public abstract static class Builder {
 
     /**
-     * Class of the road exiting the intersection.
+     * The type of rest stop, either `rest_area` (includes parking only) or `service_area`
+     * (includes amenities such as gas or restaurants).
+     * Note that adding new possible types is not considered a breaking change.
      *
-     * @param roadClass class of the road exiting the intersection.
-     * @return this builder for chaining options together
+     * @param type rest stop type
      */
-    public abstract Builder roadClass(@Nullable String roadClass);
+    public abstract Builder type(@Nullable String type);
 
     /**
-     * Build a new {@link MapboxStreetsV8} object.
+     * Build a new {@link RestStop} object.
      *
-     * @return a new {@link MapboxStreetsV8} using the provided values in this builder
+     * @return a new {@link RestStop} using the provided values in this builder
      */
-    public abstract MapboxStreetsV8 build();
+    public abstract RestStop build();
   }
 }

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteLeg.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteLeg.java
@@ -69,6 +69,14 @@ public abstract class RouteLeg extends DirectionsJsonObject {
   public abstract String summary();
 
   /**
+   * An array of objects describing the administrative boundaries the route leg travels through.
+   * Use {@link StepIntersection#adminIndex()} on the intersection object
+   * to look up the admin for each intersection in this array.
+   */
+  @Nullable
+  public abstract List<Admin> admins();
+
+  /**
    * Gives a List including all the steps to get from one waypoint to another.
    *
    * @return List of {@link LegStep}
@@ -171,6 +179,16 @@ public abstract class RouteLeg extends DirectionsJsonObject {
      * @since 3.0.0
      */
     public abstract Builder summary(@Nullable String summary);
+
+    /**
+     * An array of objects describing the administrative boundaries the route leg travels through.
+     * Use {@link StepIntersection#adminIndex()} on the intersection object
+     * to look up the admin for each intersection in this array.
+     *
+     * @param admins Array with admins
+     * @return this builder for chaining options together
+     */
+    public abstract Builder admins(@Nullable List<Admin> admins);
 
     /**
      * Gives a List including all the steps to get from one waypoint to another.

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
@@ -162,6 +162,16 @@ public abstract class StepIntersection extends DirectionsJsonObject {
   public abstract Integer adminIndex();
 
   /**
+   * An object containing information about passing rest stops along the route.
+   * Only available on the `driving` profile.
+   *
+   * @return an object containing information about passing rest stops along the route.
+   */
+  @Nullable
+  @SerializedName("rest_stop")
+  public abstract RestStop restStop();
+
+  /**
    * An object containing detailed information about the road exiting the intersection along the
    * route. Properties in this object correspond to properties in the {@link #classes()}
    * specification. Only available on the {@link DirectionsCriteria#PROFILE_DRIVING} profile.
@@ -323,6 +333,16 @@ public abstract class StepIntersection extends DirectionsJsonObject {
      */
     @Nullable
     public abstract Builder adminIndex(@Nullable Integer adminIndex);
+
+    /**
+     * An object containing information about passing rest stops along the route.
+     * Only available on the `driving` profile.
+     *
+     * @param restStop object containing information about passing rest stops along the route.
+     * @return this builder for chaining options together
+     */
+    @Nullable
+    public abstract Builder restStop(@Nullable RestStop restStop);
 
     /**
      * An object containing detailed information about the road exiting the intersection along the

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
@@ -150,6 +150,18 @@ public abstract class StepIntersection extends DirectionsJsonObject {
   public abstract Boolean isUrban();
 
   /**
+   * The zero-based index into the admin list on the route leg for this intersection.
+   * Use this field to look up the ISO-3166-1 country code for this point on the route.
+   * Only available on the `driving` profile.
+   *
+   * @return a zero-based index into the admin list on the route leg.
+   * @see RouteLeg#admins()
+   */
+  @Nullable
+  @SerializedName("admin_index")
+  public abstract Integer adminIndex();
+
+  /**
    * An object containing detailed information about the road exiting the intersection along the
    * route. Properties in this object correspond to properties in the {@link #classes()}
    * specification. Only available on the {@link DirectionsCriteria#PROFILE_DRIVING} profile.
@@ -300,6 +312,17 @@ public abstract class StepIntersection extends DirectionsJsonObject {
      */
     @Nullable
     public abstract Builder isUrban(@Nullable Boolean isUrban);
+
+    /**
+     * The zero-based index into the admin list on the route leg for this intersection.
+     * Use this field to look up the ISO-3166-1 country code for this point on the route.
+     * Only available on the `driving` profile.
+     *
+     * @param adminIndex zero-based index into the admin list on the route leg for this intersection
+     * @return this builder for chaining options together
+     */
+    @Nullable
+    public abstract Builder adminIndex(@Nullable Integer adminIndex);
 
     /**
      * An object containing detailed information about the road exiting the intersection along the

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
@@ -172,6 +172,20 @@ public abstract class StepIntersection extends DirectionsJsonObject {
   public abstract RestStop restStop();
 
   /**
+   * An object containing information about a toll collection point along the route.
+   * This is a payment booth or overhead electronic gantry
+   * <a href="https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dtoll_booth">
+   *   payment booth or overhead electronic gantry</a>
+   * where toll charge is collected.
+   * Only available on the {@link DirectionsCriteria#PROFILE_DRIVING} profile.
+   *
+   * @return an object containing information about a toll collection point along the route.
+   */
+  @Nullable
+  @SerializedName("toll_collection")
+  public abstract TollCollection tollCollection();
+
+  /**
    * An object containing detailed information about the road exiting the intersection along the
    * route. Properties in this object correspond to properties in the {@link #classes()}
    * specification. Only available on the {@link DirectionsCriteria#PROFILE_DRIVING} profile.
@@ -343,6 +357,20 @@ public abstract class StepIntersection extends DirectionsJsonObject {
      */
     @Nullable
     public abstract Builder restStop(@Nullable RestStop restStop);
+
+    /**
+     * An object containing information about a toll collection point along the route.
+     * This is a payment booth or overhead electronic gantry
+     * <a href="https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dtoll_booth">
+     *   payment booth or overhead electronic gantry</a>
+     * where toll charge is collected.
+     *
+     * @param tollCollection object containing information about
+     *                       a toll collection point along the route.
+     * @return this builder for chaining options together
+     */
+    @Nullable
+    public abstract Builder tollCollection(@Nullable TollCollection tollCollection);
 
     /**
      * An object containing detailed information about the road exiting the intersection along the

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/TollCollection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/TollCollection.java
@@ -1,0 +1,92 @@
+package com.mapbox.api.directions.v5.models;
+
+import androidx.annotation.Nullable;
+
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
+import com.mapbox.api.directions.v5.DirectionsCriteria;
+
+/**
+ * An object containing information about a toll collection point along the route.
+ * This is a payment booth or overhead electronic gantry
+ * <a href="https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dtoll_booth">
+ *   payment booth or overhead electronic gantry</a>
+ * where toll charge is collected.
+ * Only available on the {@link DirectionsCriteria#PROFILE_DRIVING} profile.
+ */
+@AutoValue
+public abstract class TollCollection extends DirectionsJsonObject {
+
+  /**
+   * The type of toll collection point, either `toll_booth` or `toll_gantry`.
+   * Note that adding new possible types is not considered a breaking change.
+   */
+  @Nullable
+  public abstract String type();
+
+  /**
+   * Create a new instance of this class by using the {@link Builder} class.
+   *
+   * @return this classes {@link Builder} for creating a new instance
+   */
+  public static Builder builder() {
+    return new AutoValue_TollCollection.Builder();
+  }
+
+  /**
+   * Convert the current {@link TollCollection} to its builder holding the currently assigned
+   * values. This allows you to modify a single property and then rebuild the object resulting in
+   * an updated and modified {@link TollCollection}.
+   *
+   * @return a {@link Builder} with the same values set to match the ones defined in this {@link
+   * TollCollection}
+   */
+  public abstract Builder toBuilder();
+
+  /**
+   * Gson type adapter for parsing Gson to this class.
+   *
+   * @param gson the built {@link Gson} object
+   * @return the type adapter for this class
+   */
+  public static TypeAdapter<TollCollection> typeAdapter(Gson gson) {
+    return new AutoValue_TollCollection.GsonTypeAdapter(gson);
+  }
+
+  /**
+   * Create a new instance of this class by passing in a formatted valid JSON String.
+   *
+   * @param json a formatted valid JSON string defining an Incident
+   * @return a new instance of this class defined by the values passed in the method
+   */
+  public static TollCollection fromJson(String json) {
+    GsonBuilder gson = new GsonBuilder();
+    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
+    return gson.create().fromJson(json, TollCollection.class);
+  }
+
+  /**
+   * This builder can be used to set the values describing the {@link TollCollection}.
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    /**
+     * The type of toll collection point, either `toll_booth` or `toll_gantry`.
+     * Note that adding new possible types is not considered a breaking change.
+     *
+     * @param type toll collection type
+     */
+    public abstract Builder type(@Nullable String type);
+
+    /**
+     * Build a new {@link TollCollection} object.
+     *
+     * @return a new {@link TollCollection} using the provided values in this builder
+     */
+    public abstract TollCollection build();
+  }
+}

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteLegTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteLegTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.mapbox.core.TestUtils;
+
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -24,7 +25,6 @@ public class RouteLegTest extends TestUtils {
     byte[] serialized = TestUtils.serialize(routeLeg);
     assertEquals(routeLeg, deserialize(serialized, RouteLeg.class));
   }
-
 
   @Test
   public void testToFromJson1() {
@@ -94,5 +94,30 @@ public class RouteLegTest extends TestUtils {
     RouteLeg routeLegFromJson = RouteLeg.fromJson(jsonString);
 
     assertEquals(routeLeg, routeLegFromJson);
+  }
+
+  @Test
+  public void testAdmins() {
+    String routeLegJsonString = "{"
+      + "\"distance\": 53.4,"
+      + "\"duration\": 14.3,"
+      + "\"summary\": \"route summary\","
+      + "\"admins\": [{ \"iso_3166_1_alpha3\": \"USA\", \"iso_3166_1\": \"US\" }]"
+      + "}";
+    List<Admin> admins = new ArrayList<>();
+    admins.add(Admin.builder().countryCode("US").countryCodeAlpha3("USA").build());
+
+    RouteLeg routeLeg = RouteLeg.builder()
+      .distance(53.4)
+      .duration(14.3)
+      .summary("route summary")
+      .admins(admins)
+      .build();
+
+    RouteLeg routeLegFromJson = RouteLeg.fromJson(routeLegJsonString);
+
+    assertEquals(routeLeg, routeLegFromJson);
+    assertEquals("US", routeLegFromJson.admins().get(0).countryCode());
+    assertEquals("USA", routeLegFromJson.admins().get(0).countryCodeAlpha3());
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
@@ -46,6 +46,7 @@ public class StepIntersectionTest extends TestUtils {
       .rawLocation(new double[]{13.426579, 52.508068})
       .geometryIndex(123)
       .isUrban(true)
+      .adminIndex(2)
       .mapboxStreetsV8(MapboxStreetsV8.builder().roadClass("street").build())
       .build();
 
@@ -96,6 +97,20 @@ public class StepIntersectionTest extends TestUtils {
 
     String jsonStr = stepIntersection.toJson();
 
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testAdminIndex() {
+    String stepIntersectionJsonString = "{"
+    + "\"location\": [ 13.426579, 52.508068 ],"
+    + "\"admin_index\": 2"
+    + "}";
+
+    StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    Assert.assertEquals(2, stepIntersection.adminIndex().intValue());
+    String jsonStr = stepIntersection.toJson();
     compareJson(stepIntersectionJsonString, jsonStr);
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
@@ -46,6 +46,7 @@ public class StepIntersectionTest extends TestUtils {
       .rawLocation(new double[]{13.426579, 52.508068})
       .geometryIndex(123)
       .isUrban(true)
+      .restStop(RestStop.builder().type("rest_area").build())
       .adminIndex(2)
       .mapboxStreetsV8(MapboxStreetsV8.builder().roadClass("street").build())
       .build();
@@ -110,6 +111,20 @@ public class StepIntersectionTest extends TestUtils {
     StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
 
     Assert.assertEquals(2, stepIntersection.adminIndex().intValue());
+    String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testRestStop() {
+    String stepIntersectionJsonString = "{"
+    + "\"location\": [ 13.426579, 52.508068 ],"
+    + "\"rest_stop\": { \"type\": \"rest_area\" }"
+    + "}";
+
+    StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    Assert.assertEquals("rest_area", stepIntersection.restStop().type());
     String jsonStr = stepIntersection.toJson();
     compareJson(stepIntersectionJsonString, jsonStr);
   }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
@@ -47,6 +47,7 @@ public class StepIntersectionTest extends TestUtils {
       .geometryIndex(123)
       .isUrban(true)
       .restStop(RestStop.builder().type("rest_area").build())
+      .tollCollection(TollCollection.builder().type("toll_gantry").build())
       .adminIndex(2)
       .mapboxStreetsV8(MapboxStreetsV8.builder().roadClass("street").build())
       .build();
@@ -125,6 +126,20 @@ public class StepIntersectionTest extends TestUtils {
     StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
 
     Assert.assertEquals("rest_area", stepIntersection.restStop().type());
+    String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testTollCollection() {
+    String stepIntersectionJsonString = "{"
+    + "\"location\": [ 13.426579, 52.508068 ],"
+    + "\"toll_collection\": { \"type\": \"toll_gantry\" }"
+    + "}";
+
+    StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    Assert.assertEquals("toll_gantry", stepIntersection.tollCollection().type());
     String jsonStr = stepIntersection.toJson();
     compareJson(stepIntersectionJsonString, jsonStr);
   }


### PR DESCRIPTION
This PR exposes:
- `leg.admins` (An array of objects describing the administrative boundaries the route leg travels through)
- `intersections.admin_index` (The zero-based index into the admin list on the route leg for this intersection)
- `intersections.rest_stop` (An object containing information about passing rest stops along the route)
- `intersections.toll_collection` (An object containing information about a toll collection point along the route)