### PR TITLE
Remove requires from release circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ workflows:
               only:
                 - master
       - release:
-          requires:
-            - build
-            - test
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
The requires here makes no workflow happen, because build and test do not run for tags.

![Screen Shot 2021-03-23 at 1 26 38 PM](https://user-images.githubusercontent.com/3021882/112213530-68f64200-8bdb-11eb-8080-cf4bf0c289fb.png)

Reference to issue/solution online https://discuss.circleci.com/t/tag-filter-not-firing-in-workflow/25534/3
