### PR TITLE
Index url path parameters from end to allow APIs to be nested under a path

### DIFF
--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -1004,9 +1004,9 @@ public abstract class RouteOptions extends DirectionsJsonObject {
 
     try {
       String[] pathElements = url.getPath().split("/");
-      optionsJson.addProperty("user", URLDecoder.decode(pathElements[3], UTF_8));
-      optionsJson.addProperty("profile", URLDecoder.decode(pathElements[4], UTF_8));
-      optionsJson.addProperty("coordinates", URLDecoder.decode(pathElements[5], UTF_8));
+      optionsJson.addProperty("user", URLDecoder.decode(pathElements[pathElements.length - 3], UTF_8));
+      optionsJson.addProperty("profile", URLDecoder.decode(pathElements[pathElements.length - 2], UTF_8));
+      optionsJson.addProperty("coordinates", URLDecoder.decode(pathElements[pathElements.length - 1], UTF_8));
 
       String[] queryElements = url.getQuery().split("&");
       for (String query : queryElements) {


### PR DESCRIPTION
Currently, the `baseUrl` needs to be 'only' a base URL.

This change will allow you to add a baseUrl with a path at the end without conflicting with the path parameters.

Passes all of the route options tests.

This can potentially break functionality for users who have additional path parameters appended after the coordinates. But I doubt anyone is doing that.

The convention is that the last path in a URL is the resource. So the last path ought to always be a coordinate. Also, coordinates are the most brittle value to be parsed. In this case, if you are using a non-standard base URL, `user` and `profile` are more likely to not have as much meaning.