### PR TITLE
Snapping closures

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -494,6 +494,36 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   public abstract WalkingOptions walkingOptions();
 
   /**
+   * A semicolon-separated list of booleans affecting snapping of waypoint locations to road
+   * segments.
+   * If true, road segments closed due to live-traffic closures will be considered for snapping.
+   * If false, they will not be considered for snapping.
+   * If provided, the number of snappingClosures must be the same as the number of
+   * coordinates.
+   * Must be used with {@link DirectionsCriteria#PROFILE_DRIVING_TRAFFIC}
+   *
+   * @return a String representing a list of booleans
+   */
+  @SerializedName("snapping_closures")
+  @Nullable
+  public abstract String snappingClosures();
+
+  /**
+   * A list of booleans affecting snapping of waypoint locations to road segments.
+   * If true, road segments closed due to live-traffic closures will be considered for snapping.
+   * If false, they will not be considered for snapping.
+   * If provided, the number of snappingClosures must be the same as the number of
+   * coordinates.
+   * Must be used with {@link DirectionsCriteria#PROFILE_DRIVING_TRAFFIC}
+   *
+   * @return a list of booleans
+   */
+  @Nullable
+  public List<Boolean> snappingClosuresList() {
+    return ParseUtils.parseToBooleans(snappingClosures());
+  }
+
+  /**
    * Gson type adapter for parsing Gson to this class.
    *
    * @param gson the built {@link Gson} object
@@ -1028,6 +1058,45 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * @since 4.8.0
      */
     public abstract Builder walkingOptions(@NonNull WalkingOptions walkingOptions);
+
+    /**
+     * A semicolon-separated list of booleans affecting snapping of waypoint locations to road
+     * segments.
+     * If true, road segments closed due to live-traffic closures will be considered for snapping.
+     * If false, they will not be considered for snapping.
+     * If provided, the number of snappingClosures must be the same as the number of
+     * coordinates.
+     * You can skip a coordinate and show its position in the list with the ; separator.
+     * If unspecified, this parameter defaults to false.
+     * Must be used with {@link DirectionsCriteria#PROFILE_DRIVING_TRAFFIC}
+     *
+     * @param snappingClosures a semicolon-separated list of booleans
+     * @return this builder for chaining options together
+     */
+    public abstract Builder snappingClosures(@NonNull String snappingClosures);
+
+    /**
+     * A list of booleans affecting snapping of waypoint locations to road segments.
+     * If true, road segments closed due to live-traffic closures will be considered for snapping.
+     * If false, they will not be considered for snapping.
+     * If provided, the number of snappingClosures must be the same as the number of
+     * coordinates.
+     * You can skip a coordinate and show its position in the list with null value.
+     * If unspecified, this parameter defaults to false.
+     * Must be used with {@link DirectionsCriteria#PROFILE_DRIVING_TRAFFIC}
+     *
+     * @param snappingClosures a list of booleans
+     * @return this builder for chaining options together
+     */
+    public Builder snappingClosures(@NonNull List<Boolean> snappingClosures) {
+      String result = FormatUtils.join(";", snappingClosures);
+      if (result != null) {
+        snappingClosures(result);
+      } else {
+        snappingClosures("");
+      }
+      return this;
+    }
 
     /**
      * Builds a new instance of the {@link RouteOptions} object.

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/utils/ParseUtils.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/utils/ParseUtils.java
@@ -14,6 +14,8 @@ public class ParseUtils {
   private static final String SEMICOLON = ";";
   private static final String COMMA = ",";
   private static final String UNLIMITED = "unlimited";
+  private static final String TRUE = "true";
+  private static final String FALSE = "false";
 
   /**
    * Parse a String to a list of Integers.
@@ -164,5 +166,40 @@ public class ParseUtils {
     }
 
     return result;
+  }
+
+  /**
+   * Parse a String to a list of Boolean.
+   *
+   * @param original an original String.
+   * @return List of Booleans
+   */
+  @Nullable
+  public static List<Boolean> parseToBooleans(@Nullable String original) {
+    if (original == null) {
+      return null;
+    }
+
+    List<Boolean> booleans = new ArrayList<>();
+    if (original.isEmpty()) {
+      return booleans;
+    }
+
+    String[] strings = original.split(SEMICOLON, -1);
+    for (String str : strings) {
+      if (str != null) {
+        if (str.isEmpty()) {
+          booleans.add(null);
+        } else if (str.equalsIgnoreCase(TRUE)) {
+          booleans.add(true);
+        } else if (str.equalsIgnoreCase(FALSE)) {
+          booleans.add(false);
+        } else {
+          booleans.add(null);
+        }
+      }
+    }
+
+    return booleans;
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -3,6 +3,7 @@ package com.mapbox.api.directions.v5.models;
 import com.mapbox.geojson.Point;
 import java.util.ArrayList;
 import java.util.List;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import static com.mapbox.api.directions.v5.DirectionsCriteria.ANNOTATION_CONGESTION;
@@ -17,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 public class RouteOptionsTest {
 
   private static final String ROUTE_OPTIONS_JSON =
-      "{\"baseUrl\":\"https://api.mapbox.com\",\"user\":\"mapbox\",\"profile\":\"driving-traffic\",\"coordinates\":[[-122.4003312,37.7736941],[-122.4187529,37.7689715],[-122.4255172,37.7775835]],\"alternatives\":false,\"language\":\"ru\",\"radiuses\":\";unlimited;100\",\"bearings\":\"0,90;90,0;\",\"continue_straight\":false,\"roundabout_exits\":false,\"geometries\":\"polyline6\",\"overview\":\"full\",\"steps\":true,\"annotations\":\"congestion,distance,duration\",\"exclude\":\"toll\",\"voice_instructions\":true,\"banner_instructions\":true,\"voice_units\":\"metric\",\"access_token\":\"token\",\"uuid\":\"12345543221\",\"approaches\":\";curb;\",\"waypoints\":\"0;1;2\",\"waypoint_names\":\";two;\",\"waypoint_targets\":\";12.2,21.2;\"}";
+      "{\"baseUrl\":\"https://api.mapbox.com\",\"user\":\"mapbox\",\"profile\":\"driving-traffic\",\"coordinates\":[[-122.4003312,37.7736941],[-122.4187529,37.7689715],[-122.4255172,37.7775835]],\"alternatives\":false,\"language\":\"ru\",\"radiuses\":\";unlimited;100\",\"bearings\":\"0,90;90,0;\",\"continue_straight\":false,\"roundabout_exits\":false,\"geometries\":\"polyline6\",\"overview\":\"full\",\"steps\":true,\"annotations\":\"congestion,distance,duration\",\"exclude\":\"toll\",\"voice_instructions\":true,\"banner_instructions\":true,\"voice_units\":\"metric\",\"access_token\":\"token\",\"uuid\":\"12345543221\",\"approaches\":\";curb;\",\"waypoints\":\"0;1;2\",\"waypoint_names\":\";two;\",\"waypoint_targets\":\";12.2,21.2;\",\"snapping_closures\":\";false;true\"}";
 
   @Test
   public void toBuilder() {
@@ -329,6 +330,79 @@ public class RouteOptionsTest {
   }
 
   @Test
+  public void snappingClosuresString() {
+    String snappingClosuresString = "true;;;false;false;true;;;;" ;
+
+    RouteOptions routeOptions = routeOptions()
+        .toBuilder()
+        .snappingClosures(snappingClosuresString)
+        .build();
+
+    assertEquals(snappingClosuresString, routeOptions.snappingClosures());
+
+    List<Boolean> snappingClosures = routeOptions.snappingClosuresList();
+    assertEquals(10, snappingClosures.size());
+    assertEquals(true, snappingClosures.get(0));
+    assertEquals(null, snappingClosures.get(1));
+    assertEquals(null, snappingClosures.get(2));
+    assertEquals(false, snappingClosures.get(3));
+    assertEquals(false, snappingClosures.get(4));
+    assertEquals(true, snappingClosures.get(5));
+    assertEquals(null, snappingClosures.get(6));
+    assertEquals(null, snappingClosures.get(7));
+    assertEquals(null, snappingClosures.get(8));
+    assertEquals(null, snappingClosures.get(9));
+  }
+
+  @Test
+  public void snappingClosuresEmptyString() {
+    String snappingClosuresString = "" ;
+
+    RouteOptions routeOptions = routeOptions()
+            .toBuilder()
+            .snappingClosures(snappingClosuresString)
+            .build();
+
+    assertEquals(snappingClosuresString, routeOptions.snappingClosures());
+
+    List<Boolean> snappingClosures = routeOptions.snappingClosuresList();
+    assertTrue(snappingClosures.isEmpty());
+  }
+
+  @Test
+  public void snappingClosuresList() {
+    List<Boolean> snappingClosures = new ArrayList<>();
+    snappingClosures.add(false);
+    snappingClosures.add(false);
+    snappingClosures.add(null);
+    snappingClosures.add(true);
+    snappingClosures.add(false);
+    snappingClosures.add(null);
+    snappingClosures.add(null);
+
+    RouteOptions routeOptions = routeOptions()
+        .toBuilder()
+        .snappingClosures(snappingClosures)
+        .build();
+
+    assertEquals(snappingClosures, routeOptions.snappingClosuresList());
+    assertEquals("false;false;;true;false;;", routeOptions.snappingClosures());
+  }
+
+  @Test
+  public void snappingClosuresEmptyList() {
+    List<Boolean> snappingClosures = new ArrayList<>();
+
+    RouteOptions routeOptions = routeOptions()
+            .toBuilder()
+            .snappingClosures(snappingClosures)
+            .build();
+
+    assertEquals(snappingClosures, routeOptions.snappingClosuresList());
+    assertTrue(routeOptions.snappingClosures().isEmpty());
+  }
+
+  @Test
   public void baseUrlIsValid_fromJson() {
     RouteOptions routeOptions = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
 
@@ -572,6 +646,24 @@ public class RouteOptionsTest {
   }
 
   @Test
+  public void snappingIncludeClosuresStringIsValid_fromJson() {
+    RouteOptions options = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    assertEquals(";false;true", options.snappingClosures());
+  }
+
+  @Test
+  public void snappingIncludeClosuresListIsValid_fromJson() {
+    RouteOptions options = RouteOptions.fromJson(ROUTE_OPTIONS_JSON);
+
+    List list = options.snappingClosuresList();
+    assertEquals(3, list.size());
+    assertEquals(null, list.get(0));
+    assertEquals(false, list.get(1));
+    assertEquals(true, list.get(2));
+  }
+
+  @Test
   public void routeOptions_toJson() {
     RouteOptions options = routeOptions();
 
@@ -742,6 +834,7 @@ public class RouteOptionsTest {
         .waypointIndices("0;1;2")
         .waypointNames(";two;")
         .waypointTargets(";12.2,21.2;")
+        .snappingClosures(";false;true")
         .build();
   }
 }

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsService.java
@@ -59,6 +59,8 @@ public interface DirectionsService {
    * @param walkwayBias         a factor that modifies the cost when encountering roads or paths
    *                            that do not allow vehicles and are set aside for pedestrian use
    * @param alleyBias           a factor that modifies the cost when alleys are encountered
+   * @param snappingClosures    a list of booleans affecting snapping of waypoint locations to road
+   *                            segments
    * @return the {@link DirectionsResponse} in a Call wrapper
    * @since 1.0.0
    */
@@ -90,7 +92,8 @@ public interface DirectionsService {
     @Query("enable_refresh") Boolean enableRefresh,
     @Query("walking_speed") Double walkingSpeed,
     @Query("walkway_bias") Double walkwayBias,
-    @Query("alley_bias") Double alleyBias
+    @Query("alley_bias") Double alleyBias,
+    @Query("snapping_include_closures") String snappingClosures
   );
 
   /**
@@ -134,6 +137,8 @@ public interface DirectionsService {
    * @param walkwayBias         a factor that modifies the cost when encountering roads or paths
    *                            that do not allow vehicles and are set aside for pedestrian use
    * @param alleyBias           a factor that modifies the cost when alleys are encountered
+   * @param snappingClosures    a list of booleans affecting snapping of waypoint locations to road
+   *                            segments
    * @return the {@link DirectionsResponse} in a Call wrapper
    * @since 4.6.0
    */
@@ -166,6 +171,7 @@ public interface DirectionsService {
     @Field("enable_refresh") Boolean enableRefresh,
     @Field("walking_speed") Double walkingSpeed,
     @Field("walkway_bias") Double walkwayBias,
-    @Field("alley_bias") Double alleyBias
+    @Field("alley_bias") Double alleyBias,
+    @Field("snapping_include_closures") String snappingClosures
   );
 }

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -46,6 +46,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class MapboxDirectionsTest extends TestUtils {
@@ -1412,6 +1413,82 @@ public class MapboxDirectionsTest extends TestUtils {
     assertEquals("2020-10-08T11:34:14Z", incident.creationTime());
     assertEquals("2020-10-06T12:52:02Z", incident.startTime());
     assertEquals("2020-11-27T16:00:00Z", incident.endTime());
+  }
+
+  @Test
+  public void snappingClosuresList() throws Exception {
+    List<Boolean> snappingClosures = new ArrayList<>();
+    snappingClosures.add(false);
+    snappingClosures.add(true);
+    snappingClosures.add(null);
+
+    MapboxDirections mapboxDirections = MapboxDirections.builder()
+        .origin(Point.fromLngLat(1.0, 1.0))
+        .addWaypoint(Point.fromLngLat(2.0, 2.0))
+        .destination(Point.fromLngLat(4.0, 4.0))
+        .baseUrl("https://foobar.com")
+        .accessToken(ACCESS_TOKEN)
+        .snappingClosures(snappingClosures)
+        .build();
+
+    assertNotNull(mapboxDirections);
+    assertEquals("false;true;",
+        mapboxDirections.cloneCall().request().url().queryParameter("snapping_include_closures"));
+  }
+
+  @Test
+  public void snappingClosuresListNotMatchingCoordinates() throws Exception {
+    thrown.expect(ServicesException.class);
+    thrown.expectMessage(
+      "Number of snapping closures elements must match number of coordinates provided."
+    );
+
+    List<Boolean> snappingClosures = new ArrayList<>();
+    snappingClosures.add(false);
+    snappingClosures.add(null);
+
+    MapboxDirections.builder()
+            .origin(Point.fromLngLat(1.0, 1.0))
+            .addWaypoint(Point.fromLngLat(2.0, 2.0))
+            .destination(Point.fromLngLat(4.0, 4.0))
+            .baseUrl("https://foobar.com")
+            .accessToken(ACCESS_TOKEN)
+            .snappingClosures(snappingClosures)
+            .build();
+  }
+
+  @Test
+  public void snappingClosures() throws Exception {
+    String snappingClosures = "true;;";
+
+    MapboxDirections mapboxDirections = MapboxDirections.builder()
+        .origin(Point.fromLngLat(1.0, 1.0))
+        .addWaypoint(Point.fromLngLat(2.0, 2.0))
+        .destination(Point.fromLngLat(4.0, 4.0))
+        .snappingClosures(snappingClosures)
+        .baseUrl("https://foobar.com")
+        .accessToken(ACCESS_TOKEN)
+        .build();
+
+    assertNotNull(mapboxDirections);
+    assertEquals("true;;",
+        mapboxDirections.cloneCall().request().url().queryParameter("snapping_include_closures"));
+  }
+
+  @Test
+  public void snappingClosuresDefaultValue() throws Exception {
+    MapboxDirections mapboxDirections = MapboxDirections.builder()
+        .origin(Point.fromLngLat(1.0, 1.0))
+        .addWaypoint(Point.fromLngLat(2.0, 2.0))
+        .destination(Point.fromLngLat(4.0, 4.0))
+        .baseUrl("https://foobar.com")
+        .accessToken(ACCESS_TOKEN)
+        .build();
+
+    assertNotNull(mapboxDirections);
+    assertNull(
+        mapboxDirections.cloneCall().request().url().queryParameter("snapping_include_closures")
+    );
   }
 
   private void addWaypoints(MapboxDirections.Builder builder, int number) {


### PR DESCRIPTION
The Directions API has added a new request parameter that allows routing from/to closed road segments (due to live-traffic closures). The draft documentation of this parameter is [here](https://github.com/mapbox/api-documentation/pull/1078/files) and this is live in production.

We need to support it.