### PR TITLE
NAVSDK-757: add TurfMisc#lineSliceAlong overload that accepts cached distances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### main
 - Specified supported amenity types via `DirectionsCriteria#AmenityTypeCriteria`. [#1515](https://github.com/mapbox/mapbox-java/pull/1515)
+- Added `TurfMisc#lineSliceAlong(LineString, List<DistanceProvider>, double, double, String)` to let the user provide their own list of distances between the coordinates instead of calculating them on the fly. [#1519](https://github.com/mapbox/mapbox-java/pull/1519)
 
 ### v6.10.0-beta.2 - November 11, 2022
 - Added `paymentMethods` parameter for `RouteOptions` and `IntersectionLanes`. [#1449](https://github.com/mapbox/mapbox-java/pull/1449)

--- a/services-turf/src/main/java/com/mapbox/turf/DistanceProvider.java
+++ b/services-turf/src/main/java/com/mapbox/turf/DistanceProvider.java
@@ -1,0 +1,19 @@
+package com.mapbox.turf;
+
+import com.mapbox.geojson.LineString;
+
+import java.util.List;
+
+/**
+ * An interface for lazy distance calculation
+ * used in {@link TurfMisc#lineSliceAlong(LineString, List, double, double, String)}.
+ */
+public interface DistanceProvider {
+
+  /**
+   * Invoked when the distance should be calculated.
+   *
+   * @return distance
+   */
+  double get();
+}

--- a/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java
@@ -127,13 +127,18 @@ public final class TurfMeasurement {
    */
   public static double distance(@NonNull Point point1, @NonNull Point point2,
                                 @NonNull @TurfConstants.TurfUnitCriteria String units) {
-    double difLat = degreesToRadians((point2.latitude() - point1.latitude()));
-    double difLon = degreesToRadians((point2.longitude() - point1.longitude()));
-    double lat1 = degreesToRadians(point1.latitude());
-    double lat2 = degreesToRadians(point2.latitude());
+    double p1Latitude = point1.latitude();
+    double p1Longitude = point1.longitude();
+    double p2Latitude = point2.latitude();
+    double p2Longitude = point2.longitude();
+    double difLat = degreesToRadians(p2Latitude - p1Latitude);
+    double difLon = degreesToRadians(p2Longitude - p1Longitude);
+    double lat1 = degreesToRadians(p1Latitude);
+    double lat2 = degreesToRadians(p2Latitude);
+    double a = Math.sin(difLat / 2);
+    double b = Math.sin(difLon / 2);
 
-    double value = Math.pow(Math.sin(difLat / 2), 2)
-      + Math.pow(Math.sin(difLon / 2), 2) * Math.cos(lat1) * Math.cos(lat2);
+    double value = a * a + b * b * Math.cos(lat1) * Math.cos(lat2);
 
     return TurfConversion.radiansToLength(
       2 * Math.atan2(Math.sqrt(value), Math.sqrt(1 - value)), units);

--- a/services-turf/src/test/java/com/mapbox/turf/TurfMiscTest.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TurfMiscTest.java
@@ -460,6 +460,121 @@ public class TurfMiscTest extends TestUtils {
   }
 
   @Test
+  public void testLineSliceAlongLine1WithDistances() throws TurfException {
+    Feature line1 = Feature.fromJson(loadJsonFixture(LINE_SLICE_ALONG_LINE_ONE));
+    LineString lineStringLine1 = (LineString) line1.geometry();
+    List<Double> distances = Arrays.asList(
+      186.84406574649304,
+      100.69192860431227,
+      87.93612331551124,
+      124.62114438458583,
+      110.6378229611394,
+      107.1185834364626,
+      112.74125942778711,
+      126.32880459146213,
+      106.08835507916929,
+      104.8758009157191,
+      183.8476756899308,
+      86.6797647250738
+    );
+    List<DistanceProvider> distanceProviders = new ArrayList<>();
+    for (double distance : distances) {
+      distanceProviders.add(() -> distance);
+    }
+
+    double start = 500;
+    double stop = 750;
+
+    Point start_point = TurfMeasurement.along(lineStringLine1, start, TurfConstants.UNIT_MILES);
+    Point end_point = TurfMeasurement.along(lineStringLine1, stop, TurfConstants.UNIT_MILES);
+    LineString sliced = TurfMisc.lineSliceAlong(lineStringLine1, distanceProviders, start, stop, TurfConstants.UNIT_MILES);
+
+    assertEquals(sliced.coordinates().get(0).coordinates(),
+      start_point.coordinates());
+    assertEquals(sliced.coordinates().get(sliced.coordinates().size() - 1).coordinates(),
+      end_point.coordinates());
+  }
+
+  @Test
+  public void testLineSliceAlongLine1WithEmptyDistances() throws TurfException {
+    thrown.expect(TurfException.class);
+    thrown.expectMessage(startsWith("distanceProviders in Turf lineSliceAlong should be of size coordinates - 1. Expected: 12, actual: 0"));
+
+    Feature line1 = Feature.fromJson(loadJsonFixture(LINE_SLICE_ALONG_LINE_ONE));
+    LineString lineStringLine1 = (LineString) line1.geometry();
+    List<DistanceProvider> distanceProviders = new ArrayList<>();
+
+    double start = 500;
+    double stop = 750;
+
+    TurfMisc.lineSliceAlong(lineStringLine1, distanceProviders, start, stop, TurfConstants.UNIT_MILES);
+  }
+
+  @Test
+  public void testLineSliceAlongLine1WithTooFewDistances() throws TurfException {
+    thrown.expect(TurfException.class);
+    thrown.expectMessage(startsWith("distanceProviders in Turf lineSliceAlong should be of size coordinates - 1. Expected: 12, actual: 11"));
+
+    Feature line1 = Feature.fromJson(loadJsonFixture(LINE_SLICE_ALONG_LINE_ONE));
+    LineString lineStringLine1 = (LineString) line1.geometry();
+    List<Double> distances = Arrays.asList(
+      186.84406574649304,
+      100.69192860431227,
+      87.93612331551124,
+      124.62114438458583,
+      110.6378229611394,
+      107.1185834364626,
+      112.74125942778711,
+      126.32880459146213,
+      106.08835507916929,
+      104.8758009157191,
+      183.8476756899308
+    );
+    List<DistanceProvider> distanceProviders = new ArrayList<>();
+    for (double distance : distances) {
+      distanceProviders.add(() -> distance);
+    }
+
+    double start = 500;
+    double stop = 750;
+
+    TurfMisc.lineSliceAlong(lineStringLine1, distanceProviders, start, stop, TurfConstants.UNIT_MILES);
+  }
+
+  @Test
+  public void testLineSliceAlongLine1WithTooManyDistances() throws TurfException {
+    thrown.expect(TurfException.class);
+    thrown.expectMessage(startsWith("distanceProviders in Turf lineSliceAlong should be of size coordinates - 1. Expected: 12, actual: 13"));
+
+    Feature line1 = Feature.fromJson(loadJsonFixture(LINE_SLICE_ALONG_LINE_ONE));
+    LineString lineStringLine1 = (LineString) line1.geometry();
+    List<Double> distances = Arrays.asList(
+      186.84406574649304,
+      100.69192860431227,
+      87.93612331551124,
+      124.62114438458583,
+      110.6378229611394,
+      107.1185834364626,
+      112.74125942778711,
+      126.32880459146213,
+      106.08835507916929,
+      104.8758009157191,
+      183.8476756899308,
+      1.2,
+      3.4
+    );
+    List<DistanceProvider> distanceProviders = new ArrayList<>();
+    for (double distance : distances) {
+      distanceProviders.add(() -> distance);
+    }
+
+    double start = 500;
+    double stop = 750;
+
+    TurfMisc.lineSliceAlong(lineStringLine1, distanceProviders, start, stop, TurfConstants.UNIT_MILES);
+  }
+
+  @Test
    public void testLineSliceAlongOvershootLine1() throws IOException, TurfException {
     Feature line1 = Feature.fromJson(loadJsonFixture(LINE_SLICE_ALONG_LINE_ONE));
     LineString lineStringLine1 = (LineString) line1.geometry();


### PR DESCRIPTION
Should be used together with https://github.com/mapbox/mapbox-navigation-android/pull/6640.
See the performance testing results in the ticket.