### PR TITLE
Adding annotation closure constant to directions criteria.

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
@@ -123,6 +123,11 @@ public final class DirectionsCriteria {
   public static final String ANNOTATION_MAXSPEED = "maxspeed";
 
   /**
+   * The closure of sections of a route.
+   */
+  public static final String ANNOTATION_CLOSURE = "closure";
+
+  /**
    * Exclude all tolls along the returned directions route.
    *
    * @since 3.0.0


### PR DESCRIPTION
Adding annotation closure constant to directions criteria.  This is related to issue #1249.