### PR TITLE
Generate docs automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,14 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+      - publish-documentation:
+          requires:
+            - release
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
   default:
     jobs:
       - build
@@ -69,7 +77,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: mbgl/android-ndk-r19:latest
+      - image: mbgl/android-ndk-r21e:latest
     steps:
       - checkout
       - build-release
@@ -78,7 +86,7 @@ jobs:
   test:
     working_directory: ~/code
     docker:
-      - image: mbgl/android-ndk-r19:latest
+      - image: mbgl/android-ndk-r21e:latest
     steps:
       - checkout
       - restore_cache:
@@ -94,7 +102,7 @@ jobs:
     environment:
       - MBX_CI_DOMAIN: o619qyc20d.execute-api.us-east-1.amazonaws.com
     docker:
-      - image: mbgl/android-ndk-r19:latest
+      - image: mbgl/android-ndk-r21e:latest
     working_directory: ~/code
     steps:
       - checkout
@@ -108,7 +116,7 @@ jobs:
     environment:
       - MBX_CI_DOMAIN: o619qyc20d.execute-api.us-east-1.amazonaws.com
     docker:
-      - image: mbgl/android-ndk-r19:latest
+      - image: mbgl/android-ndk-r21e:latest
     working_directory: ~/code
     steps:
       - checkout
@@ -125,3 +133,19 @@ jobs:
 #          name: Create pull request in api-downloads
 #          command: |
 #            make sdk-registry-publish
+  publish-documentation:
+    environment:
+      - MBX_CI_DOMAIN: o619qyc20d.execute-api.us-east-1.amazonaws.com
+    docker:
+      - image: mbgl/android-ndk-r21e:latest
+    working_directory: ~/code
+    steps:
+      - checkout
+      - setup-aws-credentials
+      - run:
+          name: Publish API docs
+          command: |
+            GITHUB_WRITER_TOKEN=$(./mbx-ci github writer token)
+            git remote set-url origin "https://x-access-token:$GITHUB_WRITER_TOKEN@github.com/mapbox/mapbox-java.git"
+            git config --global user.email no-reply@mapbox.com && git config --global user.name mapbox-ci
+            ./scripts/publish_api_docs_android.sh -p $GITHUB_WRITER_TOKEN -t $CIRCLE_TAG

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ build-cli:
 
 javadoc:
 	mkdir documentation
-	mkdir documentation/core/
-	mkdir documentation/geojson/
-	mkdir documentation/turf/
-	mkdir documentation/services/
-	./gradlew :services-core:javadoc; mv services-core/build/docs/javadoc/ ./documentation/core/javadoc/ ; \
-	./gradlew :services-geojson:javadoc; mv services-geojson/build/docs/javadoc/ ./documentation/geojson/javadoc/ ; \
-	./gradlew :services-turf:javadoc; mv services-turf/build/docs/javadoc/ ./documentation/turf/javadoc/ ; \
-	./gradlew :services:javadoc; mv services/build/docs/javadoc/ ./documentation/services/javadoc/ ; \
+	mkdir documentation/libjava-core/
+	mkdir documentation/libjava-geojson/
+	mkdir documentation/libjava-turf/
+	mkdir documentation/libjava-services/
+	./gradlew :services-core:javadoc; mv services-core/build/docs/javadoc/ ./documentation/libjava-core/javadoc/ ; \
+	./gradlew :services-geojson:javadoc; mv services-geojson/build/docs/javadoc/ ./documentation/libjava-geojson/javadoc/ ; \
+	./gradlew :services-turf:javadoc; mv services-turf/build/docs/javadoc/ ./documentation/libjava-turf/javadoc/ ; \
+	./gradlew :services:javadoc; mv services/build/docs/javadoc/ ./documentation/libjava-services/javadoc/ ; \
 
 sdk-registry-upload:
 	./gradlew mapboxSDKRegistryUpload

--- a/scripts/publish_api_docs_android.sh
+++ b/scripts/publish_api_docs_android.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: " 1>&2;
+    echo "$0 arguments [optional arguments]" 1>&2;
+    echo "  Arguments : " 1>&2;
+    echo "   -t <TAG>                       tag, e.g. v1.0.0" 1>&2;
+    echo "   -p <GITHUB APP TOKEN>          access token for pull request creation" 1>&2;
+    echo "  Optional arguments : " 1>&2;
+    echo "   -a <GIT_REPOSITORY> path to the repository, by default uses current path" 1>&2;
+    exit 1;
+}
+
+readonly DOCS_BASE_BRANCH_NAME_PRODUCTION="publisher-production"
+readonly DOCS_BASE_BRANCH_NAME_STAGING="publisher-staging"
+PATH_TO_REPO=$(pwd)
+GITHUB_PR_ACCESS_TOKEN=""
+readonly GENERATED_DOCS_FOLDER=${PATH_TO_REPO}/documentation
+readonly DOCS_PREFIX="libjava"
+
+while getopts "t:a:p:" opt; do
+    case "${opt}" in
+        t)
+            TAG=${OPTARG}
+            VERSION_NUMBER="${TAG//v}"
+            BRANCH_NAME="docs-${TAG}"
+            ;;
+        p)
+            GITHUB_PR_ACCESS_TOKEN=${OPTARG}
+            ;;
+        a)
+            PATH_TO_REPO=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+echo "Repository path=${PATH_TO_REPO}"
+
+checkIfGithubTokensAreProvided() {
+    if [ -z "$GITHUB_PR_ACCESS_TOKEN" ]; then
+        usage
+    fi
+}
+
+checkIfTagExist() {
+    pushd "${PATH_TO_REPO}"
+    if [ "$(git tag --points-at HEAD)" = "$TAG" ]; then
+        echo "tag ${TAG} exist"
+    else
+        echo "current commit doesn't point at the tag ${TAG}"
+        usage
+    fi
+    echo "VERSION_NUMBER=${VERSION_NUMBER}"
+
+    popd > /dev/null
+}
+
+generateDocs() {
+    pushd "${PATH_TO_REPO}"
+    echo "Start generating docs"
+
+    make javadoc
+
+    echo "Finish generating docs"
+    popd > /dev/null
+}
+
+checkoutToPublisherStaging() {
+    pushd "${PATH_TO_REPO}"
+
+    echo "checkout to ${DOCS_BASE_BRANCH_NAME_STAGING}"
+    git checkout "${DOCS_BASE_BRANCH_NAME_STAGING}"
+
+    popd > /dev/null
+}
+
+checkoutToPublisherProduction() {
+    pushd "${PATH_TO_REPO}"
+
+    echo "checkout to ${DOCS_BASE_BRANCH_NAME_PRODUCTION}"
+    git checkout "${DOCS_BASE_BRANCH_NAME_PRODUCTION}"
+
+    popd > /dev/null
+}
+
+copyDocumentsToDocsFolders() {
+    for fullPath in `find $GENERATED_DOCS_FOLDER -type d -maxdepth 1 -mindepth 1 | grep $DOCS_PREFIX` ; do
+        docsDirectory=`basename $fullPath`
+        targetDirectory=$PATH_TO_REPO/$docsDirectory/$VERSION_NUMBER
+        mkdir $targetDirectory
+        cp -r $fullPath/javadoc/. $targetDirectory
+    done
+}
+
+pushDocsToStaging() {
+    pushd "${PATH_TO_REPO}"
+
+    echo "push docs to staging"
+    git add "./$DOCS_PREFIX*"
+    git commit -m "Docs ${TAG}" -q
+    git push origin HEAD --set-upstream -q
+
+    popd > /dev/null
+}
+
+createBranchProduction() {
+    pushd "${PATH_TO_REPO}"
+
+    echo "create a docs brach"
+    git checkout -b ${BRANCH_NAME}
+    git add "./$DOCS_PREFIX*"
+    git commit -m "Docs ${TAG}" -q
+    git push origin HEAD --set-upstream -q
+    popd > /dev/null
+}
+
+createPullRequest() {
+    pushd "${PATH_TO_REPO}"
+
+    echo "create pull request"
+
+    GITHUB_TOKEN=$GITHUB_PR_ACCESS_TOKEN gh pr create \
+        --title "Docs ${TAG}" \
+        --body "**Docs ${TAG}**
+        <br/>**Staging**:
+        <br/> mapbox-java-core:
+        <a href='https://github.com/mapbox/mapbox-java/tree/publisher-staging/libjava-core/${VERSION_NUMBER}'>staging github</a>
+        <br/>mapbox-java-geojson:
+        <a href='https://github.com/mapbox/mapbox-java/tree/publisher-staging/libjava-geojson/${VERSION_NUMBER}'>staging github</a>
+        <br/>mapbox-java-turf:
+        <a href='https://github.com/mapbox/mapbox-java/tree/publisher-staging/libjava-turf/${VERSION_NUMBER}'>staging github</a>
+        <br/>mapbox-java-services:
+        <a href='https://github.com/mapbox/mapbox-java/tree/publisher-staging/libjava-core/${VERSION_NUMBER}'>staging github</a>
+        <br/>**cc** @mapbox/navigation-android" \
+        --base ${DOCS_BASE_BRANCH_NAME_PRODUCTION} \
+        --head ${BRANCH_NAME} \
+        --label "Documentation"
+
+    popd > /dev/null
+}
+
+checkIfGithubTokensAreProvided
+checkIfTagExist
+generateDocs
+# staging
+checkoutToPublisherStaging
+copyDocumentsToDocsFolders
+pushDocsToStaging
+# production
+checkoutToPublisherProduction
+copyDocumentsToDocsFolders
+createBranchProduction
+createPullRequest


### PR DESCRIPTION
The script automatically cuts a PR with generated documentation to the `publisher-production` branch. See #1321 as an example. 

### Testing
This time I did a great job testing it.
I launched script locally without changes and got #1321 
Then I launched the script from the circleci with hardcoded values and got  #1324