### PR TITLE
Move snapshot to default workflow and add another fix to releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,6 @@ workflows:
   version: 2
   release-workflow:
     jobs:
-      - release-snapshot:
-          filters:
-            branches:
-              only:
-                - master
       - release:
           filters:
             tags:
@@ -18,6 +13,14 @@ workflows:
     jobs:
       - build
       - test
+      - publish-snapshot:
+          requires:
+            - build
+            - test
+          filters:
+            branches:
+              only:
+                - master
 
 commands:
   build-release:
@@ -78,15 +81,12 @@ jobs:
       - run-tests
 
 # ------------------------------------------------------------------------------
-  release-snapshot:
+  publish-snapshot:
     docker:
       - image: mbgl/android-ndk-r19:latest
     working_directory: ~/code
     steps:
       - checkout
-      - build-release
-      - build-cli
-      - run-tests
       - deploy:
           name: Publish Java snapshot libraries to Mapbox SDK Registry
           command: |

--- a/cloudformation/ci.template
+++ b/cloudformation/ci.template
@@ -24,7 +24,7 @@
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": ["s3:PutObject"],
+                  "Action": ["s3:PutObject", "s3:ListObject"],
                   "Effect": "Allow",
                   "Resource": [
                     "arn:aws:s3:::mapbox-api-downloads-production/v2/*",


### PR DESCRIPTION

### Move snapshot to default workflow
After a commit, both the snapshot and the default workflow are triggered. Move the snapshot workflow into default, to remove the duplication of work.

![Screen Shot 2021-03-23 at 2 44 51 PM](https://user-images.githubusercontent.com/3021882/112226192-16248680-8beb-11eb-8bcc-9af521da8d20.png)

### Add another fix to releases

The release tag failed because it cannot check if existing releases are on s3. Add the s3:ListObject permission.