### PR TITLE
6.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ### main
+
+### v6.8.0 - September 29, 2022
 - Replaced `TurfSimplify#simplify` with `TurfTransformation#simplify`. [#1496](https://github.com/mapbox/mapbox-java/pull/1496)
 - Deprecated `PolylineUtils#simplify` in favour of `TurfTransformation#simplify`. [#1496](https://github.com/mapbox/mapbox-java/pull/1496)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:6.8.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:6.9.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
### v6.8.0 - September 29, 2022
 - Replaced `TurfSimplify#simplify` with `TurfTransformation#simplify`. [#1496](https://github.com/mapbox/mapbox-java/pull/1496)
 - Deprecated `PolylineUtils#simplify` in favour of `TurfTransformation#simplify`. [#1496](https://github.com/mapbox/mapbox-java/pull/1496)