### PR TITLE
Need feedback about exclude waypoint parameter

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
@@ -1,6 +1,7 @@
 package com.mapbox.api.directions.v5;
 
 import androidx.annotation.StringDef;
+import com.mapbox.geojson.Point;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -415,5 +416,9 @@ public final class DirectionsCriteria {
     APPROACH_CURB
   })
   public @interface ApproachesCriteria {
+  }
+
+  public static String excludePoint(Point point) {
+    return "point(" + point.longitude() + " " + point.latitude() + ")";
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -1,14 +1,17 @@
 package com.mapbox.api.directions.v5.models;
 
 import static com.google.gson.JsonParser.parseString;
+import static org.junit.Assert.*;
+
+import java.net.MalformedURLException;
 import java.net.URL;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.core.TestUtils;
 import com.mapbox.geojson.Point;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
@@ -435,6 +438,23 @@ public class RouteOptionsTest extends TestUtils {
     URL url = options.toUrl(ACCESS_TOKEN);
 
     assertEquals(expectedEncodedUrl, url.toString());
+  }
+
+  @Test
+  public void routeOptionWithExcludedWaypoint() {
+    RouteOptions options = RouteOptions.builder()
+        .coordinates("1.0,1.0;2.0,2.0")
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .excludeList(Collections.singletonList(
+            DirectionsCriteria.excludePoint(Point.fromLngLat(1.0, 2.0))
+        ))
+        .build();
+    URL url = options.toUrl("testToken");
+    List<String> queryParameters = Arrays.asList(url.getQuery().split("&"));
+    assertTrue(
+        "url is " + url.toString(),
+        queryParameters.contains("exclude=point(1.0%202.0)")
+    );
   }
 
   /**


### PR DESCRIPTION
## Description

Direction API provides a new feature "exclude waypoint". To exclude a coordinate form your route add it to the list of `exclude` like `point(lon lat)`. For example if you want to exclude motorways and coordinate `1.0 1.0` use following exclude param: `exclude=motorway,point(1.0%201.0)`

## Please provide a feedback

You will find the most simple and straightforward implementation which I can came up with. If you don't like how it looks I can try implement it in OOP style, but I'm not sure if it's worth.