### PR TITLE
Exclude waypoints from routing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### main
 - Exposed `viaWaypoints` in `RouteLeg` [#1364](https://github.com/mapbox/mapbox-java/pull/1364)
+- Added an API for providing points to exclude. [#1362](https://github.com/mapbox/mapbox-java/pull/1362)
 
 ### v6.3.0-beta.1 - January 28, 2021
 - Exposed [turf.lineIntersect](https://turfjs.org/docs/#lineIntersect) via `TurfMisc#lineIntersect` using an algorithm with O(nm) time complexity which should suite small to medium sized geometries until a more performant solution is implemented. [#1348](https://github.com/mapbox/mapbox-java/pull/1348)

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
@@ -340,6 +340,7 @@ public final class DirectionsCriteria {
    * @since 3.0.0
    */
   @Retention(RetentionPolicy.CLASS)
+  // Please update Exclude.VALID_EXCLUDE_CRITERIA adding new type of exclude
   @StringDef( {
     EXCLUDE_FERRY,
     EXCLUDE_MOTORWAY,

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/Exclude.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/Exclude.java
@@ -133,9 +133,9 @@ public abstract class Exclude {
     }
 
     return Exclude.builder()
-        .criteria(criteria)
-        .points(points)
-        .build();
+      .criteria(criteria)
+      .points(points)
+      .build();
   }
 
   @Nullable
@@ -185,14 +185,14 @@ public abstract class Exclude {
       String latitude = point.substring(delimiter + 1, point.length() - 1);
       try {
         Point result = Point.fromLngLat(
-            Double.parseDouble(longitude),
-            Double.parseDouble(latitude)
+          Double.parseDouble(longitude),
+          Double.parseDouble(latitude)
         );
         return result;
       } catch (NumberFormatException numberFormatError) {
         throw new IllegalArgumentException(
-            pointParsingErrorMessage(point),
-            numberFormatError
+          pointParsingErrorMessage(point),
+          numberFormatError
         );
       }
     } else {
@@ -202,9 +202,9 @@ public abstract class Exclude {
 
   private void appendPoint(StringBuilder result, Point point) {
     result.append("point(")
-        .append(point.longitude())
-        .append(' ')
-        .append(point.latitude())
-        .append(')');
+      .append(point.longitude())
+      .append(' ')
+      .append(point.latitude())
+      .append(')');
   }
 }

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/Exclude.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/Exclude.java
@@ -1,0 +1,210 @@
+package com.mapbox.api.directions.v5.models;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.utils.ParseUtils;
+import com.mapbox.geojson.Point;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Defines excludes for {@link RouteOptions.Builder#excludeObject(Exclude)}.
+ */
+@AutoValue
+public abstract class Exclude {
+
+  /**
+   * Build a new instance of {@link Exclude}. Nothing is excluded by default.
+   */
+  @NonNull
+  public static Builder builder() {
+    return new AutoValue_Exclude.Builder();
+  }
+
+  /**
+   * Exclude certain road types from routing. The default is to not exclude anything from the
+   * profile selected. The following exclude flags are available for each profile:
+   * <p>
+   * {@link DirectionsCriteria#PROFILE_DRIVING}: One of {@link DirectionsCriteria#EXCLUDE_TOLL},
+   * {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or {@link DirectionsCriteria#EXCLUDE_FERRY}.
+   * <p>
+   * {@link DirectionsCriteria#PROFILE_DRIVING_TRAFFIC}: One of
+   * {@link DirectionsCriteria#EXCLUDE_TOLL}, {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or
+   * {@link DirectionsCriteria#EXCLUDE_FERRY}.
+   * <p>
+   * {@link DirectionsCriteria#PROFILE_WALKING}: No excludes supported
+   * <p>
+   * {@link DirectionsCriteria#PROFILE_CYCLING}: {@link DirectionsCriteria#EXCLUDE_FERRY}
+   *
+   * @return a list of strings matching one
+   *   of the {@link DirectionsCriteria.ExcludeCriteria} exclusions
+   */
+  @Nullable
+  public abstract List<String> criteria();
+
+  /**
+   * Exclude certain points from routing. The default is to not exclude anything.
+   *
+   * @return a list of points excluded from the routing.
+   */
+  @Nullable
+  public abstract List<Point> points();
+
+  /**
+   * Use this builder to build an {@link Exclude} object.
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    /**
+     * Exclude certain road types from routing. The default is to not exclude anything from the
+     * profile selected. The following exclude flags are available for each profile:
+     * <p>
+     * {@link DirectionsCriteria#PROFILE_DRIVING}: One of {@link DirectionsCriteria#EXCLUDE_TOLL},
+     * {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or {@link DirectionsCriteria#EXCLUDE_FERRY}.
+     * <p>
+     * {@link DirectionsCriteria#PROFILE_DRIVING_TRAFFIC}: One of
+     * {@link DirectionsCriteria#EXCLUDE_TOLL}, {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or
+     * {@link DirectionsCriteria#EXCLUDE_FERRY}.
+     * <p>
+     * {@link DirectionsCriteria#PROFILE_WALKING}: No excludes supported
+     * <p>
+     * {@link DirectionsCriteria#PROFILE_CYCLING}: {@link DirectionsCriteria#EXCLUDE_FERRY}
+     *
+     * @param criteria a list of exclude criteria
+     *   matching {@link DirectionsCriteria.ExcludeCriteria}
+     * @return this builder.
+     */
+    public abstract Builder criteria(@Nullable List<String> criteria);
+
+    /**
+     * Exclude certain points from routing. The default is to not exclude anything.
+     *
+     * @param points a list of points to exclude.
+     * @return this builder.
+     */
+    public abstract Builder points(@Nullable List<Point> points);
+
+    /**
+     * Builds the object.
+     *
+     * @return a new instance of {@link Exclude}
+     */
+    public abstract Exclude build();
+  }
+
+  @Nullable
+  static Exclude fromUrlQueryParameter(@Nullable String queryParameter) {
+    if (queryParameter == null || Objects.equals(queryParameter, "")) {
+      return null;
+    }
+
+    ArrayList<Point> points = new ArrayList<>();
+    ArrayList<String> criteria = new ArrayList<>();
+
+    List<String> excludeItems = ParseUtils.parseToStrings(queryParameter, ",");
+    if (excludeItems != null) {
+      for (String excludeItem : excludeItems) {
+        if (excludeItem.startsWith("point(") && excludeItem.endsWith(")")) {
+          Point point = parsePoint(excludeItem);
+          points.add(point);
+        } else if (excludeItem.contains("(") && excludeItem.contains(")")) {
+          // Ignoring the unexpected type of data. Update the library to get support of new types
+        } else if (excludeItem.contains("(") || excludeItem.contains(")")) {
+          throw new IllegalArgumentException("Can't parse parameter " + excludeItem);
+        } else {
+          criteria.add(excludeItem);
+        }
+      }
+    }
+
+    if (criteria.size() == 0) {
+      criteria = null;
+    }
+    if (points.size() == 0) {
+      points = null;
+    }
+    if (criteria == null && points == null) {
+      return null;
+    }
+
+    return Exclude.builder()
+        .criteria(criteria)
+        .points(points)
+        .build();
+  }
+
+  @Nullable
+  String toUrlQueryParameter() {
+    if (points() == null && criteria() == null) {
+      return null;
+    }
+
+    StringBuilder result = new StringBuilder();
+
+    appendPoints(result);
+    appendCriterias(result);
+
+    return result.toString();
+  }
+
+  private void appendCriterias(StringBuilder result) {
+    if (criteria() != null) {
+      for (String item : criteria()) {
+        if (result.length() != 0) {
+          result.append(',');
+        }
+        result.append(item);
+      }
+    }
+  }
+
+  private void appendPoints(StringBuilder result) {
+    if (points() != null) {
+      for (Point point : points()) {
+        if (result.length() != 0) {
+          result.append(",");
+        }
+        appendPoint(result, point);
+      }
+    }
+  }
+
+  private static String pointParsingErrorMessage(String point) {
+    return "Can't parse a point:" + point + ". Expected format: point(lon lat)";
+  }
+
+  private static Point parsePoint(String point) {
+    int delimiter = point.indexOf(' ');
+    if (delimiter != -1) {
+      String longitude = point.substring(6, delimiter);
+      String latitude = point.substring(delimiter + 1, point.length() - 1);
+      try {
+        Point result = Point.fromLngLat(
+            Double.parseDouble(longitude),
+            Double.parseDouble(latitude)
+        );
+        return result;
+      } catch (NumberFormatException numberFormatError) {
+        throw new IllegalArgumentException(
+            pointParsingErrorMessage(point),
+            numberFormatError
+        );
+      }
+    } else {
+      throw new IllegalArgumentException(pointParsingErrorMessage(point));
+    }
+  }
+
+  private void appendPoint(StringBuilder result, Point point) {
+    result.append("point(")
+        .append(point.longitude())
+        .append(' ')
+        .append(point.latitude())
+        .append(')');
+  }
+}

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -356,8 +356,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   }
 
   /**
-   * Exclude certain road types from routing. The default is to not exclude anything from the
-   * profile selected. The following exclude flags are available for each profile:
+   * Exclude certain road types or points from routing. The default is to not exclude anything
+   * from the profile selected. The following exclude flags are available for each profile:
    * <p>
    * {@link DirectionsCriteria#PROFILE_DRIVING}: One of {@link DirectionsCriteria#EXCLUDE_TOLL},
    * {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or {@link DirectionsCriteria#EXCLUDE_FERRY}.
@@ -370,14 +370,17 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * <p>
    * {@link DirectionsCriteria#PROFILE_CYCLING}: {@link DirectionsCriteria#EXCLUDE_FERRY}
    *
-   * @return a string matching one of the {@link DirectionsCriteria.ExcludeCriteria} exclusions
+   * Excluded points are formatted like: point(longitude latitude)
+   *
+   * @return a comma separated string where each element matches one of
+   *   the {@link DirectionsCriteria.ExcludeCriteria} exclusion or a point
    */
   @Nullable
   public abstract String exclude();
 
   /**
-   * Exclude certain road types from routing. The default is to not exclude anything from the
-   * profile selected. The following exclude flags are available for each profile:
+   * Exclude certain road types and points from routing. The default is to not exclude anything
+   * from the profile selected. The following exclude flags are available for each profile:
    * <p>
    * {@link DirectionsCriteria#PROFILE_DRIVING}: One of {@link DirectionsCriteria#EXCLUDE_TOLL},
    * {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or {@link DirectionsCriteria#EXCLUDE_FERRY}.
@@ -390,11 +393,25 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * <p>
    * {@link DirectionsCriteria#PROFILE_CYCLING}: {@link DirectionsCriteria#EXCLUDE_FERRY}
    *
-   * @return a string matching one of the {@link DirectionsCriteria.ExcludeCriteria} exclusions
+   * Excluded points are formatted like: point(longitude latitude)
+   *
+   * @return a list of strings where each element matches one of the
+   *   {@link DirectionsCriteria.ExcludeCriteria} exclusion or a point
+   * @deprecated use {@link #excludeObject()} instead
    */
   @Nullable
+  @Deprecated()
   public List<String> excludeList() {
     return ParseUtils.parseToStrings(exclude(), ",");
+  }
+
+  /**
+   * Exclude certain road types and points from routing. The default is to not exclude anything
+   * from the profile selected.
+   */
+  @Nullable
+  public Exclude excludeObject() {
+    return Exclude.fromUrlQueryParameter(exclude());
   }
 
   /**
@@ -1411,8 +1428,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     public abstract Builder voiceUnits(@Nullable String voiceUnits);
 
     /**
-     * Exclude certain road types from routing. The default is to not exclude anything from the
-     * profile selected. The following exclude flags are available for each profile:
+     * Exclude certain road types or points from routing. The default is to not exclude anything
+     * from the profile selected. The following exclude flags are available for each profile:
      * <p>
      * {@link DirectionsCriteria#PROFILE_DRIVING}: One of {@link DirectionsCriteria#EXCLUDE_TOLL},
      * {@link DirectionsCriteria#EXCLUDE_MOTORWAY}, or {@link DirectionsCriteria#EXCLUDE_FERRY}.
@@ -1425,15 +1442,17 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * <p>
      * {@link DirectionsCriteria#PROFILE_CYCLING}: {@link DirectionsCriteria#EXCLUDE_FERRY}
      *
-     * @param exclude a string matching one of the {@link DirectionsCriteria.ExcludeCriteria}
-     *                exclusions
+     * Use following format to exclude a point: point(longitude latitude)
+     *
+     * @param exclude a comma separated string. Each value matches one of
+     *   the {@link DirectionsCriteria.ExcludeCriteria} exclusions or point format.
      * @return this builder for chaining options together
      */
     @NonNull
     public abstract Builder exclude(@Nullable @DirectionsCriteria.ExcludeCriteria String exclude);
 
     /**
-     * Exclude certain road types from routing.
+     * Exclude certain road types or points from routing.
      * The default is to not exclude anything from the profile selected.
      * The following exclude flags are available for each profile:
      * <p>
@@ -1448,14 +1467,36 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      * <p>
      * {@link DirectionsCriteria#PROFILE_CYCLING}: {@link DirectionsCriteria#EXCLUDE_FERRY}
      *
+     * Use following format to exclude a point: point(longitude latitude)
+     *
      * @param exclude a list of exclude that were used during the request
      * @return this builder for chaining options together
+     * @deprecated Use {@link #excludeObject(Exclude)} instead
      */
     @NonNull
+    @Deprecated
     public Builder excludeList(@Nullable List<String> exclude) {
       String result = FormatUtils.join(",", exclude);
       if (result != null) {
         exclude(result);
+      }
+      return this;
+    }
+
+    /**
+     * Exclude certain road types or points from routing.
+     * The default is to not exclude anything from the profile selected.
+     *
+     * @param exclude an object of excludes that are used during the request.
+     *   Use {@link Exclude.Builder} to build exclude.
+     * @return this builder for chaining options together
+    */
+    @NonNull
+    public Builder excludeObject(@Nullable Exclude exclude) {
+      if (exclude != null) {
+        exclude(exclude.toUrlQueryParameter());
+      } else {
+        exclude(null);
       }
       return this;
     }

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -397,10 +397,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    *
    * @return a list of strings where each element matches one of the
    *   {@link DirectionsCriteria.ExcludeCriteria} exclusion or a point
-   * @deprecated use {@link #excludeObject()} instead
    */
   @Nullable
-  @Deprecated()
   public List<String> excludeList() {
     return ParseUtils.parseToStrings(exclude(), ",");
   }
@@ -1471,10 +1469,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
      *
      * @param exclude a list of exclude that were used during the request
      * @return this builder for chaining options together
-     * @deprecated Use {@link #excludeObject(Exclude)} instead
      */
     @NonNull
-    @Deprecated
     public Builder excludeList(@Nullable List<String> exclude) {
       String result = FormatUtils.join(",", exclude);
       if (result != null) {
@@ -1486,6 +1482,9 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     /**
      * Exclude certain road types or points from routing.
      * The default is to not exclude anything from the profile selected.
+     *
+     * Exclude object may not provide all features that are currently present by Direction API.
+     * See {@link Exclude} for more details.
      *
      * @param exclude an object of excludes that are used during the request.
      *   Use {@link Exclude.Builder} to build exclude.

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -406,6 +406,9 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   /**
    * Exclude certain road types and points from routing. The default is to not exclude anything
    * from the profile selected.
+   *
+   * Exclude object may not provide all features that are currently present by Direction API.
+   * See {@link Exclude} for more details.
    */
   @Nullable
   public Exclude excludeObject() {

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/ExcludeTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/ExcludeTest.java
@@ -10,11 +10,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-public class RouteOptionsExcludeTest {
+public class ExcludeTest {
   @Test
   public void parseTwoPointsWithTwoCriteriaMixed() {
     String excludeQueryParameter = "point(4234.23423 -8482.49523445),motorway,point(-444.0 999.111111),ferry";
+
     Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
+
     assertEquals(
         Arrays.asList(
             Point.fromLngLat(4234.23423, -8482.49523445),
@@ -46,7 +48,9 @@ public class RouteOptionsExcludeTest {
   @Test
   public void parseOnePoint() {
     String excludeQueryParameter = "point(555.5 2222.0)";
+
     Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
+
     assertEquals(
         Arrays.asList(
             Point.fromLngLat(555.5, 2222.0)
@@ -59,7 +63,9 @@ public class RouteOptionsExcludeTest {
   @Test
   public void parseOneCriteria() {
     String excludeQueryParameter = DirectionsCriteria.EXCLUDE_TUNNEL;
+
     Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
+
     assertEquals(
         Arrays.asList(
             DirectionsCriteria.EXCLUDE_TUNNEL
@@ -72,7 +78,9 @@ public class RouteOptionsExcludeTest {
   @Test
   public void parsePointWithAFewSpaces() {
     String invalidPoint = "point(3.0      4.0)";
+
     Exclude exclude = Exclude.fromUrlQueryParameter(invalidPoint);
+
     assertEquals(
         Arrays.asList(
             Point.fromLngLat(3.0, 4.0)

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/ExcludeTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/ExcludeTest.java
@@ -18,18 +18,18 @@ public class ExcludeTest {
     Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
 
     assertEquals(
-        Arrays.asList(
-            Point.fromLngLat(4234.23423, -8482.49523445),
-            Point.fromLngLat(-444.0, 999.111111)
-        ),
-        exclude.points()
+      Arrays.asList(
+        Point.fromLngLat(4234.23423, -8482.49523445),
+        Point.fromLngLat(-444.0, 999.111111)
+      ),
+      exclude.points()
     );
     assertEquals(
-        Arrays.asList(
-            DirectionsCriteria.EXCLUDE_MOTORWAY,
-            DirectionsCriteria.EXCLUDE_FERRY
-        ),
-        exclude.criteria()
+      Arrays.asList(
+        DirectionsCriteria.EXCLUDE_MOTORWAY,
+        DirectionsCriteria.EXCLUDE_FERRY
+      ),
+      exclude.criteria()
     );
   }
 
@@ -52,10 +52,10 @@ public class ExcludeTest {
     Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
 
     assertEquals(
-        Arrays.asList(
-            Point.fromLngLat(555.5, 2222.0)
-        ),
-        exclude.points()
+      Arrays.asList(
+        Point.fromLngLat(555.5, 2222.0)
+      ),
+      exclude.points()
     );
     assertNull(exclude.criteria());
   }
@@ -67,10 +67,10 @@ public class ExcludeTest {
     Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
 
     assertEquals(
-        Arrays.asList(
-            DirectionsCriteria.EXCLUDE_TUNNEL
-        ),
-        exclude.criteria()
+      Arrays.asList(
+        DirectionsCriteria.EXCLUDE_TUNNEL
+      ),
+      exclude.criteria()
     );
     assertNull(exclude.points());
   }
@@ -82,10 +82,10 @@ public class ExcludeTest {
     Exclude exclude = Exclude.fromUrlQueryParameter(invalidPoint);
 
     assertEquals(
-        Arrays.asList(
-            Point.fromLngLat(3.0, 4.0)
-        ),
-        exclude.points()
+      Arrays.asList(
+        Point.fromLngLat(3.0, 4.0)
+      ),
+      exclude.points()
     );
   }
 
@@ -110,18 +110,18 @@ public class ExcludeTest {
   @Test
   public void singleCriteriaToQueryUrl() {
     String queryParameter = Exclude.builder()
-        .criteria(Arrays.asList(DirectionsCriteria.EXCLUDE_FERRY))
-        .build()
-        .toUrlQueryParameter();
+      .criteria(Arrays.asList(DirectionsCriteria.EXCLUDE_FERRY))
+      .build()
+      .toUrlQueryParameter();
     assertEquals(DirectionsCriteria.EXCLUDE_FERRY, queryParameter);
   }
 
   @Test
   public void criteriaListToQueryUrl() {
     String queryParameter = Exclude.builder()
-        .criteria(Arrays.asList(DirectionsCriteria.EXCLUDE_FERRY, DirectionsCriteria.EXCLUDE_TOLL))
-        .build()
-        .toUrlQueryParameter();
+      .criteria(Arrays.asList(DirectionsCriteria.EXCLUDE_FERRY, DirectionsCriteria.EXCLUDE_TOLL))
+      .build()
+      .toUrlQueryParameter();
     assertEquals("ferry,toll", queryParameter);
   }
 

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/ExcludeTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/ExcludeTest.java
@@ -89,22 +89,50 @@ public class ExcludeTest {
     );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void parsePointWithTextInsteadOfNumbers() {
     String invalidPoint = "point(one two)";
-    Exclude.fromUrlQueryParameter(invalidPoint);
+    Exclude exclude = Exclude.fromUrlQueryParameter(invalidPoint);
+    assertNull(exclude);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void parsePointWithSemicolonDelimiter() {
     String invalidPoint = "point(5.0;7.0)";
-    Exclude.fromUrlQueryParameter(invalidPoint);
+    Exclude exclude = Exclude.fromUrlQueryParameter(invalidPoint);
+    assertNull(exclude);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void parsePointWithCommaDelimiter() {
     String invalidPoint = "point(5.0,7.0)";
-    Exclude.fromUrlQueryParameter(invalidPoint);
+    Exclude exclude = Exclude.fromUrlQueryParameter(invalidPoint);
+    assertNull(exclude);
+  }
+
+  @Test
+  public void parseCorrectValuesMixedWithInvalid() {
+    String invalidPoint = "point(5.0;7.0),point(8.0 -9.0),toll";
+
+    Exclude exclude = Exclude.fromUrlQueryParameter(invalidPoint);
+
+    assertNotNull(exclude);
+    assertEquals(
+      Arrays.asList(DirectionsCriteria.EXCLUDE_TOLL),
+      exclude.criteria()
+    );
+    assertEquals(
+      Arrays.asList(Point.fromLngLat(8.0, -9.0)),
+      exclude.points()
+    );
+  }
+
+  @Test
+  public void buildExcludeUsingNotSupportedCriteria() {
+    Exclude exclude = Exclude.builder()
+      .criteria(Arrays.asList("test", DirectionsCriteria.EXCLUDE_MOTORWAY))
+      .build();
+    assertEquals(2, exclude.criteria().size());
   }
 
   @Test

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsExcludeTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsExcludeTest.java
@@ -1,0 +1,133 @@
+package com.mapbox.api.directions.v5.models;
+
+import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.geojson.Point;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class RouteOptionsExcludeTest {
+  @Test
+  public void parseTwoPointsWithTwoCriteriaMixed() {
+    String excludeQueryParameter = "point(4234.23423 -8482.49523445),motorway,point(-444.0 999.111111),ferry";
+    Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
+    assertEquals(
+        Arrays.asList(
+            Point.fromLngLat(4234.23423, -8482.49523445),
+            Point.fromLngLat(-444.0, 999.111111)
+        ),
+        exclude.points()
+    );
+    assertEquals(
+        Arrays.asList(
+            DirectionsCriteria.EXCLUDE_MOTORWAY,
+            DirectionsCriteria.EXCLUDE_FERRY
+        ),
+        exclude.criteria()
+    );
+  }
+
+  @Test
+  public void parseNull() {
+    Exclude exclude = Exclude.fromUrlQueryParameter(null);
+    assertNull(exclude);
+  }
+
+  @Test
+  public void parseEmptyParameter() {
+    Exclude exclude = Exclude.fromUrlQueryParameter("");
+    assertNull(exclude);
+  }
+
+  @Test
+  public void parseOnePoint() {
+    String excludeQueryParameter = "point(555.5 2222.0)";
+    Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
+    assertEquals(
+        Arrays.asList(
+            Point.fromLngLat(555.5, 2222.0)
+        ),
+        exclude.points()
+    );
+    assertNull(exclude.criteria());
+  }
+
+  @Test
+  public void parseOneCriteria() {
+    String excludeQueryParameter = DirectionsCriteria.EXCLUDE_TUNNEL;
+    Exclude exclude = Exclude.fromUrlQueryParameter(excludeQueryParameter);
+    assertEquals(
+        Arrays.asList(
+            DirectionsCriteria.EXCLUDE_TUNNEL
+        ),
+        exclude.criteria()
+    );
+    assertNull(exclude.points());
+  }
+
+  @Test
+  public void parsePointWithAFewSpaces() {
+    String invalidPoint = "point(3.0      4.0)";
+    Exclude exclude = Exclude.fromUrlQueryParameter(invalidPoint);
+    assertEquals(
+        Arrays.asList(
+            Point.fromLngLat(3.0, 4.0)
+        ),
+        exclude.points()
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parsePointWithTextInsteadOfNumbers() {
+    String invalidPoint = "point(one two)";
+    Exclude.fromUrlQueryParameter(invalidPoint);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parsePointWithSemicolonDelimiter() {
+    String invalidPoint = "point(5.0;7.0)";
+    Exclude.fromUrlQueryParameter(invalidPoint);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parsePointWithCommaDelimiter() {
+    String invalidPoint = "point(5.0,7.0)";
+    Exclude.fromUrlQueryParameter(invalidPoint);
+  }
+
+  @Test
+  public void singleCriteriaToQueryUrl() {
+    String queryParameter = Exclude.builder()
+        .criteria(Arrays.asList(DirectionsCriteria.EXCLUDE_FERRY))
+        .build()
+        .toUrlQueryParameter();
+    assertEquals(DirectionsCriteria.EXCLUDE_FERRY, queryParameter);
+  }
+
+  @Test
+  public void criteriaListToQueryUrl() {
+    String queryParameter = Exclude.builder()
+        .criteria(Arrays.asList(DirectionsCriteria.EXCLUDE_FERRY, DirectionsCriteria.EXCLUDE_TOLL))
+        .build()
+        .toUrlQueryParameter();
+    assertEquals("ferry,toll", queryParameter);
+  }
+
+  @Test
+  public void parseUnexpectedTypeOfParameter() {
+    Exclude exclude = Exclude.fromUrlQueryParameter("new(test)");
+    assertNull(exclude);
+  }
+
+  @Test
+  public void parseUnexpectedTypeOfParameterMixedWithPointAndCriteria() {
+    Exclude exclude = Exclude.fromUrlQueryParameter("ferry,new(test),point(0.5 -0.5)");
+    assertNotNull(exclude);
+    assertEquals(1, exclude.criteria().size());
+    assertEquals(1, exclude.points().size());
+  }
+}

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -1,16 +1,25 @@
 package com.mapbox.api.directions.v5.models;
 
 import static com.google.gson.JsonParser.parseString;
-import java.net.URL;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import com.google.gson.JsonParser;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.core.TestUtils;
 import com.mapbox.geojson.Point;
+
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import org.junit.Test;
 
 public class RouteOptionsTest extends TestUtils {
@@ -18,7 +27,8 @@ public class RouteOptionsTest extends TestUtils {
    * Always update this file when new option is introduced.
    */
   private static final String ROUTE_OPTIONS_JSON = "route_options_v5.json";
-  private static final String ROUTE_OPTIONS_URL = "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835?access_token=pk.token&geometries=polyline6&alternatives=false&overview=full&radiuses=;unlimited;5.1&steps=true&avoid_maneuver_radius=200&bearings=0,90;90,0;&layers=-42;;0&continue_straight=false&annotations=congestion,distance,duration&language=ru&roundabout_exits=false&voice_instructions=true&banner_instructions=true&voice_units=metric&exclude=toll,ferry&include=hot,hov2&approaches=;curb;&waypoints=0;1;2&waypoint_names=;two;&waypoint_targets=;12.2,21.2;&enable_refresh=true&walking_speed=5.11&walkway_bias=-0.2&alley_bias=0.75&snapping_include_closures=;false;true&arrive_by=2021-01-01'T'01:01&depart_at=2021-02-02'T'02:02&max_height=1.5&max_width=1.4&metadata=true";
+  private static final String ROUTE_OPTIONS_URL =
+      "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835?access_token=pk.token&geometries=polyline6&alternatives=false&overview=full&radiuses=;unlimited;5.1&steps=true&avoid_maneuver_radius=200&bearings=0,90;90,0;&layers=-42;;0&continue_straight=false&annotations=congestion,distance,duration&language=ru&roundabout_exits=false&voice_instructions=true&banner_instructions=true&voice_units=metric&exclude=toll,ferry&include=hot,hov2&approaches=;curb;&waypoints=0;1;2&waypoint_names=;two;&waypoint_targets=;12.2,21.2;&enable_refresh=true&walking_speed=5.11&walkway_bias=-0.2&alley_bias=0.75&snapping_include_closures=;false;true&arrive_by=2021-01-01'T'01:01&depart_at=2021-02-02'T'02:02&max_height=1.5&max_width=1.4&metadata=true";
   private static final String ACCESS_TOKEN = "pk.token";
 
   private final String optionsJson = loadJsonFixture(ROUTE_OPTIONS_JSON);
@@ -52,8 +62,8 @@ public class RouteOptionsTest extends TestUtils {
     RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(
-      "-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835",
-      routeOptions.coordinates()
+        "-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835",
+        routeOptions.coordinates()
     );
   }
 
@@ -114,11 +124,10 @@ public class RouteOptionsTest extends TestUtils {
     assertEquals("-42;;0", routeOptions.layers());
   }
 
-
   @Test
   public void layersListIsValid_fromJson() {
     RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
-    
+
     List<Integer> expected = new ArrayList<Integer>();
     Collections.addAll(expected, -42, null, 0);
 
@@ -349,15 +358,16 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void routeOptionsWithDefaults_toUrl() {
-    String expectedUrl = "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
+    String expectedUrl =
+        "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions options = RouteOptions.builder()
-            .profile(DirectionsCriteria.PROFILE_DRIVING)
-            .coordinatesList(coordinates)
-            .build();
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .coordinatesList(coordinates)
+        .build();
 
     URL url = options.toUrl(ACCESS_TOKEN);
 
@@ -366,16 +376,17 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void baseUrlWithLastSlash() {
-    String expectedUrl = "https://mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
+    String expectedUrl =
+        "https://mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions options = RouteOptions.builder()
-            .baseUrl("https://mapbox.com/")
-            .profile(DirectionsCriteria.PROFILE_DRIVING)
-            .coordinatesList(coordinates)
-            .build();
+        .baseUrl("https://mapbox.com/")
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .coordinatesList(coordinates)
+        .build();
 
     URL url = options.toUrl(ACCESS_TOKEN);
 
@@ -384,16 +395,17 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void routeOptionsWithDecodedChars_toUrlWithEncodedChars() {
-    String expectedEncodedUrl = "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=my%20starting%20position;my%20destination";
+    String expectedEncodedUrl =
+        "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=my%20starting%20position;my%20destination";
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions options = RouteOptions.builder()
-      .profile(DirectionsCriteria.PROFILE_DRIVING)
-      .coordinatesList(coordinates)
-      .waypointNames("my starting position;my destination")
-      .build();
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .coordinatesList(coordinates)
+        .waypointNames("my starting position;my destination")
+        .build();
 
     URL url = options.toUrl(ACCESS_TOKEN);
 
@@ -407,10 +419,10 @@ public class RouteOptionsTest extends TestUtils {
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions expectedOptions = RouteOptions.builder()
-      .profile(DirectionsCriteria.PROFILE_DRIVING)
-      .coordinatesList(coordinates)
-      .waypointNames("my starting position;my destination")
-      .build();
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .coordinatesList(coordinates)
+        .waypointNames("my starting position;my destination")
+        .build();
 
     URL url = expectedOptions.toUrl(ACCESS_TOKEN);
 
@@ -421,20 +433,155 @@ public class RouteOptionsTest extends TestUtils {
 
   @Test
   public void routeOptionsWithUTF8Chars_toUrlWithEncodedChars() {
-    String expectedEncodedUrl = "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=;%D0%A3%D0%BB%D0%B8%D1%86%D0%B0%20%D0%AF%D0%BD%D0%B0%20%D0%A7%D0%B5%D1%87%D0%BE%D1%82%D0%B0%207,%20Minsk%20220045,%20Belarus";
+    String expectedEncodedUrl =
+        "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=;%D0%A3%D0%BB%D0%B8%D1%86%D0%B0%20%D0%AF%D0%BD%D0%B0%20%D0%A7%D0%B5%D1%87%D0%BE%D1%82%D0%B0%207,%20Minsk%20220045,%20Belarus";
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions options = RouteOptions.builder()
-      .profile(DirectionsCriteria.PROFILE_DRIVING)
-      .coordinatesList(coordinates)
-      .waypointNames(";Улица Яна Чечота 7, Minsk 220045, Belarus")
-      .build();
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .coordinatesList(coordinates)
+        .waypointNames(";Улица Яна Чечота 7, Minsk 220045, Belarus")
+        .build();
 
     URL url = options.toUrl(ACCESS_TOKEN);
 
     assertEquals(expectedEncodedUrl, url.toString());
+  }
+
+  @Test
+  public void routeOptionWithExcludedPoint() {
+    RouteOptions options = RouteOptions.builder()
+        .coordinates("1.0,1.0;2.0,2.0")
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .excludeObject(
+            Exclude.builder()
+                .points(Arrays.asList(Point.fromLngLat(1.0, 2.0)))
+                .build()
+        )
+        .build();
+    URL url = options.toUrl("testToken");
+    List<String> queryParameters = Arrays.asList(url.getQuery().split("&"));
+    assertTrue(
+        "url doesn't contain excluded point: " + url.toString(),
+        queryParameters.contains("exclude=point(1.0%202.0)")
+    );
+  }
+
+  @Test
+  public void routeOptionWithTwoExcludedPoints() {
+    RouteOptions options = RouteOptions.builder()
+        .coordinates("1.0,1.0;2.0,2.0")
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .excludeObject(
+            Exclude.builder()
+                .points(
+                    Arrays.asList(
+                        Point.fromLngLat(1.0, 2.0),
+                        Point.fromLngLat(6.03, 8.07)
+                    )
+                )
+                .build()
+        )
+        .build();
+    URL url = options.toUrl("testToken");
+    List<String> queryParameters = Arrays.asList(url.getQuery().split("&"));
+    assertTrue(
+        "url doesn't contain excluded point: " + url.toString(),
+        queryParameters.contains("exclude=point(1.0%202.0),point(6.03%208.07)")
+    );
+  }
+
+  @Test
+  public void routeOptionsWithExcludePointAndCriteriaFromUrl() throws MalformedURLException {
+    URL testUrl = new URL(
+        "https://api.mapbox.com/directions/v5/mapbox/driving-traffic/18.60289583391497,54.41121871390118;18.59400217318438,54.40983705017376.json?access_token=testToken&alternatives=true&annotations=distance%2Cduration%2Ccongestion%2Cspeed&geometries=geojson&language=en&overview=full&steps=true&exclude=point(18.595875353791087%2054.41000119108463),toll");
+    RouteOptions routeOptions = RouteOptions.fromUrl(testUrl);
+    List<Point> excludedPoints = routeOptions.excludeObject().points();
+    assertNotNull(excludedPoints);
+    assertEquals(1, excludedPoints.size());
+    Point excludedPoint = excludedPoints.get(0);
+    assertEquals(18.595875353791087, excludedPoint.longitude(), 0.001);
+    assertEquals(54.41000119108463, excludedPoint.latitude(), 0.001);
+    assertEquals(
+        Arrays.asList(DirectionsCriteria.EXCLUDE_TOLL),
+        routeOptions.excludeObject().criteria()
+    );
+  }
+
+  @Test
+  public void routeOptionsWithExcludePointToJson() {
+    RouteOptions options = RouteOptions.builder()
+        .coordinates("1.0,1.0;2.0,2.0")
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .excludeObject(
+            Exclude.builder()
+                .points(Arrays.asList(
+                    Point.fromLngLat(11.0, 22.0)
+                )
+            ).build()
+        )
+        .build();
+
+    String json = options.toJson();
+    String exclude = JsonParser.parseString(json)
+        .getAsJsonObject()
+        .get("exclude")
+        .getAsString();
+    assertEquals("point(11.0 22.0)", exclude);
+  }
+
+  @Test
+  public void routeOptionsWithMixedExcludePointsAndExcludeList() {
+    Exclude excludeObject = Exclude.builder()
+        .criteria(
+            Arrays.asList(
+                DirectionsCriteria.EXCLUDE_FERRY
+            )
+        )
+        .points(
+            Arrays.asList(
+                Point.fromLngLat(19.4567, -55.5677)
+            )
+        )
+        .build();
+    RouteOptions options = RouteOptions.builder()
+        .coordinates("1.0,1.0;2.0,2.0")
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .excludeObject(excludeObject)
+        .build();
+
+    String rawExclude = options.exclude();
+    assertTrue(
+        "exclude doesn't contain point. exclude: " + rawExclude,
+        rawExclude.contains("point(19.4567 -55.5677)")
+    );
+    assertTrue(
+        "exclude doesn't contain criteria. exclude: " + rawExclude,
+        rawExclude.contains(DirectionsCriteria.EXCLUDE_FERRY)
+    );
+    assertEquals(excludeObject, options.excludeObject());
+  }
+
+  @Test
+  public void cleanExcludes() {
+    RouteOptions routeOptions = routeOptions().toBuilder()
+        .excludeObject(null)
+        .build();
+
+    assertNull(routeOptions.exclude());
+  }
+
+  @Test
+  public void emptyExcludeObjectsCleansUpExcludes() {
+    RouteOptions routeOptions = routeOptions().toBuilder()
+        .excludeObject(
+            Exclude.builder().build()
+        )
+        .build();
+
+    assertNull(routeOptions.exclude());
   }
 
   /**
@@ -495,83 +642,83 @@ public class RouteOptionsTest extends TestUtils {
     coordinates.add(Point.fromLngLat(-122.4255172, 37.7775835));
 
     return RouteOptions.builder()
-      .baseUrl("https://api.mapbox.com")
-      .profile(DirectionsCriteria.PROFILE_DRIVING)
-      .coordinatesList(coordinates)
-      .alternatives(false)
-      .annotationsList(new ArrayList<String>() {{
-        add("congestion");
-        add("distance");
-        add("duration");
-      }})
-      .bearingsList(new ArrayList<Bearing>() {{
-        add(Bearing.builder().angle(0.0).degrees(90.0).build());
-        add(Bearing.builder().angle(90.0).degrees(0.0).build());
-        add(null);
-      }})
-      .avoidManeuverRadius(200)
-      .layersList(new ArrayList<Integer>() {{
-        add(-42);
-        add(null);
-        add(0);
-      }})
-      .continueStraight(false)
-      .excludeList(new ArrayList<String>() {{
+        .baseUrl("https://api.mapbox.com")
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .coordinatesList(coordinates)
+        .alternatives(false)
+        .annotationsList(new ArrayList<String>() {{
+          add("congestion");
+          add("distance");
+          add("duration");
+        }})
+        .bearingsList(new ArrayList<Bearing>() {{
+          add(Bearing.builder().angle(0.0).degrees(90.0).build());
+          add(Bearing.builder().angle(90.0).degrees(0.0).build());
+          add(null);
+        }})
+        .avoidManeuverRadius(200)
+        .layersList(new ArrayList<Integer>() {{
+          add(-42);
+          add(null);
+          add(0);
+        }})
+        .continueStraight(false)
+        .excludeList(new ArrayList<String>() {{
           add(DirectionsCriteria.EXCLUDE_TOLL);
           add(DirectionsCriteria.EXCLUDE_FERRY);
-      }})
-      .includeList(new ArrayList<String>() {{
+        }})
+        .includeList(new ArrayList<String>() {{
           add(DirectionsCriteria.INCLUDE_HOT);
           add(DirectionsCriteria.INCLUDE_HOV2);
-      }})
-      .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
-      .overview(DirectionsCriteria.OVERVIEW_FULL)
-      .radiusesList(new ArrayList<Double>() {{
-        add(null);
-        add(Double.POSITIVE_INFINITY);
-        add(5.1);
-      }})
-      .approachesList(new ArrayList<String>() {{
-        add(null);
-        add("curb");
-        add(null);
-      }})
-      .steps(true)
-      .bannerInstructions(true)
-      .language("ru")
-      .roundaboutExits(false)
-      .voiceInstructions(true)
-      .voiceUnits(DirectionsCriteria.METRIC)
-      .waypointNamesList(new ArrayList<String>() {{
-        add(null);
-        add("two");
-        add(null);
-      }})
-      .waypointTargetsList(new ArrayList<Point>() {{
-        add(null);
-        add(Point.fromLngLat(12.2, 21.2));
-        add(null);
-      }})
-      .waypointIndicesList(new ArrayList<Integer>() {{
-        add(0);
-        add(1);
-        add(2);
-      }})
-      .alleyBias(0.75)
-      .walkingSpeed(5.11)
-      .walkwayBias(-0.2)
-      .arriveBy("2021-01-01'T'01:01")
-      .departAt("2021-02-02'T'02:02")
-      .maxHeight(1.5)
-      .maxWidth(1.4)
-      .snappingIncludeClosuresList(new ArrayList<Boolean>() {{
-        add(null);
-        add(false);
-        add(true);
-      }})
-      .user(DirectionsCriteria.PROFILE_DEFAULT_USER)
-      .enableRefresh(true)
-      .metadata(true)
-      .build();
+        }})
+        .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
+        .overview(DirectionsCriteria.OVERVIEW_FULL)
+        .radiusesList(new ArrayList<Double>() {{
+          add(null);
+          add(Double.POSITIVE_INFINITY);
+          add(5.1);
+        }})
+        .approachesList(new ArrayList<String>() {{
+          add(null);
+          add("curb");
+          add(null);
+        }})
+        .steps(true)
+        .bannerInstructions(true)
+        .language("ru")
+        .roundaboutExits(false)
+        .voiceInstructions(true)
+        .voiceUnits(DirectionsCriteria.METRIC)
+        .waypointNamesList(new ArrayList<String>() {{
+          add(null);
+          add("two");
+          add(null);
+        }})
+        .waypointTargetsList(new ArrayList<Point>() {{
+          add(null);
+          add(Point.fromLngLat(12.2, 21.2));
+          add(null);
+        }})
+        .waypointIndicesList(new ArrayList<Integer>() {{
+          add(0);
+          add(1);
+          add(2);
+        }})
+        .alleyBias(0.75)
+        .walkingSpeed(5.11)
+        .walkwayBias(-0.2)
+        .arriveBy("2021-01-01'T'01:01")
+        .departAt("2021-02-02'T'02:02")
+        .maxHeight(1.5)
+        .maxWidth(1.4)
+        .snappingIncludeClosuresList(new ArrayList<Boolean>() {{
+          add(null);
+          add(false);
+          add(true);
+        }})
+        .user(DirectionsCriteria.PROFILE_DEFAULT_USER)
+        .enableRefresh(true)
+        .metadata(true)
+        .build();
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -28,7 +28,7 @@ public class RouteOptionsTest extends TestUtils {
    */
   private static final String ROUTE_OPTIONS_JSON = "route_options_v5.json";
   private static final String ROUTE_OPTIONS_URL =
-      "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835?access_token=pk.token&geometries=polyline6&alternatives=false&overview=full&radiuses=;unlimited;5.1&steps=true&avoid_maneuver_radius=200&bearings=0,90;90,0;&layers=-42;;0&continue_straight=false&annotations=congestion,distance,duration&language=ru&roundabout_exits=false&voice_instructions=true&banner_instructions=true&voice_units=metric&exclude=toll,ferry&include=hot,hov2&approaches=;curb;&waypoints=0;1;2&waypoint_names=;two;&waypoint_targets=;12.2,21.2;&enable_refresh=true&walking_speed=5.11&walkway_bias=-0.2&alley_bias=0.75&snapping_include_closures=;false;true&arrive_by=2021-01-01'T'01:01&depart_at=2021-02-02'T'02:02&max_height=1.5&max_width=1.4&metadata=true";
+      "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835?access_token=pk.token&geometries=polyline6&alternatives=false&overview=full&radiuses=;unlimited;5.1&steps=true&avoid_maneuver_radius=200&bearings=0,90;90,0;&layers=-42;;0&continue_straight=false&annotations=congestion,distance,duration&language=ru&roundabout_exits=false&voice_instructions=true&banner_instructions=true&voice_units=metric&exclude=toll,ferry,point(11.0%20-22.0)&include=hot,hov2&approaches=;curb;&waypoints=0;1;2&waypoint_names=;two;&waypoint_targets=;12.2,21.2;&enable_refresh=true&walking_speed=5.11&walkway_bias=-0.2&alley_bias=0.75&snapping_include_closures=;false;true&arrive_by=2021-01-01'T'01:01&depart_at=2021-02-02'T'02:02&max_height=1.5&max_width=1.4&metadata=true";
   private static final String ACCESS_TOKEN = "pk.token";
 
   private final String optionsJson = loadJsonFixture(ROUTE_OPTIONS_JSON);
@@ -180,7 +180,7 @@ public class RouteOptionsTest extends TestUtils {
   public void excludeIsValid_fromJson() {
     RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
-    assertEquals("toll,ferry", routeOptions.exclude());
+    assertEquals("toll,ferry,point(11.0 -22.0)", routeOptions.exclude());
   }
 
   @Test
@@ -611,7 +611,7 @@ public class RouteOptionsTest extends TestUtils {
       .avoidManeuverRadius(200)
       .layers("-42;;0")
       .continueStraight(false)
-      .exclude(DirectionsCriteria.EXCLUDE_TOLL + "," + DirectionsCriteria.EXCLUDE_FERRY)
+      .exclude(DirectionsCriteria.EXCLUDE_TOLL + "," + DirectionsCriteria.EXCLUDE_FERRY + ",point(11.0 -22.0)")
       .include(DirectionsCriteria.INCLUDE_HOT + "," + DirectionsCriteria.INCLUDE_HOV2)
       .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
       .overview(DirectionsCriteria.OVERVIEW_FULL)
@@ -674,6 +674,7 @@ public class RouteOptionsTest extends TestUtils {
         .excludeList(new ArrayList<String>() {{
           add(DirectionsCriteria.EXCLUDE_TOLL);
           add(DirectionsCriteria.EXCLUDE_FERRY);
+          add("point(11.0 -22.0)");
         }})
         .includeList(new ArrayList<String>() {{
           add(DirectionsCriteria.INCLUDE_HOT);

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -461,7 +461,9 @@ public class RouteOptionsTest extends TestUtils {
                 .build()
         )
         .build();
+
     URL url = options.toUrl("testToken");
+
     List<String> queryParameters = Arrays.asList(url.getQuery().split("&"));
     assertTrue(
         "url doesn't contain excluded point: " + url.toString(),
@@ -485,7 +487,9 @@ public class RouteOptionsTest extends TestUtils {
                 .build()
         )
         .build();
+
     URL url = options.toUrl("testToken");
+
     List<String> queryParameters = Arrays.asList(url.getQuery().split("&"));
     assertTrue(
         "url doesn't contain excluded point: " + url.toString(),
@@ -497,7 +501,9 @@ public class RouteOptionsTest extends TestUtils {
   public void routeOptionsWithExcludePointAndCriteriaFromUrl() throws MalformedURLException {
     URL testUrl = new URL(
         "https://api.mapbox.com/directions/v5/mapbox/driving-traffic/18.60289583391497,54.41121871390118;18.59400217318438,54.40983705017376.json?access_token=testToken&alternatives=true&annotations=distance%2Cduration%2Ccongestion%2Cspeed&geometries=geojson&language=en&overview=full&steps=true&exclude=point(18.595875353791087%2054.41000119108463),toll");
+
     RouteOptions routeOptions = RouteOptions.fromUrl(testUrl);
+
     List<Point> excludedPoints = routeOptions.excludeObject().points();
     assertNotNull(excludedPoints);
     assertEquals(1, excludedPoints.size());
@@ -525,6 +531,7 @@ public class RouteOptionsTest extends TestUtils {
         .build();
 
     String json = options.toJson();
+
     String exclude = JsonParser.parseString(json)
         .getAsJsonObject()
         .get("exclude")
@@ -553,6 +560,7 @@ public class RouteOptionsTest extends TestUtils {
         .build();
 
     String rawExclude = options.exclude();
+
     assertTrue(
         "exclude doesn't contain point. exclude: " + rawExclude,
         rawExclude.contains("point(19.4567 -55.5677)")

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -28,7 +28,7 @@ public class RouteOptionsTest extends TestUtils {
    */
   private static final String ROUTE_OPTIONS_JSON = "route_options_v5.json";
   private static final String ROUTE_OPTIONS_URL =
-      "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835?access_token=pk.token&geometries=polyline6&alternatives=false&overview=full&radiuses=;unlimited;5.1&steps=true&avoid_maneuver_radius=200&bearings=0,90;90,0;&layers=-42;;0&continue_straight=false&annotations=congestion,distance,duration&language=ru&roundabout_exits=false&voice_instructions=true&banner_instructions=true&voice_units=metric&exclude=toll,ferry,point(11.0%20-22.0)&include=hot,hov2&approaches=;curb;&waypoints=0;1;2&waypoint_names=;two;&waypoint_targets=;12.2,21.2;&enable_refresh=true&walking_speed=5.11&walkway_bias=-0.2&alley_bias=0.75&snapping_include_closures=;false;true&arrive_by=2021-01-01'T'01:01&depart_at=2021-02-02'T'02:02&max_height=1.5&max_width=1.4&metadata=true";
+    "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835?access_token=pk.token&geometries=polyline6&alternatives=false&overview=full&radiuses=;unlimited;5.1&steps=true&avoid_maneuver_radius=200&bearings=0,90;90,0;&layers=-42;;0&continue_straight=false&annotations=congestion,distance,duration&language=ru&roundabout_exits=false&voice_instructions=true&banner_instructions=true&voice_units=metric&exclude=toll,ferry,point(11.0%20-22.0)&include=hot,hov2&approaches=;curb;&waypoints=0;1;2&waypoint_names=;two;&waypoint_targets=;12.2,21.2;&enable_refresh=true&walking_speed=5.11&walkway_bias=-0.2&alley_bias=0.75&snapping_include_closures=;false;true&arrive_by=2021-01-01'T'01:01&depart_at=2021-02-02'T'02:02&max_height=1.5&max_width=1.4&metadata=true";
   private static final String ACCESS_TOKEN = "pk.token";
 
   private final String optionsJson = loadJsonFixture(ROUTE_OPTIONS_JSON);
@@ -62,8 +62,8 @@ public class RouteOptionsTest extends TestUtils {
     RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
 
     assertEquals(
-        "-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835",
-        routeOptions.coordinates()
+      "-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835",
+      routeOptions.coordinates()
     );
   }
 
@@ -359,15 +359,15 @@ public class RouteOptionsTest extends TestUtils {
   @Test
   public void routeOptionsWithDefaults_toUrl() {
     String expectedUrl =
-        "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
+      "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions options = RouteOptions.builder()
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .coordinatesList(coordinates)
-        .build();
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .build();
 
     URL url = options.toUrl(ACCESS_TOKEN);
 
@@ -377,16 +377,16 @@ public class RouteOptionsTest extends TestUtils {
   @Test
   public void baseUrlWithLastSlash() {
     String expectedUrl =
-        "https://mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
+      "https://mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions options = RouteOptions.builder()
-        .baseUrl("https://mapbox.com/")
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .coordinatesList(coordinates)
-        .build();
+      .baseUrl("https://mapbox.com/")
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .build();
 
     URL url = options.toUrl(ACCESS_TOKEN);
 
@@ -396,16 +396,16 @@ public class RouteOptionsTest extends TestUtils {
   @Test
   public void routeOptionsWithDecodedChars_toUrlWithEncodedChars() {
     String expectedEncodedUrl =
-        "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=my%20starting%20position;my%20destination";
+      "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=my%20starting%20position;my%20destination";
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions options = RouteOptions.builder()
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .coordinatesList(coordinates)
-        .waypointNames("my starting position;my destination")
-        .build();
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .waypointNames("my starting position;my destination")
+      .build();
 
     URL url = options.toUrl(ACCESS_TOKEN);
 
@@ -419,10 +419,10 @@ public class RouteOptionsTest extends TestUtils {
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions expectedOptions = RouteOptions.builder()
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .coordinatesList(coordinates)
-        .waypointNames("my starting position;my destination")
-        .build();
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .waypointNames("my starting position;my destination")
+      .build();
 
     URL url = expectedOptions.toUrl(ACCESS_TOKEN);
 
@@ -434,16 +434,16 @@ public class RouteOptionsTest extends TestUtils {
   @Test
   public void routeOptionsWithUTF8Chars_toUrlWithEncodedChars() {
     String expectedEncodedUrl =
-        "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=;%D0%A3%D0%BB%D0%B8%D1%86%D0%B0%20%D0%AF%D0%BD%D0%B0%20%D0%A7%D0%B5%D1%87%D0%BE%D1%82%D0%B0%207,%20Minsk%20220045,%20Belarus";
+      "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6&waypoint_names=;%D0%A3%D0%BB%D0%B8%D1%86%D0%B0%20%D0%AF%D0%BD%D0%B0%20%D0%A7%D0%B5%D1%87%D0%BE%D1%82%D0%B0%207,%20Minsk%20220045,%20Belarus";
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
     coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
 
     RouteOptions options = RouteOptions.builder()
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .coordinatesList(coordinates)
-        .waypointNames(";Улица Яна Чечота 7, Minsk 220045, Belarus")
-        .build();
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .waypointNames(";Улица Яна Чечота 7, Minsk 220045, Belarus")
+      .build();
 
     URL url = options.toUrl(ACCESS_TOKEN);
 
@@ -453,54 +453,54 @@ public class RouteOptionsTest extends TestUtils {
   @Test
   public void routeOptionWithExcludedPoint() {
     RouteOptions options = RouteOptions.builder()
-        .coordinates("1.0,1.0;2.0,2.0")
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .excludeObject(
-            Exclude.builder()
-                .points(Arrays.asList(Point.fromLngLat(1.0, 2.0)))
-                .build()
-        )
-        .build();
+      .coordinates("1.0,1.0;2.0,2.0")
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .excludeObject(
+        Exclude.builder()
+          .points(Arrays.asList(Point.fromLngLat(1.0, 2.0)))
+          .build()
+      )
+      .build();
 
     URL url = options.toUrl("testToken");
 
     List<String> queryParameters = Arrays.asList(url.getQuery().split("&"));
     assertTrue(
-        "url doesn't contain excluded point: " + url.toString(),
-        queryParameters.contains("exclude=point(1.0%202.0)")
+      "url doesn't contain excluded point: " + url.toString(),
+      queryParameters.contains("exclude=point(1.0%202.0)")
     );
   }
 
   @Test
   public void routeOptionWithTwoExcludedPoints() {
     RouteOptions options = RouteOptions.builder()
-        .coordinates("1.0,1.0;2.0,2.0")
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .excludeObject(
-            Exclude.builder()
-                .points(
-                    Arrays.asList(
-                        Point.fromLngLat(1.0, 2.0),
-                        Point.fromLngLat(6.03, 8.07)
-                    )
-                )
-                .build()
-        )
-        .build();
+      .coordinates("1.0,1.0;2.0,2.0")
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .excludeObject(
+        Exclude.builder()
+          .points(
+            Arrays.asList(
+              Point.fromLngLat(1.0, 2.0),
+              Point.fromLngLat(6.03, 8.07)
+            )
+          )
+          .build()
+      )
+      .build();
 
     URL url = options.toUrl("testToken");
 
     List<String> queryParameters = Arrays.asList(url.getQuery().split("&"));
     assertTrue(
-        "url doesn't contain excluded point: " + url.toString(),
-        queryParameters.contains("exclude=point(1.0%202.0),point(6.03%208.07)")
+      "url doesn't contain excluded point: " + url.toString(),
+      queryParameters.contains("exclude=point(1.0%202.0),point(6.03%208.07)")
     );
   }
 
   @Test
   public void routeOptionsWithExcludePointAndCriteriaFromUrl() throws MalformedURLException {
     URL testUrl = new URL(
-        "https://api.mapbox.com/directions/v5/mapbox/driving-traffic/18.60289583391497,54.41121871390118;18.59400217318438,54.40983705017376.json?access_token=testToken&alternatives=true&annotations=distance%2Cduration%2Ccongestion%2Cspeed&geometries=geojson&language=en&overview=full&steps=true&exclude=point(18.595875353791087%2054.41000119108463),toll");
+      "https://api.mapbox.com/directions/v5/mapbox/driving-traffic/18.60289583391497,54.41121871390118;18.59400217318438,54.40983705017376.json?access_token=testToken&alternatives=true&annotations=distance%2Cduration%2Ccongestion%2Cspeed&geometries=geojson&language=en&overview=full&steps=true&exclude=point(18.595875353791087%2054.41000119108463),toll");
 
     RouteOptions routeOptions = RouteOptions.fromUrl(testUrl);
 
@@ -511,63 +511,63 @@ public class RouteOptionsTest extends TestUtils {
     assertEquals(18.595875353791087, excludedPoint.longitude(), 0.001);
     assertEquals(54.41000119108463, excludedPoint.latitude(), 0.001);
     assertEquals(
-        Arrays.asList(DirectionsCriteria.EXCLUDE_TOLL),
-        routeOptions.excludeObject().criteria()
+      Arrays.asList(DirectionsCriteria.EXCLUDE_TOLL),
+      routeOptions.excludeObject().criteria()
     );
   }
 
   @Test
   public void routeOptionsWithExcludePointToJson() {
     RouteOptions options = RouteOptions.builder()
-        .coordinates("1.0,1.0;2.0,2.0")
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .excludeObject(
-            Exclude.builder()
-                .points(Arrays.asList(
-                    Point.fromLngLat(11.0, 22.0)
-                )
-            ).build()
-        )
-        .build();
+      .coordinates("1.0,1.0;2.0,2.0")
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .excludeObject(
+        Exclude.builder()
+          .points(Arrays.asList(
+            Point.fromLngLat(11.0, 22.0)
+            )
+          ).build()
+      )
+      .build();
 
     String json = options.toJson();
 
     String exclude = JsonParser.parseString(json)
-        .getAsJsonObject()
-        .get("exclude")
-        .getAsString();
+      .getAsJsonObject()
+      .get("exclude")
+      .getAsString();
     assertEquals("point(11.0 22.0)", exclude);
   }
 
   @Test
   public void routeOptionsWithMixedExcludePointsAndExcludeList() {
     Exclude excludeObject = Exclude.builder()
-        .criteria(
-            Arrays.asList(
-                DirectionsCriteria.EXCLUDE_FERRY
-            )
+      .criteria(
+        Arrays.asList(
+          DirectionsCriteria.EXCLUDE_FERRY
         )
-        .points(
-            Arrays.asList(
-                Point.fromLngLat(19.4567, -55.5677)
-            )
+      )
+      .points(
+        Arrays.asList(
+          Point.fromLngLat(19.4567, -55.5677)
         )
-        .build();
+      )
+      .build();
     RouteOptions options = RouteOptions.builder()
-        .coordinates("1.0,1.0;2.0,2.0")
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .excludeObject(excludeObject)
-        .build();
+      .coordinates("1.0,1.0;2.0,2.0")
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .excludeObject(excludeObject)
+      .build();
 
     String rawExclude = options.exclude();
 
     assertTrue(
-        "exclude doesn't contain point. exclude: " + rawExclude,
-        rawExclude.contains("point(19.4567 -55.5677)")
+      "exclude doesn't contain point. exclude: " + rawExclude,
+      rawExclude.contains("point(19.4567 -55.5677)")
     );
     assertTrue(
-        "exclude doesn't contain criteria. exclude: " + rawExclude,
-        rawExclude.contains(DirectionsCriteria.EXCLUDE_FERRY)
+      "exclude doesn't contain criteria. exclude: " + rawExclude,
+      rawExclude.contains(DirectionsCriteria.EXCLUDE_FERRY)
     );
     assertEquals(excludeObject, options.excludeObject());
   }
@@ -575,8 +575,8 @@ public class RouteOptionsTest extends TestUtils {
   @Test
   public void cleanExcludes() {
     RouteOptions routeOptions = routeOptions().toBuilder()
-        .excludeObject(null)
-        .build();
+      .excludeObject(null)
+      .build();
 
     assertNull(routeOptions.exclude());
   }
@@ -584,10 +584,10 @@ public class RouteOptionsTest extends TestUtils {
   @Test
   public void emptyExcludeObjectsCleansUpExcludes() {
     RouteOptions routeOptions = routeOptions().toBuilder()
-        .excludeObject(
-            Exclude.builder().build()
-        )
-        .build();
+      .excludeObject(
+        Exclude.builder().build()
+      )
+      .build();
 
     assertNull(routeOptions.exclude());
   }
@@ -650,84 +650,84 @@ public class RouteOptionsTest extends TestUtils {
     coordinates.add(Point.fromLngLat(-122.4255172, 37.7775835));
 
     return RouteOptions.builder()
-        .baseUrl("https://api.mapbox.com")
-        .profile(DirectionsCriteria.PROFILE_DRIVING)
-        .coordinatesList(coordinates)
-        .alternatives(false)
-        .annotationsList(new ArrayList<String>() {{
-          add("congestion");
-          add("distance");
-          add("duration");
-        }})
-        .bearingsList(new ArrayList<Bearing>() {{
-          add(Bearing.builder().angle(0.0).degrees(90.0).build());
-          add(Bearing.builder().angle(90.0).degrees(0.0).build());
-          add(null);
-        }})
-        .avoidManeuverRadius(200)
-        .layersList(new ArrayList<Integer>() {{
-          add(-42);
-          add(null);
-          add(0);
-        }})
-        .continueStraight(false)
-        .excludeList(new ArrayList<String>() {{
-          add(DirectionsCriteria.EXCLUDE_TOLL);
-          add(DirectionsCriteria.EXCLUDE_FERRY);
-          add("point(11.0 -22.0)");
-        }})
-        .includeList(new ArrayList<String>() {{
-          add(DirectionsCriteria.INCLUDE_HOT);
-          add(DirectionsCriteria.INCLUDE_HOV2);
-        }})
-        .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
-        .overview(DirectionsCriteria.OVERVIEW_FULL)
-        .radiusesList(new ArrayList<Double>() {{
-          add(null);
-          add(Double.POSITIVE_INFINITY);
-          add(5.1);
-        }})
-        .approachesList(new ArrayList<String>() {{
-          add(null);
-          add("curb");
-          add(null);
-        }})
-        .steps(true)
-        .bannerInstructions(true)
-        .language("ru")
-        .roundaboutExits(false)
-        .voiceInstructions(true)
-        .voiceUnits(DirectionsCriteria.METRIC)
-        .waypointNamesList(new ArrayList<String>() {{
-          add(null);
-          add("two");
-          add(null);
-        }})
-        .waypointTargetsList(new ArrayList<Point>() {{
-          add(null);
-          add(Point.fromLngLat(12.2, 21.2));
-          add(null);
-        }})
-        .waypointIndicesList(new ArrayList<Integer>() {{
-          add(0);
-          add(1);
-          add(2);
-        }})
-        .alleyBias(0.75)
-        .walkingSpeed(5.11)
-        .walkwayBias(-0.2)
-        .arriveBy("2021-01-01'T'01:01")
-        .departAt("2021-02-02'T'02:02")
-        .maxHeight(1.5)
-        .maxWidth(1.4)
-        .snappingIncludeClosuresList(new ArrayList<Boolean>() {{
-          add(null);
-          add(false);
-          add(true);
-        }})
-        .user(DirectionsCriteria.PROFILE_DEFAULT_USER)
-        .enableRefresh(true)
-        .metadata(true)
-        .build();
+      .baseUrl("https://api.mapbox.com")
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .alternatives(false)
+      .annotationsList(new ArrayList<String>() {{
+        add("congestion");
+        add("distance");
+        add("duration");
+      }})
+      .bearingsList(new ArrayList<Bearing>() {{
+        add(Bearing.builder().angle(0.0).degrees(90.0).build());
+        add(Bearing.builder().angle(90.0).degrees(0.0).build());
+        add(null);
+      }})
+      .avoidManeuverRadius(200)
+      .layersList(new ArrayList<Integer>() {{
+        add(-42);
+        add(null);
+        add(0);
+      }})
+      .continueStraight(false)
+      .excludeList(new ArrayList<String>() {{
+        add(DirectionsCriteria.EXCLUDE_TOLL);
+        add(DirectionsCriteria.EXCLUDE_FERRY);
+        add("point(11.0 -22.0)");
+      }})
+      .includeList(new ArrayList<String>() {{
+        add(DirectionsCriteria.INCLUDE_HOT);
+        add(DirectionsCriteria.INCLUDE_HOV2);
+      }})
+      .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
+      .overview(DirectionsCriteria.OVERVIEW_FULL)
+      .radiusesList(new ArrayList<Double>() {{
+        add(null);
+        add(Double.POSITIVE_INFINITY);
+        add(5.1);
+      }})
+      .approachesList(new ArrayList<String>() {{
+        add(null);
+        add("curb");
+        add(null);
+      }})
+      .steps(true)
+      .bannerInstructions(true)
+      .language("ru")
+      .roundaboutExits(false)
+      .voiceInstructions(true)
+      .voiceUnits(DirectionsCriteria.METRIC)
+      .waypointNamesList(new ArrayList<String>() {{
+        add(null);
+        add("two");
+        add(null);
+      }})
+      .waypointTargetsList(new ArrayList<Point>() {{
+        add(null);
+        add(Point.fromLngLat(12.2, 21.2));
+        add(null);
+      }})
+      .waypointIndicesList(new ArrayList<Integer>() {{
+        add(0);
+        add(1);
+        add(2);
+      }})
+      .alleyBias(0.75)
+      .walkingSpeed(5.11)
+      .walkwayBias(-0.2)
+      .arriveBy("2021-01-01'T'01:01")
+      .departAt("2021-02-02'T'02:02")
+      .maxHeight(1.5)
+      .maxWidth(1.4)
+      .snappingIncludeClosuresList(new ArrayList<Boolean>() {{
+        add(null);
+        add(false);
+        add(true);
+      }})
+      .user(DirectionsCriteria.PROFILE_DEFAULT_USER)
+      .enableRefresh(true)
+      .metadata(true)
+      .build();
   }
 }

--- a/services-directions-models/src/test/resources/route_options_v5.json
+++ b/services-directions-models/src/test/resources/route_options_v5.json
@@ -15,7 +15,7 @@
   "overview": "full",
   "steps": true,
   "annotations": "congestion,distance,duration",
-  "exclude": "toll,ferry",
+  "exclude": "toll,ferry,point(11.0 -22.0)",
   "include": "hot,hov2",
   "voice_instructions": true,
   "banner_instructions": true,


### PR DESCRIPTION
## Description

Direction API provides a new feature "exclude waypoint". To exclude a coordinate form your route add it to the list of `exclude` like `point(lon lat)`. For example if you want to exclude motorways and coordinate `1.0 1.0` use following exclude param: `exclude=motorway,point(1.0%201.0)`

You're reviewing a second iteration of the exclude waypoints implementation. First iteration is #1361.

