### PR TITLE
add missing properties to Incident object

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/Incident.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/Incident.java
@@ -250,6 +250,36 @@ public abstract class Incident extends DirectionsJsonObject {
   public abstract String endTime();
 
   /**
+   * Two letter country code where the incident is located.
+   * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2.">ISO Country code Wikipedia page</a>
+   */
+  @Nullable
+  @SerializedName("iso_3166_1_alpha2")
+  public abstract String countryCodeAlpha2();
+
+  /**
+   * Three letter country code where the incident is located.
+   * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3.">ISO Country code Wikipedia page</a>
+   */
+  @Nullable
+  @SerializedName("iso_3166_1_alpha3")
+  public abstract String countryCodeAlpha3();
+
+  /**
+   * A list of lanes that are blocked by the incident.
+   */
+  @Nullable
+  @SerializedName("lanes_blocked")
+  public abstract List<String> lanesBlocked();
+
+  /**
+   * The number of items in the {@link Incident#lanesBlocked()} list.
+   */
+  @Nullable
+  @SerializedName("num_lanes_blocked")
+  public abstract Integer numLanesBlocked();
+
+  /**
    * Create a new instance of this class by using the {@link Incident.Builder} class.
    *
    * @return this classes {@link Incident.Builder} for creating a new instance
@@ -405,6 +435,36 @@ public abstract class Incident extends DirectionsJsonObject {
      * @param endTime ISO8601 format
      */
     public abstract Builder endTime(@Nullable String endTime);
+
+    /**
+     * Two letter country code where the incident is located.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2.">ISO Country code Wikipedia page</a>
+     *
+     * @param countryCodeAlpha2 2 letter country code
+     */
+    public abstract Builder countryCodeAlpha2(@Nullable String countryCodeAlpha2);
+
+    /**
+     * Three letter country code where the incident is located.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3.">ISO Country code Wikipedia page</a>
+     *
+     * @param countryCodeAlpha3 3 letter country code
+     */
+    public abstract Builder countryCodeAlpha3(@Nullable String countryCodeAlpha3);
+
+    /**
+     * A list of lanes that are blocked by the incident.
+     *
+     * @param lanesBlocked lanes blocked
+     */
+    public abstract Builder lanesBlocked(@Nullable List<String> lanesBlocked);
+
+    /**
+     * The number of items in the {@link Incident#lanesBlocked()} list.
+     *
+     * @param numLanesBlocked number lanes blocked
+     */
+    public abstract Builder numLanesBlocked(@Nullable Integer numLanesBlocked);
 
     /**
      * Build a new instance of {@link Incident}.

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/IncidentTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/IncidentTest.java
@@ -4,8 +4,9 @@ import com.google.common.collect.Lists;
 import com.mapbox.core.TestUtils;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
 
 public class IncidentTest extends TestUtils {
 
@@ -32,6 +33,10 @@ public class IncidentTest extends TestUtils {
       .subType("sub type")
       .subTypeDescription("sub type desc")
       .type(Incident.INCIDENT_DISABLED_VEHICLE)
+      .lanesBlocked(Lists.<String>newArrayList())
+      .numLanesBlocked(null)
+      .countryCodeAlpha2("US")
+      .countryCodeAlpha3("USA")
       .build();
     byte[] serialized = TestUtils.serialize(incident);
     assertEquals(incident, deserialize(serialized, Incident.class));
@@ -57,6 +62,9 @@ public class IncidentTest extends TestUtils {
       "803" +
       "]," +
       "\"lanes_blocked\": []," +
+      "\"num_lanes_blocked\": null," +
+      "\"iso_3166_1_alpha2\": US," +
+      "\"iso_3166_1_alpha3\": USA," +
       "\"geometry_index_start\": 805," +
       "\"geometry_index_end\": 896" +
       "}";
@@ -78,6 +86,10 @@ public class IncidentTest extends TestUtils {
     assertEquals(fromJson.alertcCodes().size(), 2);
     assertEquals(fromJson.geometryIndexStart().longValue(), 805L);
     assertEquals(fromJson.geometryIndexEnd().longValue(), 896L);
+    assertEquals(fromJson.countryCodeAlpha2(), "US");
+    assertEquals(fromJson.countryCodeAlpha3(), "USA");
+    assertEquals(fromJson.lanesBlocked().size(), 0);
+    assertNull(fromJson.numLanesBlocked());
   }
 
   private Incident getDefault() {


### PR DESCRIPTION
Fixes #1287 

**Before**
```
2021-08-30 10:57:04.438 30289-30289/com.mapbox.navigation.examples D/abhishek_testing: incident: Incident{id=15206143733423687, type=lane_restriction, closed=null, congestion=Congestion{value=101}, description=Lilienthalallee: Bauarbeiten zwischen Heidemannstrasse und Frankfurter Ring, longDescription=Vorübergehende Ampelregelung und ein alternativer Linienverkehr wegen Bauarbeiten auf der Lilienthalallee in beiden Richtungen zwischen Heidemannstrasse und Frankfurter Ring., impact=low, subType=CONSTRUCTION, subTypeDescription=null, alertcCodes=[742, 708], geometryIndexStart=4, geometryIndexEnd=44, creationTime=2021-08-30T17:40:33Z, startTime=2020-09-14T05:30:00Z, endTime=2021-10-01T13:00:00Z}
```

**After**
```
2021-08-30 11:09:46.077 15901-15901/com.mapbox.navigation.examples D/abhishek_testing: incident: Incident{id=15206143733423687, type=lane_restriction, closed=null, congestion=Congestion{value=101}, description=Lilienthalallee: Bauarbeiten zwischen Heidemannstrasse und Frankfurter Ring, longDescription=Vorübergehende Ampelregelung und ein alternativer Linienverkehr wegen Bauarbeiten auf der Lilienthalallee in beiden Richtungen zwischen Heidemannstrasse und Frankfurter Ring., impact=low, subType=CONSTRUCTION, subTypeDescription=null, alertcCodes=[742, 708], geometryIndexStart=4, geometryIndexEnd=43, creationTime=2021-08-30T17:55:33Z, startTime=2020-09-14T05:30:00Z, endTime=2021-10-01T13:00:00Z, countryCodeAlpha2=DE, countryCodeAlpha3=DEU, lanesBlocked=[], numLanesBlocked=null}
```