### PR TITLE
added encoding for RouteOptions.toUrl

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -16,6 +16,8 @@ import com.mapbox.api.directions.v5.utils.ParseUtils;
 import com.mapbox.geojson.Point;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.List;
@@ -846,7 +848,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   }
 
   /**
-   * Create a URL from RouteOptions instance.
+   * Create an encoded URL from RouteOptions instance.
    *
    * @param accessToken access token to make API request
    * @return a URL object instance
@@ -957,8 +959,18 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     }
 
     try {
-      return new URL(sb.toString());
-    } catch (MalformedURLException ex) {
+      URL decodedUrl = new URL(sb.toString());
+      URI encodedUri = new URI(
+        decodedUrl.getProtocol(),
+        decodedUrl.getUserInfo(),
+        decodedUrl.getHost(),
+        decodedUrl.getPort(),
+        decodedUrl.getPath(),
+        decodedUrl.getQuery(),
+        decodedUrl.getRef()
+      );
+      return encodedUri.toURL();
+    } catch (MalformedURLException | URISyntaxException ex) {
       throw new RuntimeException(ex);
     }
   }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -382,6 +382,43 @@ public class RouteOptionsTest extends TestUtils {
     assertEquals(expectedUrl, url.toString());
   }
 
+  @Test
+  public void routeOptionsWithDecodedChars_toUrlWithEncodedChars() {
+    String expectedEncodedUrl = "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=my%20starting%20position;my%20destination";
+    List<Point> coordinates = new ArrayList<>();
+    coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
+    coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
+
+    RouteOptions options = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .waypointNames("my starting position;my destination")
+      .build();
+
+    URL url = options.toUrl(ACCESS_TOKEN);
+
+    assertEquals(expectedEncodedUrl, url.toString());
+  }
+
+  @Test
+  public void routeOptions_toUrl_fromUrl_withEncodedChars() {
+    List<Point> coordinates = new ArrayList<>();
+    coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
+    coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
+
+    RouteOptions expectedOptions = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .waypointNames("my starting position;my destination")
+      .build();
+
+    URL url = expectedOptions.toUrl(ACCESS_TOKEN);
+
+    RouteOptions resultingOptions = RouteOptions.fromUrl(url);
+
+    assertEquals(expectedOptions, resultingOptions);
+  }
+
   /**
    * Fills up all the options using string variants. Values need ot be equal to the ones in {@link #optionsJson}.
    */


### PR DESCRIPTION
Follow up to https://github.com/mapbox/mapbox-java/pull/1314. Added encoding for parameters transformed with `RouteOptions#toUrl()`.