### PR TITLE
Add snapping closures to a response options

### DIFF
--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsResponseFactory.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/DirectionsResponseFactory.java
@@ -78,6 +78,7 @@ class DirectionsResponseFactory {
           .requestUuid(response.body().uuid())
           .baseUrl(mapboxDirections.baseUrl())
           .walkingOptions(mapboxDirections.walkingOptions())
+          .snappingClosures(mapboxDirections.snappingClosures())
           .build()
       ).build());
     }


### PR DESCRIPTION
SnappingClosures options was not added to a response options. This PR fixes it

we should cover such cases with tests https://github.com/mapbox/mapbox-java/issues/1243