### PR TITLE
Do not serialize access tokens

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
@@ -146,7 +146,7 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
    * @return a new instance of this class defined by the values passed inside this static factory
    *   method
    * @see RouteOptions#fromUrl(java.net.URL)
-   * @see RouteOptions#fromJson(String)
+   * @see RouteOptions#fromJson(String, String)
    */
   public static DirectionsResponse fromJson(
     @NonNull String json, @Nullable RouteOptions routeOptions, @Nullable String requestUuid) {

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsRoute.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsRoute.java
@@ -193,7 +193,7 @@ public abstract class DirectionsRoute extends DirectionsJsonObject {
    * @return a new instance of this class defined by the values passed inside this static factory
    *   method
    * @see RouteOptions#fromUrl(java.net.URL)
-   * @see RouteOptions#fromJson(String)
+   * @see RouteOptions#fromJson(String, String)
    */
   public static DirectionsRoute fromJson(
     @NonNull String json, @Nullable RouteOptions routeOptions, @Nullable String requestUuid

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -14,6 +14,7 @@ import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.utils.FormatUtils;
 import com.mapbox.api.directions.v5.utils.ParseUtils;
 import com.mapbox.geojson.Point;
+import com.ryanharter.auto.value.gson.Ignore;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -366,11 +367,15 @@ public abstract class RouteOptions extends DirectionsJsonObject {
 
   /**
    * A valid Mapbox access token used to making the request.
+   * <p>
+   * Avoiding to provide a token will most-likely result in a failure, however,
+   * it's annotated as nullable to prevent serialization of tokens.
    *
    * @return a string representing the Mapbox access token
    */
   @SerializedName("access_token")
-  @NonNull
+  @Ignore(Ignore.Type.SERIALIZATION)
+  @Nullable
   public abstract String accessToken();
 
   /**
@@ -670,6 +675,30 @@ public abstract class RouteOptions extends DirectionsJsonObject {
 
   /**
    * Create a new instance of this class by passing in a formatted valid JSON String.
+   * <p>
+   * The Mapbox Access Token that was part of the original object was not serialized and needs
+   * to be provided again.
+   * The options will not be valid for a request without a Mapbox Access Token.
+   *
+   * @param json        a formatted valid JSON string defining a RouteOptions
+   * @param accessToken a Mapbox Access Token
+   * @return a new instance of this class defined by the values passed inside this static factory
+   *   method
+   * @see #fromUrl(URL)
+   */
+  @NonNull
+  public static RouteOptions fromJson(@NonNull String json, @Nullable String accessToken) {
+    return fromJson(json).toBuilder().accessToken(accessToken).build();
+  }
+
+  /**
+   * Create a new instance of this class by passing in a formatted valid JSON String.
+   * <p>
+   * The Mapbox Access Token that was part of the original object was not serialized and needs
+   * to be provided again.
+   * The options will not be valid for a request without a Mapbox Access Token so make sure to
+   * provide a token with {@link #fromJson(String, String)}
+   * or rebuild the options with {@link #toBuilder()}.
    *
    * @param json a formatted valid JSON string defining a RouteOptions
    * @return a new instance of this class defined by the values passed inside this static factory
@@ -677,7 +706,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * @see #fromUrl(URL)
    */
   @NonNull
-  public static RouteOptions fromJson(String json) {
+  public static RouteOptions fromJson(@NonNull String json) {
     GsonBuilder gson = new GsonBuilder();
     gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
     return gson.create().fromJson(json, RouteOptions.class);
@@ -689,7 +718,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * @param url request URL
    * @return a new instance of this class defined by the values passed inside this static factory
    *   method
-   * @see #fromJson(String)
+   * @see #fromJson(String, String)
    */
   @NonNull
   public static RouteOptions fromUrl(@NonNull URL url) {
@@ -1077,11 +1106,13 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     /**
      * A valid Mapbox access token used to making the request.
      *
-     * @param accessToken a string containing a valid Mapbox access token
+     * @param accessToken a string containing a valid Mapbox access token.
+     *                    Avoiding to provide a token will most-likely result in a failure, however,
+     *                    it's annotated as nullable to prevent serialization of tokens.
      * @return this builder for chaining options together
      */
     @NonNull
-    public abstract Builder accessToken(@NonNull String accessToken);
+    public abstract Builder accessToken(@Nullable String accessToken);
 
     /**
      * Exclude certain road types from routing. The default is to not exclude anything from the

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -3,12 +3,15 @@ package com.mapbox.api.directions.v5.models;
 import static com.google.gson.JsonParser.parseString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.core.TestUtils;
 import com.mapbox.geojson.Point;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class RouteOptionsTest extends TestUtils {
@@ -25,28 +28,28 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void baseUrlIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(DirectionsCriteria.BASE_API_URL, routeOptions.baseUrl());
   }
 
   @Test
   public void userIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(DirectionsCriteria.PROFILE_DEFAULT_USER, routeOptions.user());
   }
 
   @Test
   public void profileIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC, routeOptions.profile());
   }
 
   @Test
   public void coordinatesAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(
       "-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835",
@@ -56,28 +59,28 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void alternativesAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(false, routeOptions.alternatives());
   }
 
   @Test
   public void languageIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("ru", routeOptions.language());
   }
 
   @Test
   public void radiusesAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(";unlimited;5.1", routeOptions.radiuses());
   }
 
   @Test
   public void radiusesListIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(3, routeOptions.radiusesList().size());
     assertNull(routeOptions.radiusesList().get(0));
@@ -87,14 +90,14 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void bearingsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("0,90;90,0;", routeOptions.bearings());
   }
 
   @Test
   public void bearingsListIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(3, routeOptions.bearingsList().size());
     assertEquals(0.0, routeOptions.bearingsList().get(0).angle(), 0.00001);
@@ -106,154 +109,154 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void continueStraightIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(false, routeOptions.continueStraight());
   }
 
   @Test
   public void roundaboutExitsIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(false, routeOptions.continueStraight());
   }
 
   @Test
   public void geometriesAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(DirectionsCriteria.GEOMETRY_POLYLINE6, routeOptions.geometries());
   }
 
   @Test
   public void stepsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(true, routeOptions.steps());
   }
 
   @Test
   public void annotationsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("congestion,distance,duration", routeOptions.annotations());
   }
 
   @Test
   public void excludeIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("toll", routeOptions.exclude());
   }
 
   @Test
   public void overviewIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("full", routeOptions.overview());
   }
 
   @Test
   public void voiceInstructionsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(true, routeOptions.voiceInstructions());
   }
 
   @Test
   public void bannerInstructionsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(true, routeOptions.bannerInstructions());
   }
 
   @Test
   public void voiceUnitsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(DirectionsCriteria.METRIC, routeOptions.voiceUnits());
   }
 
   @Test
   public void accessTokenIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("token", routeOptions.accessToken());
   }
 
   @Test
   public void approachesStringIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(";curb;", routeOptions.approaches());
   }
 
   @Test
   public void waypointIndicesStringIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("0;1;2", routeOptions.waypointIndices());
   }
 
   @Test
   public void waypointNamesStringIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(";two;", routeOptions.waypointNames());
   }
 
   @Test
   public void waypointTargetsStringIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson);
+    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(";12.2,21.2;", options.waypointTargets());
   }
 
   @Test
   public void snappingIncludeClosuresStringIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson);
+    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(";false;true", options.snappingIncludeClosures());
   }
 
   @Test
   public void alleyBiasIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson);
+    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(0.75, options.alleyBias(), 0.000001);
   }
 
   @Test
   public void walkingSpeedIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson);
+    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(5.11, options.walkingSpeed(), 0.000001);
   }
 
   @Test
   public void walkwayBiasIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson);
+    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(-0.2, options.walkwayBias(), 0.000001);
   }
 
   @Test
   public void arriveByIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson);
+    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("2021-01-01'T'01:01", options.arriveBy());
   }
 
   @Test
   public void departAtIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson);
+    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals("2021-02-02'T'02:02", options.departAt());
   }
 
   @Test
   public void enableRefreshIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson);
+    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
 
     assertEquals(true, options.enableRefresh());
   }
@@ -270,6 +273,16 @@ public class RouteOptionsTest extends TestUtils {
     RouteOptions options = routeOptionsList();
 
     assertEquals(parseString(optionsJson), parseString(options.toJson()));
+  }
+
+  @Test
+  public void routeOptions_toJson_tokenNotSerialized() {
+    String json = routeOptions().toJson();
+
+    Gson gson = new Gson();
+    JsonObject object = gson.fromJson(json, JsonObject.class);
+
+    Assert.assertNull(object.get("access_token"));
   }
 
   /**

--- a/services-directions-models/src/test/resources/route_options_v5.json
+++ b/services-directions-models/src/test/resources/route_options_v5.json
@@ -17,7 +17,6 @@
   "voice_instructions": true,
   "banner_instructions": true,
   "voice_units": "metric",
-  "access_token": "token",
   "approaches": ";curb;",
   "waypoints": "0;1;2",
   "waypoint_names": ";two;",

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -1,5 +1,8 @@
 package com.mapbox.api.directions.v5;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mapbox.api.directions.v5.models.BannerComponents;
@@ -12,11 +15,6 @@ import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.core.MapboxService;
 import com.mapbox.core.TestUtils;
 import com.mapbox.geojson.Point;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -24,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
-
 import okhttp3.Call;
 import okhttp3.EventListener;
 import okhttp3.HttpUrl;
@@ -32,11 +29,10 @@ import okhttp3.Interceptor;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import retrofit2.Response;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class MapboxDirectionsTest extends TestUtils {
 
@@ -59,7 +55,7 @@ public class MapboxDirectionsTest extends TestUtils {
   private MockWebServer server;
   private HttpUrl mockUrl;
 
-  private final RouteOptions routeOptions = RouteOptions.fromJson(loadJsonFixture(ROUTE_OPTIONS_V5));
+  private final RouteOptions routeOptions = RouteOptions.fromJson(loadJsonFixture(ROUTE_OPTIONS_V5), "token");
 
   public MapboxDirectionsTest() throws IOException {
   }
@@ -81,6 +77,7 @@ public class MapboxDirectionsTest extends TestUtils {
 
   @Test
   public void testRouteOptionsFromUrl() throws IOException {
+    assertNotNull(routeOptions.accessToken());
     MapboxDirections directions = MapboxDirections.builder()
       .routeOptions(routeOptions)
       .build();
@@ -92,6 +89,7 @@ public class MapboxDirectionsTest extends TestUtils {
 
   @Test
   public void testRouteOptionsFromUrl_alreadyDecoded() throws IOException {
+    assertNotNull(routeOptions.accessToken());
     MapboxDirections directions = MapboxDirections.builder()
       .routeOptions(routeOptions)
       .build();

--- a/services-directions/src/test/resources/route_options_v5.json
+++ b/services-directions/src/test/resources/route_options_v5.json
@@ -17,7 +17,6 @@
   "voice_instructions": true,
   "banner_instructions": true,
   "voice_units": "metric",
-  "access_token": "token",
   "approaches": ";curb;",
   "waypoints": "0;1;2",
   "waypoint_names": ";two;",


### PR DESCRIPTION
Ensures that access tokens are not serialized in order to avoid often unintentional leaks of the data when paired with other tools and utilities that serialize and store either the whole route response, route, or only the options. Unfortunately, due to the limitations of the code generation tools used we need to make the token field nullable until we find a better solution.

I also tried upgrading the https://github.com/rharter/auto-value-gson library that is used in this project to the latest version but it didn't seem to have the features needed to support a non-nullable property that is also not serializable and initialize it externally. We can cut a feature request, contribute, or think about a different solution in the future.