### PR TITLE
Fix compilation for the newer Java envs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ subprojects {
   apply from: "${rootDir}/gradle/dependencies.gradle"
   apply plugin: 'java'
   apply plugin: 'idea'
-  apply plugin: 'net.ltgt.errorprone'
+//  apply plugin: 'net.ltgt.errorprone'
 
   // Fixes issue with test resources not being found inside Intellij
   idea {
@@ -75,7 +75,7 @@ subprojects {
 
   dependencies {
 
-    errorprone dependenciesList.errorprone
+//    errorprone dependenciesList.errorprone
 
     // Test Dependencies
     testCompile dependenciesList.junit

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -18,7 +18,7 @@ ext {
 
 def getVersionName() {
     def cmd = "git describe --tag --abbrev=0"
-    def version = cmd.execute().text.trim()
+    def version = cmd.execute([], project.rootDir).text.trim()
     return isSnapshot() ? getSnapshotVersion(version) : getReleaseVersion(version)
 }
 


### PR DESCRIPTION
Added couple workarounds to solve the issues mentioned at https://github.com/mapbox-collab/Decathlon-collab/issues/14#issuecomment-1428338946, seems with recent JVM (e.g. mine is `openjdk 11.0.17 2022-10-18 LTS`) builds are broken at the moment. 
Haven't found compatible `net.ltgt.errorprone` settings, tried couple different verisions with no luck. Could someone familiar with the repo from pick it up cc @mapbox/navigation-android? 