### PR TITLE
when encoding RouteOptions to URL use UTF-8

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -991,7 +991,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
         decodedUrl.getQuery(),
         decodedUrl.getRef()
       );
-      return encodedUri.toURL();
+      return new URL(encodedUri.toASCIIString());
     } catch (MalformedURLException | URISyntaxException ex) {
       throw new RuntimeException(ex);
     }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -419,6 +419,24 @@ public class RouteOptionsTest extends TestUtils {
     assertEquals(expectedOptions, resultingOptions);
   }
 
+  @Test
+  public void routeOptionsWithUTF8Chars_toUrlWithEncodedChars() {
+    String expectedEncodedUrl = "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=;%D0%A3%D0%BB%D0%B8%D1%86%D0%B0%20%D0%AF%D0%BD%D0%B0%20%D0%A7%D0%B5%D1%87%D0%BE%D1%82%D0%B0%207,%20Minsk%20220045,%20Belarus";
+    List<Point> coordinates = new ArrayList<>();
+    coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
+    coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
+
+    RouteOptions options = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .waypointNames(";Улица Яна Чечота 7, Minsk 220045, Belarus")
+      .build();
+
+    URL url = options.toUrl(ACCESS_TOKEN);
+
+    assertEquals(expectedEncodedUrl, url.toString());
+  }
+
   /**
    * Fills up all the options using string variants. Values need ot be equal to the ones in {@link #optionsJson}.
    */


### PR DESCRIPTION
Makes sure that no forbidden characters are found in the encoded URL. With the old approach, all characters were escaped correctly but UTF-8 characters were not encoded.