### PR TITLE
Simplify release publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,11 @@ jobs:
       - build-cli
       - run-tests
       - deploy:
-          name: Publish Java libraries to Mapbox SDK Registry
+          name: Upload libraries to Mapbox SDK Registry
           command: |
-            make sdk-registry-publish
+            make sdk-registry-upload
+#      This is not yet supported, still need to be able to authenticate CI to create a Github pull request.
+#      - run:
+#          name: Create pull request in api-downloads
+#          command: |
+#            make sdk-registry-publish

--- a/Makefile
+++ b/Makefile
@@ -30,21 +30,14 @@ javadoc:
 	./gradlew :services-turf:javadoc; mv services-turf/build/docs/javadoc/ ./documentation/turf/javadoc/ ; \
 	./gradlew :services:javadoc; mv services/build/docs/javadoc/ ./documentation/services/javadoc/ ; \
 
+sdk-registry-upload:
+	./gradlew mapboxSDKRegistryUpload
+
 sdk-registry-publish:
-	./gradlew :services-core:mapboxSDKRegistryUpload ; \
-	./gradlew :services-geojson:mapboxSDKRegistryUpload ; \
-	./gradlew :services:mapboxSDKRegistryUpload ; \
-	./gradlew :services-turf:mapboxSDKRegistryUpload ; \
-	./gradlew :services-directions-models:mapboxSDKRegistryUpload ; \
-	./gradlew :services-directions-refresh-models:mapboxSDKRegistryUpload ; \
+	./gradlew mapboxSDKRegistryPublishAll
 
 sdk-registry-publish-snapshot:
-	./gradlew :services-core:mapboxSDKRegistryUpload -Psnapshot=true ; \
-	./gradlew :services-geojson:mapboxSDKRegistryUpload -Psnapshot=true ; \
-	./gradlew :services:mapboxSDKRegistryUpload -Psnapshot=true ; \
-	./gradlew :services-turf:mapboxSDKRegistryUpload -Psnapshot=true ; \
-	./gradlew :services-directions-models:mapboxSDKRegistryUpload -Psnapshot=true ; \
-	./gradlew :services-directions-refresh-models:mapboxSDKRegistryUpload -Psnapshot=true ; \
+	./gradlew mapboxSDKRegistryUpload -Psnapshot=true
 
 graphs:
 	./gradlew :services-core:generateDependencyGraphMapboxLibraries


### PR DESCRIPTION
EDIT: we can't publish to api-downloads with CI yet. Changed this pull request to only simplify the commands

## Release process down to 3 steps

1. Add CHANGELOG.md and merge pull request
2. Copy changes and tag a new release to https://github.com/mapbox/mapbox-java/releases
3. `$ make sdk-registry-publish`


Following up to update documentation: https://github.com/mapbox/android-internal/issues/130