### PR TITLE
Refactor RouteOptions.toUrl

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -854,8 +854,14 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   @NonNull
   public URL toUrl(@NonNull String accessToken) {
     StringBuilder sb = new StringBuilder()
-      .append(baseUrl())
-      .append("/directions/v5")
+            .append(baseUrl());
+
+    Character lastBaseUrlChar = baseUrl().charAt(baseUrl().length() - 1);
+    if (!lastBaseUrlChar.equals('/')) {
+      sb.append('/');
+    }
+
+    sb.append("directions/v5")
       .append(String.format("/%s", user()))
       .append(String.format("/%s", profile()))
       .append(String.format("/%s", coordinates()))

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -364,6 +364,24 @@ public class RouteOptionsTest extends TestUtils {
     assertEquals(expectedUrl, url.toString());
   }
 
+  @Test
+  public void baseUrlWithLastSlash() {
+    String expectedUrl = "https://mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
+    List<Point> coordinates = new ArrayList<>();
+    coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
+    coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
+
+    RouteOptions options = RouteOptions.builder()
+            .baseUrl("https://mapbox.com/")
+            .profile(DirectionsCriteria.PROFILE_DRIVING)
+            .coordinatesList(coordinates)
+            .build();
+
+    URL url = options.toUrl(ACCESS_TOKEN);
+
+    assertEquals(expectedUrl, url.toString());
+  }
+
   /**
    * Fills up all the options using string variants. Values need ot be equal to the ones in {@link #optionsJson}.
    */


### PR DESCRIPTION
closes https://github.com/mapbox/mapbox-java/issues/1313

can't use`java.net.URL` case it doesn't have handy methods to build URL, so use okhttp `HttpUrl`

also some symbols were encoded:
; -> %3B
, -> %2C
it shouldn't be an issue, right?
