### PR TITLE
handle custom port number in RouteOptions#fromUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ### main
+- Fixed an issue where `RouteOptions#fromUrl` didn't deserialize the port number. [#1382](https://github.com/mapbox/mapbox-java/pull/1382)
 
 ### v6.4.0-beta.2 - March 10, 2022
 - :warning: Fixed an issue where `RouteOptions#avoidManeuverRadius` field was represented as integer instead of double. This change is breaking but necessary to correctly represent the Directions API structure. [#1376](https://github.com/mapbox/mapbox-java/pull/1376)

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -871,7 +871,12 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   public static RouteOptions fromUrl(@NonNull URL url) {
     JsonObject optionsJson = new JsonObject();
 
-    optionsJson.addProperty("baseUrl", url.getProtocol() + "://" + url.getHost());
+    String baseUrl = url.getProtocol() + "://" + url.getHost();
+    int port = url.getPort();
+    if (port != -1) {
+      baseUrl +=  ":" + port;
+    }
+    optionsJson.addProperty("baseUrl", baseUrl);
 
     try {
       String[] pathElements = url.getPath().split("/");

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -376,6 +376,27 @@ public class RouteOptionsTest extends TestUtils {
   }
 
   @Test
+  public void routeOptionsWithPort_roundtripping() {
+    String expectedUrl =
+      "https://api.mapbox.com:12345/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";
+    List<Point> coordinates = new ArrayList<>();
+    coordinates.add(Point.fromLngLat(-122.4003312, 37.7736941));
+    coordinates.add(Point.fromLngLat(-122.4187529, 37.7689715));
+
+    RouteOptions options = RouteOptions.builder()
+      .baseUrl("https://api.mapbox.com:12345")
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .coordinatesList(coordinates)
+      .build();
+
+    URL url = options.toUrl(ACCESS_TOKEN);
+    assertEquals(expectedUrl, url.toString());
+
+    RouteOptions recreatedOptions = RouteOptions.fromUrl(url);
+    assertEquals(options, recreatedOptions);
+  }
+
+  @Test
   public void baseUrlWithLastSlash() {
     String expectedUrl =
       "https://mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715?access_token=pk.token&geometries=polyline6";


### PR DESCRIPTION
Ensures that port number is deserialized from URL.