### PR TITLE
Fix lineIntersects to align with Turf.js implementation

### DIFF
--- a/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
@@ -346,11 +346,11 @@ public final class TurfMisc {
       + (varA * (line1EndY - line1StartY))).build();
 
     // if line1 is a segment and line2 is infinite, they intersect if:
-    if (varA > 0 && varA < 1) {
+    if (varA >= 0 && varA <= 1) {
       result = result.toBuilder().onLine1(true).build();
     }
     // if line2 is a segment and line1 is infinite, they intersect if:
-    if (varB > 0 && varB < 1) {
+    if (varB >= 0 && varB <= 1) {
       result = result.toBuilder().onLine2(true).build();
     }
     // if line1 and line2 are segments, they intersect if both of the above are true

--- a/services-turf/src/test/java/com/mapbox/turf/TurfMiscTest.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TurfMiscTest.java
@@ -3,12 +3,15 @@ package com.mapbox.turf;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
+import com.mapbox.turf.models.LineIntersectsResult;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -489,5 +492,28 @@ public class TurfMiscTest extends TestUtils {
       start_point.coordinates());
     assertEquals(sliced.coordinates().get(sliced.coordinates().size() - 1).coordinates(),
       end_point.coordinates());
+  }
+
+  @Test
+  public void testLineIntersects() throws
+          NoSuchMethodException, SecurityException,
+          IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    Method method = TurfMisc.class.getDeclaredMethod("lineIntersects",
+      double.class, double.class, double.class, double.class,  double.class, double.class, double.class, double.class);
+    method.setAccessible(true);
+
+    LineIntersectsResult result1 = (LineIntersectsResult)method.invoke(null, 1.0, 2.0, 2.0, 3.0, 2.0, 3.0, 4.0, 2.0);
+    assertNotNull(result1);
+    assertEquals(new Double(2.0), result1.horizontalIntersection());
+    assertEquals(new Double(3.0), result1.verticalIntersection());
+    assertTrue(result1.onLine1());
+    assertTrue(result1.onLine2());
+
+    LineIntersectsResult result2 = (LineIntersectsResult)method.invoke(null, 1.0, 2.0, 2.0, 3.0, 0.0, 3.0, 1.0, 2.0);
+    assertNotNull(result2);
+    assertEquals(new Double(1.0), result2.horizontalIntersection());
+    assertEquals(new Double(2.0), result2.verticalIntersection());
+    assertTrue(result2.onLine1());
+    assertTrue(result2.onLine2());
   }
 }


### PR DESCRIPTION
## Summary
`lineIntersects` excludes line segment endpoints which is not consistent with Turf.js / Turf-Swift.

## Detail
[This](https://github.com/mapbox/mapbox-java/blob/v6.1.0/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java#L349) and [this](https://github.com/mapbox/mapbox-java/blob/v6.1.0/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java#L353) `if` conditions causes the difference. Turf.js implementation is [here](https://github.com/Turfjs/turf/blob/6bc5fbe927b85b2be8e38600b5ffb29525a6f925/packages/turf-line-intersect/index.ts#L124).


[Reference](https://github.com/mapbox/mapbox-java/pull/1348#pullrequestreview-854414293)