### PR TITLE
Primitive implementation of line intersect

### DIFF
--- a/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
@@ -27,6 +27,44 @@ public final class TurfMisc {
   }
 
   /**
+   * Takes lines {@link LineString} and returns intersect points. The time complexity is O(nm)
+   * that is not as efficient as Turf.js implementation.
+   *
+   * @param line1 LineString 1
+   * @param line2 LineString 2
+   * @return Intersect points
+   * @see <a href="https://turfjs.org/docs/#lineIntersect">Turf Line intersect documentation</a>
+   * @since 6.2.0
+   */
+  @NonNull
+  public static List<Point> lineIntersect(@NonNull LineString line1, @NonNull LineString line2) {
+    List<Point> result = new ArrayList<>();
+    Point[] line1Points = line1.coordinates().toArray(new Point[line1.coordinates().size()]);
+    Point[] line2Points = line2.coordinates().toArray(new Point[line2.coordinates().size()]);
+
+    for (int i = 0; i < line1Points.length - 1; i++) {
+      for (int j = 0; j < line2Points.length - 1; j++) {
+        LineIntersectsResult intersects = lineIntersects(
+          line1Points[i].longitude(),
+          line1Points[i].latitude(),
+          line1Points[i + 1].longitude(),
+          line1Points[i + 1].latitude(),
+          line2Points[j].longitude(),
+          line2Points[j].latitude(),
+          line2Points[j + 1].longitude(),
+          line2Points[j + 1].latitude());
+
+        if (intersects != null) {
+          result.add(Point.fromLngLat(
+            intersects.horizontalIntersection(),
+            intersects.verticalIntersection()));
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
    * Takes a line, a start {@link Point}, and a stop point and returns the line in between those
    * points.
    *

--- a/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
@@ -346,11 +346,11 @@ public final class TurfMisc {
       + (varA * (line1EndY - line1StartY))).build();
 
     // if line1 is a segment and line2 is infinite, they intersect if:
-    if (varA > 0 && varA < 1) {
+    if (varA >= 0 && varA <= 1) {
       result = result.toBuilder().onLine1(true).build();
     }
     // if line2 is a segment and line1 is infinite, they intersect if:
-    if (varB > 0 && varB < 1) {
+    if (varB >= 0 && varB <= 1) {
       result = result.toBuilder().onLine2(true).build();
     }
     // if line1 and line2 are segments, they intersect if both of the above are true

--- a/services-turf/src/test/java/com/mapbox/turf/TurfMiscTest.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TurfMiscTest.java
@@ -34,6 +34,78 @@ public class TurfMiscTest extends TestUtils {
   public ExpectedException thrown = ExpectedException.none();
 
   @Test
+  public void lineIntersect_intersectingEdge() {
+    List<Point> line1Coords = new ArrayList<>();
+    line1Coords.add(Point.fromLngLat(1.0, 2.0));
+    line1Coords.add(Point.fromLngLat(2.0, 3.0));
+    LineString line1 = LineString.fromLngLats(line1Coords);
+
+    List<Point> line2Coords = new ArrayList<>();
+    line2Coords.add(Point.fromLngLat(2.0, 3.0));
+    line2Coords.add(Point.fromLngLat(4.0, 2.0));
+    LineString line2 = LineString.fromLngLats(line2Coords);
+
+    List<Point> result1 = TurfMisc.lineIntersect(line1, line2);
+    assertEquals(1, result1.size());
+    assertEquals(Point.fromLngLat(2.0, 3.0), result1.get(0));
+
+    List<Point> line3Coords = new ArrayList<>();
+    line3Coords.add(Point.fromLngLat(0.0, 3.0));
+    line3Coords.add(Point.fromLngLat(1.0, 2.0));
+    LineString line3 = LineString.fromLngLats(line3Coords);
+
+    List<Point> result2 = TurfMisc.lineIntersect(line1, line3);
+    assertEquals(1, result2.size());
+    assertEquals(Point.fromLngLat(1.0, 2.0), result2.get(0));
+  }
+
+  @Test
+  public void lineIntersect_intersecting() {
+    List<Point> line1Coords = new ArrayList<>();
+    line1Coords.add(Point.fromLngLat(2.0, 1.0));
+    line1Coords.add(Point.fromLngLat(2.0, 5.0));
+    line1Coords.add(Point.fromLngLat(2.0, 9.0));
+    LineString line1 = LineString.fromLngLats(line1Coords);
+
+    List<Point> line2Coords = new ArrayList<>();
+    line2Coords.add(Point.fromLngLat(4.0, 1.0));
+    line2Coords.add(Point.fromLngLat(0.0, 5.0));
+    line2Coords.add(Point.fromLngLat(2.0, 9.0));
+    LineString line2 = LineString.fromLngLats(line2Coords);
+
+    List<Point> expected = new ArrayList<>();
+    expected.add(Point.fromLngLat(2.0, 3.0));
+    expected.add(Point.fromLngLat(2.0, 9.0));
+
+    List<Point> result = TurfMisc.lineIntersect(line1, line2);
+    for(int i = 0; i < result.size(); i++) {
+      assertEquals(expected.get(i), result.get(i));
+    }
+  }
+
+  @Test
+  public void lineIntersect_nonintersecting() {
+    List<Point> line1Coords = new ArrayList<>();
+    line1Coords.add(Point.fromLngLat(2.0, 1.0));
+    line1Coords.add(Point.fromLngLat(2.0, 5.0));
+    line1Coords.add(Point.fromLngLat(2.0, 9.0));
+    LineString line1 = LineString.fromLngLats(line1Coords);
+
+    List<Point> line2Coords = new ArrayList<>();
+    line2Coords.add(Point.fromLngLat(1.0, 1.0));
+    line2Coords.add(Point.fromLngLat(1.0, 5.0));
+    line2Coords.add(Point.fromLngLat(1.0, 9.0));
+    LineString line2 = LineString.fromLngLats(line2Coords);
+
+    List<Point> expected = new ArrayList<>();
+    expected.add(Point.fromLngLat(2.0, 3.0));
+    expected.add(Point.fromLngLat(2.0, 9.0));
+
+    List<Point> result = TurfMisc.lineIntersect(line1, line2);
+    assertEquals(0, result.size());
+  }
+
+  @Test
   public void lineSlice_throwsStartStopPointException() throws Exception {
     thrown.expect(TurfException.class);
     thrown.expectMessage(startsWith("Turf lineSlice requires a LineString made up of at least 2 "


### PR DESCRIPTION
## Summary
Implement line intersect which is equivalent to [turf.lineIntersect](https://turfjs.org/docs/#lineIntersect) with a primitive manner.

## Discussion

- [ ] It's O(nm) implementation as same as [Turf-Swift](https://github.com/mapbox/turf-swift/blob/v2.1.0/Sources/Turf/Geometries/LineString.swift#L384). Please judge if this algorithm is acceptable or not as a stopgap solution.
- [ ] The handling of line segment endpoint is different from Turf-Swift. In Turf-Swift endpoint is included while not in Turf-Java. [This](https://github.com/mapbox/mapbox-java/blob/v6.1.0/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java#L349) and [this](https://github.com/mapbox/mapbox-java/blob/v6.1.0/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java#L353) `if` conditions causes the difference. If they are like `varA >= 0 && varA <= 1`, the behavior becomes same. Which Swift/Java is the expected? (This is because the test is slightly different from Turf-Swift)