### PR TITLE
Removed access token from RouteOptions

### DIFF
--- a/samples/src/main/java/com/mapbox/samples/BasicDirections.java
+++ b/samples/src/main/java/com/mapbox/samples/BasicDirections.java
@@ -40,10 +40,10 @@ public class BasicDirections {
     coordinates.add(Point.fromLngLat(-95.6332, 29.7890));
     coordinates.add(Point.fromLngLat(-95.3591, 29.7576));
     RouteOptions routeOptions = RouteOptions.builder()
-      .accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN)
       .coordinatesList(coordinates)
       .build();
     builder.routeOptions(routeOptions);
+    builder.accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN);
 
     // 2. That's it! Now execute the command and get the response.
     Response<DirectionsResponse> response = builder.build().executeCall();
@@ -66,7 +66,6 @@ public class BasicDirections {
     coordinates.add(Point.fromLngLat(-95.6332, 29.7890));
     coordinates.add(Point.fromLngLat(-95.3591, 29.7576));
     RouteOptions routeOptions = RouteOptions.builder()
-      .accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN)
       .coordinatesList(coordinates)
       .profile("walking")
       .walkingSpeed(1.0)
@@ -74,6 +73,7 @@ public class BasicDirections {
       .alleyBias(0.7)
       .build();
     builder.routeOptions(routeOptions);
+    builder.accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN);
 
     // 2. That's it! Now execute the command and get the response.
     Response<DirectionsResponse> response = builder.build().executeCall();
@@ -96,11 +96,11 @@ public class BasicDirections {
     coordinates.add(Point.fromLngLat(-95.6332, 29.7890));
     coordinates.add(Point.fromLngLat(-95.3591, 29.7576));
     RouteOptions routeOptions = RouteOptions.builder()
-      .accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN)
       .coordinatesList(coordinates)
       .build();
     builder.routeOptions(routeOptions);
     builder.usePostMethod(true);
+    builder.accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN);
 
     Response<DirectionsResponse> response = builder.build().executeCall();
 
@@ -120,12 +120,12 @@ public class BasicDirections {
     coordinates.add(Point.fromLngLat(-95.6332, 29.7890));
     coordinates.add(Point.fromLngLat(-95.3591, 29.7576));
     RouteOptions routeOptions = RouteOptions.builder()
-      .accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN)
       .coordinatesList(coordinates)
       .profile(DirectionsCriteria.PROFILE_CYCLING)
       .steps(true)
       .build();
     builder.routeOptions(routeOptions);
+    builder.accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN);
 
     // 2. Now request the route using a async call
     builder.build().enqueueCall(new Callback<DirectionsResponse>() {

--- a/samples/src/main/java/com/mapbox/samples/BasicDirectionsRefresh.java
+++ b/samples/src/main/java/com/mapbox/samples/BasicDirectionsRefresh.java
@@ -49,7 +49,6 @@ public class BasicDirectionsRefresh {
     }
     coordinates.add(Point.fromLngLat(-95.3591, 29.7576));
     RouteOptions routeOptions = RouteOptions.builder()
-      .accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN)
       .coordinatesList(coordinates)
       .enableRefresh(true)
       .overview(OVERVIEW_FULL)
@@ -57,6 +56,7 @@ public class BasicDirectionsRefresh {
       .annotationsList(Arrays.asList(ANNOTATION_CONGESTION, ANNOTATION_MAXSPEED))
       .build();
     builder.routeOptions(routeOptions);
+    builder.accessToken(BuildConfig.MAPBOX_ACCESS_TOKEN);
 
     return builder.build();
   }

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
@@ -17,7 +17,7 @@ import java.util.List;
  * chained together to make up a similar structure to the original APIs JSON response.
  *
  * @see <a href="https://www.mapbox.com/api-documentation/navigation/#directions-response-object">Direction
- * Response Object</a>
+ *   Response Object</a>
  * @since 1.0.0
  */
 @AutoValue
@@ -146,7 +146,7 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
    * @return a new instance of this class defined by the values passed inside this static factory
    *   method
    * @see RouteOptions#fromUrl(java.net.URL)
-   * @see RouteOptions#fromJson(String, String)
+   * @see RouteOptions#fromJson(String)
    */
   public static DirectionsResponse fromJson(
     @NonNull String json, @Nullable RouteOptions routeOptions, @Nullable String requestUuid) {

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsRoute.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsRoute.java
@@ -167,9 +167,6 @@ public abstract class DirectionsRoute extends DirectionsJsonObject {
   /**
    * Create a new instance of this class by passing in a formatted valid JSON String.
    * <p>
-   * Use this method if the provided serialized route was not obtained by this library.
-   * Alternatively, use {@link #fromJson(String, String)}.
-   * <p>
    * If you're using the provided route with the Mapbox Navigation SDK, also see
    * {@link #fromJson(String, RouteOptions, String)}.
    *
@@ -180,41 +177,6 @@ public abstract class DirectionsRoute extends DirectionsJsonObject {
   public static DirectionsRoute fromJson(@NonNull String json) {
     GsonBuilder gson = new GsonBuilder();
     JsonObject jsonObject = gson.create().fromJson(json, JsonObject.class);
-    if (jsonObject.has("routeOptions")) {
-      throw new IllegalArgumentException(
-        "Provided serialized route contains RouteOptions. "
-          + "Use DirectionsRoute#fromJson(json, accessToken) instead."
-      );
-    }
-    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
-    gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
-    return gson.create().fromJson(jsonObject, DirectionsRoute.class);
-  }
-
-  /**
-   * Create a new instance of this class by passing in a formatted valid JSON String.
-   * <p>
-   * Use this method if the provided serialized route was obtained by this library.
-   * This means that it includes {@link RouteOptions} and you need to supply a Mapbox Access Token.
-   * Alternatively, use {@link #fromJson(String)}.
-   *
-   * @param json        a formatted valid JSON string defining a GeoJson Directions Route
-   * @param accessToken a Mapbox Access Token
-   * @return a new instance of this class defined by the values passed inside this static factory
-   *   method
-   */
-  public static DirectionsRoute fromJson(@NonNull String json, @NonNull String accessToken) {
-    GsonBuilder gson = new GsonBuilder();
-    JsonObject jsonObject = gson.create().fromJson(json, JsonObject.class);
-    if (jsonObject.has("routeOptions")) {
-      JsonObject routeOptions = jsonObject.getAsJsonObject("routeOptions");
-      routeOptions.addProperty("access_token", accessToken);
-    } else {
-      throw new IllegalArgumentException(
-        "Provided serialized route does not contain RouteOptions. "
-          + "Use DirectionsRoute#fromJson(json) instead."
-      );
-    }
     gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
     gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
     return gson.create().fromJson(jsonObject, DirectionsRoute.class);
@@ -234,7 +196,7 @@ public abstract class DirectionsRoute extends DirectionsJsonObject {
    * @return a new instance of this class defined by the values passed inside this static factory
    *   method
    * @see RouteOptions#fromUrl(java.net.URL)
-   * @see RouteOptions#fromJson(String, String)
+   * @see RouteOptions#fromJson(String)
    */
   public static DirectionsRoute fromJson(
     @NonNull String json, @Nullable RouteOptions routeOptions, @Nullable String requestUuid

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -6,7 +6,6 @@ import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -15,7 +14,6 @@ import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.utils.FormatUtils;
 import com.mapbox.api.directions.v5.utils.ParseUtils;
 import com.mapbox.geojson.Point;
-import com.ryanharter.auto.value.gson.Ignore;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -367,16 +365,6 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   public abstract String voiceUnits();
 
   /**
-   * A valid Mapbox access token used to making the request.
-   *
-   * @return a string representing the Mapbox access token
-   */
-  @SerializedName("access_token")
-  @Ignore(Ignore.Type.SERIALIZATION)
-  @NonNull
-  public abstract String accessToken();
-
-  /**
    * A semicolon-separated list indicating from which side of the road
    * to approach a waypoint.
    * Accepts  {@link DirectionsCriteria#APPROACH_UNRESTRICTED} (default) or
@@ -675,20 +663,14 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * Create a new instance of this class by passing in a formatted valid JSON String
    * with a Mapbox Access Token.
    *
-   * @param json        a formatted valid JSON string defining a RouteOptions
-   * @param accessToken a Mapbox Access Token since {@link #toJson()} does not serialize the token
+   * @param json a formatted valid JSON string defining a RouteOptions
    * @return a new instance of this class defined by the values passed inside this static factory
    *   method
    * @see #fromUrl(URL)
    */
   @NonNull
-  public static RouteOptions fromJson(@NonNull String json, @NonNull String accessToken) {
-    GsonBuilder gson = new GsonBuilder();
-
-    JsonObject jsonObject = gson.create().fromJson(json, JsonObject.class);
-    jsonObject.addProperty("access_token", accessToken);
-
-    return fromJsonElement(jsonObject);
+  public static RouteOptions fromJson(@NonNull String json) {
+    return fromJsonString(json);
   }
 
   /**
@@ -710,7 +692,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * @param url request URL
    * @return a new instance of this class defined by the values passed inside this static factory
    *   method
-   * @see #fromJson(String, String)
+   * @see #fromJson(String)
    */
   @NonNull
   public static RouteOptions fromUrl(@NonNull URL url) {
@@ -744,13 +726,6 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     GsonBuilder gson = new GsonBuilder();
     gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
     return gson.create().fromJson(json, RouteOptions.class);
-  }
-
-  @NonNull
-  private static RouteOptions fromJsonElement(@NonNull JsonElement jsonElement) {
-    GsonBuilder gson = new GsonBuilder();
-    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
-    return gson.create().fromJson(jsonElement, RouteOptions.class);
   }
 
   /**
@@ -1108,17 +1083,6 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      */
     @NonNull
     public abstract Builder voiceUnits(@Nullable String voiceUnits);
-
-    /**
-     * A valid Mapbox access token used to making the request.
-     *
-     * @param accessToken a string containing a valid Mapbox access token.
-     *                    Avoiding to provide a token will most-likely result in a failure, however,
-     *                    it's annotated as nullable to prevent serialization of tokens.
-     * @return this builder for chaining options together
-     */
-    @NonNull
-    public abstract Builder accessToken(@Nullable String accessToken);
 
     /**
      * Exclude certain road types from routing. The default is to not exclude anything from the

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -55,7 +55,6 @@ public class DirectionsResponseTest extends TestUtils {
         add(Point.fromLngLat(1.0, 1.0));
         add(Point.fromLngLat(2.0, 2.0));
       }})
-      .accessToken("token")
       .build();
     String uuid = "123";
     DirectionsResponse response = DirectionsResponse.fromJson(json, options, uuid);

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsRouteTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsRouteTest.java
@@ -69,7 +69,6 @@ public class DirectionsRouteTest extends TestUtils {
         add(Point.fromLngLat(1.0, 1.0));
         add(Point.fromLngLat(2.0, 2.0));
       }})
-      .accessToken("token")
       .build();
     String uuid = "123";
     DirectionsRoute route = DirectionsRoute.fromJson(json, options, uuid);
@@ -87,52 +86,14 @@ public class DirectionsRouteTest extends TestUtils {
         add(Point.fromLngLat(1.0, 1.0));
         add(Point.fromLngLat(2.0, 2.0));
       }})
-      .accessToken("token")
       .build();
     String uuid = "123";
     DirectionsRoute route = DirectionsRoute.fromJson(json, options, uuid);
 
     String newRouteJson = route.toJson();
 
-    DirectionsRoute newRoute = DirectionsRoute.fromJson(newRouteJson, "token");
+    DirectionsRoute newRoute = DirectionsRoute.fromJson(newRouteJson);
 
     assertEquals(route, newRoute);
-  }
-
-  @Test
-  public void directionsRoute_json_invalid_with_options() throws Exception {
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage(
-      "Provided serialized route contains RouteOptions. "
-        + "Use DirectionsRoute#fromJson(json, accessToken) instead.");
-    String json = loadJsonFixture("directions_v5-with-closure_precision_6.json");
-    RouteOptions options = RouteOptions.builder()
-      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
-      .coordinatesList(new ArrayList<Point>() {{
-        add(Point.fromLngLat(1.0, 1.0));
-        add(Point.fromLngLat(2.0, 2.0));
-      }})
-      .accessToken("token")
-      .build();
-    String uuid = "123";
-    DirectionsRoute route = DirectionsRoute.fromJson(json, options, uuid);
-
-    String newRouteJson = route.toJson();
-
-    DirectionsRoute.fromJson(newRouteJson);
-  }
-
-  @Test
-  public void directionsRoute_json_invalid_without_options() throws Exception {
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage(
-      "Provided serialized route does not contain RouteOptions. "
-        + "Use DirectionsRoute#fromJson(json) instead.");
-    String json = loadJsonFixture("directions_v5-with-closure_precision_6.json");
-    DirectionsRoute route = DirectionsRoute.fromJson(json);
-
-    String newRouteJson = route.toJson();
-
-    DirectionsRoute.fromJson(newRouteJson, "token");
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -3,15 +3,12 @@ package com.mapbox.api.directions.v5.models;
 import static com.google.gson.JsonParser.parseString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.core.TestUtils;
 import com.mapbox.geojson.Point;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class RouteOptionsTest extends TestUtils {
@@ -28,28 +25,28 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void baseUrlIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(DirectionsCriteria.BASE_API_URL, routeOptions.baseUrl());
   }
 
   @Test
   public void userIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(DirectionsCriteria.PROFILE_DEFAULT_USER, routeOptions.user());
   }
 
   @Test
   public void profileIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC, routeOptions.profile());
   }
 
   @Test
   public void coordinatesAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(
       "-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835",
@@ -59,28 +56,28 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void alternativesAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(false, routeOptions.alternatives());
   }
 
   @Test
   public void languageIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals("ru", routeOptions.language());
   }
 
   @Test
   public void radiusesAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(";unlimited;5.1", routeOptions.radiuses());
   }
 
   @Test
   public void radiusesListIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(3, routeOptions.radiusesList().size());
     assertNull(routeOptions.radiusesList().get(0));
@@ -90,14 +87,14 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void bearingsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals("0,90;90,0;", routeOptions.bearings());
   }
 
   @Test
   public void bearingsListIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(3, routeOptions.bearingsList().size());
     assertEquals(0.0, routeOptions.bearingsList().get(0).angle(), 0.00001);
@@ -109,154 +106,147 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void continueStraightIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(false, routeOptions.continueStraight());
   }
 
   @Test
   public void roundaboutExitsIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(false, routeOptions.continueStraight());
   }
 
   @Test
   public void geometriesAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(DirectionsCriteria.GEOMETRY_POLYLINE6, routeOptions.geometries());
   }
 
   @Test
   public void stepsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(true, routeOptions.steps());
   }
 
   @Test
   public void annotationsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals("congestion,distance,duration", routeOptions.annotations());
   }
 
   @Test
   public void excludeIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals("toll", routeOptions.exclude());
   }
 
   @Test
   public void overviewIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals("full", routeOptions.overview());
   }
 
   @Test
   public void voiceInstructionsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(true, routeOptions.voiceInstructions());
   }
 
   @Test
   public void bannerInstructionsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(true, routeOptions.bannerInstructions());
   }
 
   @Test
   public void voiceUnitsAreValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(DirectionsCriteria.METRIC, routeOptions.voiceUnits());
   }
 
   @Test
-  public void accessTokenIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
-
-    assertEquals("token", routeOptions.accessToken());
-  }
-
-  @Test
   public void approachesStringIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(";curb;", routeOptions.approaches());
   }
 
   @Test
   public void waypointIndicesStringIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals("0;1;2", routeOptions.waypointIndices());
   }
 
   @Test
   public void waypointNamesStringIsValid_fromJson() {
-    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(";two;", routeOptions.waypointNames());
   }
 
   @Test
   public void waypointTargetsStringIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions options = RouteOptions.fromJson(optionsJson);
 
     assertEquals(";12.2,21.2;", options.waypointTargets());
   }
 
   @Test
   public void snappingIncludeClosuresStringIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions options = RouteOptions.fromJson(optionsJson);
 
     assertEquals(";false;true", options.snappingIncludeClosures());
   }
 
   @Test
   public void alleyBiasIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions options = RouteOptions.fromJson(optionsJson);
 
     assertEquals(0.75, options.alleyBias(), 0.000001);
   }
 
   @Test
   public void walkingSpeedIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions options = RouteOptions.fromJson(optionsJson);
 
     assertEquals(5.11, options.walkingSpeed(), 0.000001);
   }
 
   @Test
   public void walkwayBiasIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions options = RouteOptions.fromJson(optionsJson);
 
     assertEquals(-0.2, options.walkwayBias(), 0.000001);
   }
 
   @Test
   public void arriveByIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions options = RouteOptions.fromJson(optionsJson);
 
     assertEquals("2021-01-01'T'01:01", options.arriveBy());
   }
 
   @Test
   public void departAtIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions options = RouteOptions.fromJson(optionsJson);
 
     assertEquals("2021-02-02'T'02:02", options.departAt());
   }
 
   @Test
   public void enableRefreshIsValid_fromJson() {
-    RouteOptions options = RouteOptions.fromJson(optionsJson, "token");
+    RouteOptions options = RouteOptions.fromJson(optionsJson);
 
     assertEquals(true, options.enableRefresh());
   }
@@ -273,16 +263,6 @@ public class RouteOptionsTest extends TestUtils {
     RouteOptions options = routeOptionsList();
 
     assertEquals(parseString(optionsJson), parseString(options.toJson()));
-  }
-
-  @Test
-  public void routeOptions_toJson_tokenNotSerialized() {
-    String json = routeOptions().toJson();
-
-    Gson gson = new Gson();
-    JsonObject object = gson.fromJson(json, JsonObject.class);
-
-    Assert.assertNull(object.get("access_token"));
   }
 
   /**
@@ -322,7 +302,6 @@ public class RouteOptionsTest extends TestUtils {
       .arriveBy("2021-01-01'T'01:01")
       .departAt("2021-02-02'T'02:02")
       .snappingIncludeClosures(";false;true")
-      .accessToken("token")
       .user(DirectionsCriteria.PROFILE_DEFAULT_USER)
       .enableRefresh(true)
       .build();
@@ -397,7 +376,6 @@ public class RouteOptionsTest extends TestUtils {
         add(false);
         add(true);
       }})
-      .accessToken("token")
       .user(DirectionsCriteria.PROFILE_DEFAULT_USER)
       .enableRefresh(true)
       .build();

--- a/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
+++ b/services-directions/src/main/java/com/mapbox/api/directions/v5/MapboxDirections.java
@@ -79,7 +79,7 @@ public abstract class MapboxDirections extends
       routeOptions().user(),
       routeOptions().profile(),
       routeOptions().coordinates(),
-      routeOptions().accessToken(),
+      accessToken(),
       routeOptions().alternatives(),
       routeOptions().geometries(),
       routeOptions().overview(),
@@ -114,7 +114,7 @@ public abstract class MapboxDirections extends
       routeOptions().user(),
       routeOptions().profile(),
       routeOptions().coordinates(),
-      routeOptions().accessToken(),
+      accessToken(),
       routeOptions().alternatives(),
       routeOptions().geometries(),
       routeOptions().overview(),
@@ -216,6 +216,9 @@ public abstract class MapboxDirections extends
   }
 
   @NonNull
+  abstract String accessToken();
+
+  @NonNull
   abstract RouteOptions routeOptions();
 
   @Nullable
@@ -256,6 +259,18 @@ public abstract class MapboxDirections extends
    */
   @AutoValue.Builder
   public abstract static class Builder {
+
+    /**
+     * A valid Mapbox Access Token used to making the request.
+     * <p>
+     * Learn more about the tokens
+     * <a href="https://docs.mapbox.com/help/getting-started/access-tokens/">here</a>.
+     *
+     * @param accessToken a string representing the Mapbox Access Token
+     * @return this builder for chaining options together
+     */
+    @NonNull
+    public abstract Builder accessToken(@NonNull String accessToken);
 
     /**
      * Set of options specified for this directions request.

--- a/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
+++ b/services-directions/src/test/java/com/mapbox/api/directions/v5/MapboxDirectionsTest.java
@@ -43,11 +43,15 @@ public class MapboxDirectionsTest extends TestUtils {
   private static final String DIRECTIONS_V5_ANNOTATIONS_FIXTURE = "directions_annotations_v5.json";
   private static final String DIRECTIONS_V5_NO_ROUTE = "directions_v5_no_route.json";
   private static final String DIRECTIONS_V5_SPEED_LIMIT = "directions_v5_speedlimit.json";
-  private static final String DIRECTIONS_V5_MAX_SPEED_ANNOTATION = "directions_v5_max_speed_annotation.json";
-  private static final String DIRECTIONS_V5_BANNER_INSTRUCTIONS = "directions_v5_banner_instructions.json";
+  private static final String DIRECTIONS_V5_MAX_SPEED_ANNOTATION =
+    "directions_v5_max_speed_annotation.json";
+  private static final String DIRECTIONS_V5_BANNER_INSTRUCTIONS =
+    "directions_v5_banner_instructions.json";
   private static final String DIRECTIONS_V5_APPROACHES_REQUEST = "directions_v5_approaches.json";
-  private static final String DIRECTIONS_V5_WAYPOINT_NAMES_FIXTURE = "directions_v5_waypoint_names.json";
-  private static final String DIRECTIONS_V5_WAYPOINT_TARGETS_FIXTURE = "directions_v5_waypoint_targets.json";
+  private static final String DIRECTIONS_V5_WAYPOINT_NAMES_FIXTURE =
+    "directions_v5_waypoint_names.json";
+  private static final String DIRECTIONS_V5_WAYPOINT_TARGETS_FIXTURE =
+    "directions_v5_waypoint_targets.json";
   private static final String DIRECTIONS_V5_POST = "directions_v5_post.json";
   private static final String ROUTE_OPTIONS_V5 = "route_options_v5.json";
 
@@ -55,7 +59,8 @@ public class MapboxDirectionsTest extends TestUtils {
   private MockWebServer server;
   private HttpUrl mockUrl;
 
-  private final RouteOptions routeOptions = RouteOptions.fromJson(loadJsonFixture(ROUTE_OPTIONS_V5), "token");
+  private final RouteOptions routeOptions =
+    RouteOptions.fromJson(loadJsonFixture(ROUTE_OPTIONS_V5));
 
   public MapboxDirectionsTest() throws IOException {
   }
@@ -77,8 +82,8 @@ public class MapboxDirectionsTest extends TestUtils {
 
   @Test
   public void testRouteOptionsFromUrl() throws IOException {
-    assertNotNull(routeOptions.accessToken());
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertEquals(
@@ -89,8 +94,8 @@ public class MapboxDirectionsTest extends TestUtils {
 
   @Test
   public void testRouteOptionsFromUrl_alreadyDecoded() throws IOException {
-    assertNotNull(routeOptions.accessToken());
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertEquals(
@@ -104,6 +109,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void sanity() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertNotNull(mapboxDirections);
@@ -113,6 +119,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void build_coordinatesListCreatedInCorrectOrder() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString()
@@ -122,6 +129,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void build_walkingWalkingSpeedOptions() {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("walking_speed=5.11"));
@@ -130,6 +138,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void build_walkingWalkwayBiasOptions() {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("walkway_bias=-0.2"));
@@ -138,6 +147,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void build_walkingAlleyBiasOptions() {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("alley_bias=0.75"));
@@ -146,6 +156,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void user_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("/mapbox/"));
@@ -154,6 +165,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void profile_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("/driving-traffic/"));
@@ -162,6 +174,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void waypointList_doesGetFormattedInUrlCorrectly() {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
 
@@ -171,6 +184,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void alternatives_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("alternatives=false"));
@@ -179,6 +193,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void geometries_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("geometries=polyline6"));
@@ -187,6 +202,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void overview_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("overview=full"));
@@ -195,6 +211,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void steps_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("steps=true"));
@@ -203,6 +220,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void continueStraight_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString()
@@ -212,6 +230,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void language_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("language=ru"));
@@ -220,6 +239,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void annotations_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertEquals("congestion,distance,duration",
@@ -229,6 +249,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void addBearing_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertEquals("0,90;90,0;",
@@ -238,6 +259,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void radiuses_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertEquals(";unlimited;5.1",
@@ -247,6 +269,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void clientAppName_doesGetAddedToRequestHeader1() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .clientAppName("APP")
       .build();
@@ -256,6 +279,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void clientAppName_doesGetAddedToRequestHeader2() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .clientAppName("APP")
       .build();
@@ -265,6 +289,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void accessToken_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertTrue(directions.cloneCall().request().url().toString().contains("access_token=token"));
@@ -273,14 +298,17 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void baseUrl_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
-    assertTrue(directions.cloneCall().request().url().toString().startsWith("https://api.mapbox.com"));
+    assertTrue(
+      directions.cloneCall().request().url().toString().startsWith("https://api.mapbox.com"));
   }
 
   @Test
   public void voiceUnits_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
 
@@ -290,24 +318,29 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void bannerInstructions_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
 
-    assertTrue(directions.cloneCall().request().url().toString().contains("banner_instructions=true"));
+    assertTrue(
+      directions.cloneCall().request().url().toString().contains("banner_instructions=true"));
   }
 
   @Test
   public void voiceInstructions_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
 
-    assertTrue(directions.cloneCall().request().url().toString().contains("voice_instructions=true"));
+    assertTrue(
+      directions.cloneCall().request().url().toString().contains("voice_instructions=true"));
   }
 
   @Test
   public void exclude_doesGetFormattedInUrlCorrectly() throws Exception {
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
 
@@ -317,6 +350,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void callFactoryNonNull() throws IOException {
     MapboxDirections client = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
@@ -331,6 +365,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void radiusWithUnlimitedDistance() throws IOException {
     MapboxDirections client = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
@@ -342,6 +377,7 @@ public class MapboxDirectionsTest extends TestUtils {
   public void noValidRouteTest() throws Exception {
     testDispatcher.currentResource = DIRECTIONS_V5_NO_ROUTE;
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
@@ -354,6 +390,7 @@ public class MapboxDirectionsTest extends TestUtils {
   public void setCoordinates_localeShouldNotMatter() {
     Locale.setDefault(Locale.GERMANY);
     MapboxDirections directions = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
     assertTrue(directions.cloneCall().request().url().toString()
@@ -420,6 +457,7 @@ public class MapboxDirectionsTest extends TestUtils {
     testDispatcher.currentResource = DIRECTIONS_V5_BANNER_INSTRUCTIONS;
 
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
@@ -440,6 +478,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void sanityApproachesInstructions() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
 
@@ -450,6 +489,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void sanityWaypointNamesInstructions() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
     assertNotNull(mapboxDirections);
@@ -460,6 +500,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void withWaypointTargets() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions)
       .build();
 
@@ -479,6 +520,7 @@ public class MapboxDirectionsTest extends TestUtils {
       }
     };
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .interceptor(interceptor)
       .build();
@@ -496,6 +538,7 @@ public class MapboxDirectionsTest extends TestUtils {
     };
 
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .networkInterceptor(interceptor)
       .build();
@@ -513,6 +556,7 @@ public class MapboxDirectionsTest extends TestUtils {
     };
 
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .eventListener(eventListener)
       .build();
@@ -523,6 +567,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void post() throws IOException {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .usePostMethod(true)
       .build();
@@ -544,12 +589,12 @@ public class MapboxDirectionsTest extends TestUtils {
       fakeCoordinates.add(Point.fromLngLat(random.nextInt(50), random.nextInt(50)));
     }
     MapboxDirections.Builder builder = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(
         RouteOptions.builder()
           .baseUrl(mockUrl.toString())
           .coordinatesList(fakeCoordinates)
           .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
-          .accessToken("token")
           .build()
       );
 
@@ -561,6 +606,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void callForUrlLength_shortUrl() {
     MapboxDirections.Builder builder = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build());
 
     retrofit2.Call<DirectionsResponse> call = builder.build().initializeCall();
@@ -571,6 +617,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void postIsUsed() {
     MapboxDirections.Builder builder = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .usePostMethod(true);
 
@@ -582,6 +629,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void getIsUsed() {
     MapboxDirections.Builder builder = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .usePostMethod(false);
 
@@ -593,6 +641,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void getIsUsedByDefault() {
     MapboxDirections.Builder builder = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build());
 
     retrofit2.Call<DirectionsResponse> call = builder.build().initializeCall();
@@ -603,6 +652,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void withIncidents() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
@@ -639,6 +689,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void snappingIncludeClosures() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
@@ -649,6 +700,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void arrive_by() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
@@ -659,6 +711,7 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void depart_at() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
@@ -669,11 +722,19 @@ public class MapboxDirectionsTest extends TestUtils {
   @Test
   public void enable_refresh() throws Exception {
     MapboxDirections mapboxDirections = MapboxDirections.builder()
+      .accessToken("token")
       .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
       .build();
 
     assertEquals("true",
       mapboxDirections.cloneCall().request().url().queryParameter("enable_refresh"));
+  }
+
+  @Test(expected = Exception.class)
+  public void token_required() throws Exception {
+    MapboxDirections.builder()
+      .routeOptions(routeOptions.toBuilder().baseUrl(mockUrl.toString()).build())
+      .build();
   }
 
   class TestDispatcher extends okhttp3.mockwebserver.Dispatcher {

--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MatchingResponseFactory.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MatchingResponseFactory.java
@@ -70,7 +70,6 @@ class MatchingResponseFactory {
               .overview(mapboxMapMatching.overview())
               .steps(mapboxMapMatching.steps())
               .voiceUnits(mapboxMapMatching.voiceUnits())
-              .accessToken(mapboxMapMatching.accessToken())
               .waypointIndices(mapboxMapMatching.waypointIndices())
               .waypointNames(mapboxMapMatching.waypointNames())
               .baseUrl(mapboxMapMatching.baseUrl())

--- a/services-matching/src/test/java/com/mapbox/api/matching/v5/MapMatchingRouteOptionsTest.java
+++ b/services-matching/src/test/java/com/mapbox/api/matching/v5/MapMatchingRouteOptionsTest.java
@@ -83,7 +83,6 @@ public class MapMatchingRouteOptionsTest extends TestUtils {
       .profile("hello")
       .user("user")
       .coordinatesList(pointList)
-      .accessToken(ACCESS_TOKEN)
       .build();
     assertNotNull(routeOptions);
     assertEquals("hello", routeOptions.profile());


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-java/issues/1275. Moves the `accessToken` parameter from `RouteOptions` to `MapboxDirections`.