### PR TITLE
NAVAND-1037 support streaming serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ### main
+- Added `DirectionsResponse.fromJson(Reader)` and `DirectionsResponse.fromJson(Reader, RouteOptions)` to support streaming serialisation of `DirectionsResponse`.
 
 ### v6.11.0 - March 03, 2023
 - No additional changes

--- a/services-core/src/test/java/com/mapbox/core/TestUtils.java
+++ b/services-core/src/test/java/com/mapbox/core/TestUtils.java
@@ -28,10 +28,14 @@ public class TestUtils {
   }
 
   protected String loadJsonFixture(String filename) throws IOException {
-    ClassLoader classLoader = getClass().getClassLoader();
-    InputStream inputStream = classLoader.getResourceAsStream(filename);
+    InputStream inputStream = getResourceInputSteam(filename);
     Scanner scanner = new Scanner(inputStream, UTF_8.name()).useDelimiter("\\A");
     return scanner.hasNext() ? scanner.next() : "";
+  }
+
+  protected InputStream getResourceInputSteam(String filename) {
+    ClassLoader classLoader = getClass().getClassLoader();
+    return classLoader.getResourceAsStream(filename);
   }
 
   public static <T extends Serializable> byte[] serialize(T obj)

--- a/services-core/src/test/java/com/mapbox/core/TestUtils.java
+++ b/services-core/src/test/java/com/mapbox/core/TestUtils.java
@@ -8,9 +8,11 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -33,7 +35,11 @@ public class TestUtils {
     return scanner.hasNext() ? scanner.next() : "";
   }
 
-  protected InputStream getResourceInputSteam(String filename) {
+  protected InputStreamReader getResourceInputSteamReader(String filename) {
+    return new InputStreamReader(getResourceInputSteam(filename), StandardCharsets.UTF_8);
+  }
+
+  private InputStream getResourceInputSteam(String filename) {
     ClassLoader classLoader = getClass().getClassLoader();
     return classLoader.getResourceAsStream(filename);
   }

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
@@ -9,6 +9,14 @@ import com.google.gson.TypeAdapter;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.PointAsCoordinatesTypeAdapter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -144,6 +152,48 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
     gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
     // rebuilding to ensure that underlying routes have assigned indices and UUID
     return gson.create().fromJson(json, DirectionsResponse.class).toBuilder().build();
+  }
+
+  public static DirectionsResponse fromJson(@NonNull ByteBuffer json, Charset charsets) {
+    GsonBuilder gson = new GsonBuilder();
+    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
+    gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
+    // rebuilding to ensure that underlying routes have assigned indices and UUID
+
+    InputStream is = new ByteBufferBackedInputStream(json);
+    InputStreamReader r = new InputStreamReader(is, charsets);
+    return gson.create().fromJson(r, DirectionsResponse.class).toBuilder().build();
+  }
+
+  private static class ByteBufferBackedInputStream extends InputStream {
+
+    ByteBuffer buf;
+
+    public ByteBufferBackedInputStream(ByteBuffer buf) {
+      this.buf = buf;
+    }
+
+    public synchronized int read() throws IOException {
+      if (!buf.hasRemaining()) {
+        return -1;
+      }
+      return buf.get() & 0xFF;
+    }
+
+    @Override
+    public int available() throws IOException {
+      return buf.remaining();
+    }
+
+    public synchronized int read(byte[] bytes, int off, int len) throws IOException {
+      if (!buf.hasRemaining()) {
+        return -1;
+      }
+
+      len = Math.min(len, buf.remaining());
+      buf.get(bytes, off, len);
+      return len;
+    }
   }
 
   /**

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
@@ -156,7 +156,6 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
    * @return a new instance of this class defined by the values passed inside this static factory
    *   method
    * @see #fromJson(Reader, RouteOptions)
-   * @since 3.0.0
    */
   public static DirectionsResponse fromJson(@NonNull Reader json) {
     // rebuilding to ensure that underlying routes have assigned indices and UUID

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
@@ -141,19 +141,26 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
    * @since 3.0.0
    */
   public static DirectionsResponse fromJson(@NonNull String json) {
-    GsonBuilder gson = new GsonBuilder();
-    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
-    gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
     // rebuilding to ensure that underlying routes have assigned indices and UUID
-    return gson.create().fromJson(json, DirectionsResponse.class).toBuilder().build();
+    return createGson().fromJson(json, DirectionsResponse.class).toBuilder().build();
   }
 
+  /**
+   * Deserializes a new instance of this class reading from the specified reader.
+   * <p>
+   * Consider using {@link #fromJson(Reader, RouteOptions)} if the result is used with
+   * downstream consumers of the directions models (like Mapbox Navigation SDK)
+   * to provide rerouting and route refreshing features.
+   *
+   * @param json a reader producing a valid JSON defining a GeoJson Directions Response
+   * @return a new instance of this class defined by the values passed inside this static factory
+   *   method
+   * @see #fromJson(Reader, RouteOptions)
+   * @since 3.0.0
+   */
   public static DirectionsResponse fromJson(@NonNull Reader json) {
-    GsonBuilder gson = new GsonBuilder();
-    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
-    gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
     // rebuilding to ensure that underlying routes have assigned indices and UUID
-    return gson.create().fromJson(json, DirectionsResponse.class).toBuilder().build();
+    return createGson().fromJson(json, DirectionsResponse.class).toBuilder().build();
   }
 
   /**
@@ -176,10 +183,7 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
   @Deprecated
   public static DirectionsResponse fromJson(
     @NonNull String json, @Nullable RouteOptions routeOptions, @Nullable String requestUuid) {
-    GsonBuilder gson = new GsonBuilder();
-    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
-    gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
-    DirectionsResponse response = gson.create().fromJson(json, DirectionsResponse.class);
+    DirectionsResponse response = createGson().fromJson(json, DirectionsResponse.class);
     if (routeOptions != null) {
       response = response.updateWithRequestData(routeOptions);
     }
@@ -206,11 +210,33 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
    * @see RouteOptions#fromJson(String)
    */
   public static DirectionsResponse fromJson(
-    @NonNull String json, @NonNull RouteOptions routeOptions) {
-    GsonBuilder gson = new GsonBuilder();
-    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
-    gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
-    DirectionsResponse response = gson.create().fromJson(json, DirectionsResponse.class);
+    @NonNull String json,
+    @NonNull RouteOptions routeOptions
+  ) {
+    DirectionsResponse response = createGson().fromJson(json, DirectionsResponse.class);
+    // rebuilding to ensure that underlying routes have assigned indices and UUID
+    return response.updateWithRequestData(routeOptions);
+  }
+
+  /**
+   * Deserializes a new instance of this class reading from the specified reader.
+   * <p>
+   * The parameter of {@link RouteOptions} that were used to make the original route request
+   * which might be required by downstream consumers of the directions models
+   * (like Mapbox Navigation SDK) to provide rerouting and route refreshing features.
+   *
+   * @param json         a reader producing a valid JSON defining a GeoJson Directions Response
+   * @param routeOptions options that were used during the original route request
+   * @return a new instance of this class defined by the values passed inside this static factory
+   *   method
+   * @see RouteOptions#fromUrl(java.net.URL)
+   * @see RouteOptions#fromJson(String)
+   */
+  public static DirectionsResponse fromJson(
+    @NonNull Reader json,
+    @NonNull RouteOptions routeOptions
+  ) {
+    DirectionsResponse response = createGson().fromJson(json, DirectionsResponse.class);
     // rebuilding to ensure that underlying routes have assigned indices and UUID
     return response.updateWithRequestData(routeOptions);
   }
@@ -341,5 +367,12 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
 
       return autoBuild();
     }
+  }
+
+  @NonNull private static Gson createGson() {
+    GsonBuilder gson = new GsonBuilder();
+    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
+    gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
+    return gson.create();
   }
 }

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/DirectionsResponse.java
@@ -10,13 +10,7 @@ import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.PointAsCoordinatesTypeAdapter;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -154,46 +148,12 @@ public abstract class DirectionsResponse extends DirectionsJsonObject {
     return gson.create().fromJson(json, DirectionsResponse.class).toBuilder().build();
   }
 
-  public static DirectionsResponse fromJson(@NonNull ByteBuffer json, Charset charsets) {
+  public static DirectionsResponse fromJson(@NonNull Reader json) {
     GsonBuilder gson = new GsonBuilder();
     gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
     gson.registerTypeAdapter(Point.class, new PointAsCoordinatesTypeAdapter());
     // rebuilding to ensure that underlying routes have assigned indices and UUID
-
-    InputStream is = new ByteBufferBackedInputStream(json);
-    InputStreamReader r = new InputStreamReader(is, charsets);
-    return gson.create().fromJson(r, DirectionsResponse.class).toBuilder().build();
-  }
-
-  private static class ByteBufferBackedInputStream extends InputStream {
-
-    ByteBuffer buf;
-
-    public ByteBufferBackedInputStream(ByteBuffer buf) {
-      this.buf = buf;
-    }
-
-    public synchronized int read() throws IOException {
-      if (!buf.hasRemaining()) {
-        return -1;
-      }
-      return buf.get() & 0xFF;
-    }
-
-    @Override
-    public int available() throws IOException {
-      return buf.remaining();
-    }
-
-    public synchronized int read(byte[] bytes, int off, int len) throws IOException {
-      if (!buf.hasRemaining()) {
-        return -1;
-      }
-
-      len = Math.min(len, buf.remaining());
-      buf.get(bytes, off, len);
-      return len;
-    }
+    return gson.create().fromJson(json, DirectionsResponse.class).toBuilder().build();
   }
 
   /**

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -1,6 +1,5 @@
 package com.mapbox.api.directions.v5.models;
 
-import androidx.annotation.NonNull;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -9,19 +8,16 @@ import com.google.gson.JsonPrimitive;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.core.TestUtils;
 import com.mapbox.geojson.Point;
+import org.junit.Test;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-
-import org.junit.Test;
-
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 
@@ -88,22 +84,15 @@ public class DirectionsResponseTest extends TestUtils {
   }
 
   @Test
-  public void deserialization_from_byte_buffer() throws Exception {
-    String textJson = loadJsonFixture(DIRECTIONS_V5_PRECISION6_FIXTURE);
-    ByteBuffer buffer = putTextToDirectByteBuffer(textJson, StandardCharsets.UTF_8);
+  public void deserialization_from_reader() throws Exception {
+    InputStream jsonStream = getResourceInputSteam(DIRECTIONS_V5_PRECISION6_FIXTURE);
+    String jsonText = loadJsonFixture(DIRECTIONS_V5_PRECISION6_FIXTURE);
+    InputStreamReader reader = new InputStreamReader(jsonStream);
 
-    DirectionsResponse responseFromBuffer = DirectionsResponse.fromJson(buffer, StandardCharsets.UTF_8);
-    DirectionsResponse responseFromText = DirectionsResponse.fromJson(textJson);
+    DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader);
+    DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText);
 
-    assertEquals(responseFromText, responseFromBuffer);
-  }
-
-  @NonNull private ByteBuffer putTextToDirectByteBuffer(String textJson, Charset charset) {
-    byte[] json = textJson.getBytes(charset);
-    ByteBuffer buffer = ByteBuffer.allocateDirect(json.length);
-    buffer.put(json);
-    buffer.position(0);
-    return buffer;
+    assertEquals(responseFromText, responseFromReader);
   }
 
   @Test

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -93,12 +93,7 @@ public class DirectionsResponseTest extends TestUtils {
 
     DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader);
     DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText);
-    System.out.println("vadzim-test: " + System.getProperty("file.encoding"));
-    System.out.println("vadzim-test: " + responseFromText.routes().get(0).legs().get(0).steps().get(6).pronunciation());
-    assertEquals(
-      responseFromText.routes().get(0).legs().get(0).steps().get(6).pronunciation(),
-      responseFromReader.routes().get(0).legs().get(0).steps().get(6).pronunciation()
-    );
+
     assertEquals(responseFromText, responseFromReader);
   }
 
@@ -114,7 +109,7 @@ public class DirectionsResponseTest extends TestUtils {
     String testJsonFileName = DIRECTIONS_V5_PRECISION6_FIXTURE;
     InputStream jsonStream = getResourceInputSteam(testJsonFileName);
     String jsonText = loadJsonFixture(testJsonFileName);
-    InputStreamReader reader = new InputStreamReader(jsonStream);
+    InputStreamReader reader = new InputStreamReader(jsonStream, StandardCharsets.UTF_8);
 
     DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader, testRouteOptions);
     DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText, testRouteOptions);

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -96,6 +96,25 @@ public class DirectionsResponseTest extends TestUtils {
   }
 
   @Test
+  public void deserialization_from_reader_with_route_options() throws Exception {
+    RouteOptions testRouteOptions = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+      .coordinatesList(new ArrayList<Point>() {{
+        add(Point.fromLngLat(1.0, 1.0));
+        add(Point.fromLngLat(2.0, 2.0));
+      }})
+      .build();
+    InputStream jsonStream = getResourceInputSteam(DIRECTIONS_V5_PRECISION6_FIXTURE);
+    String jsonText = loadJsonFixture(DIRECTIONS_V5_PRECISION6_FIXTURE);
+    InputStreamReader reader = new InputStreamReader(jsonStream);
+
+    DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader, testRouteOptions);
+    DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText, testRouteOptions);
+
+    assertEquals(responseFromText, responseFromReader);
+  }
+
+  @Test
   public void testToFromJsonWithRealResponse() throws Exception {
     Gson gson = new GsonBuilder().create();
     String originalJson = loadJsonFixture(DIRECTIONS_V5_PRECISION6_FIXTURE_ARTIFICIAL_FIELDS);

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -85,6 +85,7 @@ public class DirectionsResponseTest extends TestUtils {
 
   @Test
   public void deserialization_from_reader() throws Exception {
+    System.setProperty("file.encoding", "UTF-8");
     String testJsonFileName = DIRECTIONS_V5_PRECISION6_FIXTURE;
     InputStream jsonStream = getResourceInputSteam(testJsonFileName);
     String jsonText = loadJsonFixture(testJsonFileName);

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -1,5 +1,6 @@
 package com.mapbox.api.directions.v5.models;
 
+import androidx.annotation.NonNull;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -10,6 +11,9 @@ import com.mapbox.core.TestUtils;
 import com.mapbox.geojson.Point;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -81,6 +85,25 @@ public class DirectionsResponseTest extends TestUtils {
     DirectionsResponse response = DirectionsResponse.fromJson(json);
     assertNotNull(response);
     assertEquals(1, response.routes().size());
+  }
+
+  @Test
+  public void deserialization_from_byte_buffer() throws Exception {
+    String textJson = loadJsonFixture(DIRECTIONS_V5_PRECISION6_FIXTURE);
+    ByteBuffer buffer = putTextToDirectByteBuffer(textJson, StandardCharsets.UTF_8);
+
+    DirectionsResponse responseFromBuffer = DirectionsResponse.fromJson(buffer, StandardCharsets.UTF_8);
+    DirectionsResponse responseFromText = DirectionsResponse.fromJson(textJson);
+
+    assertEquals(responseFromText, responseFromBuffer);
+  }
+
+  @NonNull private ByteBuffer putTextToDirectByteBuffer(String textJson, Charset charset) {
+    byte[] json = textJson.getBytes(charset);
+    ByteBuffer buffer = ByteBuffer.allocateDirect(json.length);
+    buffer.put(json);
+    buffer.position(0);
+    return buffer;
   }
 
   @Test

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -85,11 +86,10 @@ public class DirectionsResponseTest extends TestUtils {
 
   @Test
   public void deserialization_from_reader() throws Exception {
-    System.setProperty("file.encoding", "UTF-8");
     String testJsonFileName = DIRECTIONS_V5_PRECISION6_FIXTURE;
     InputStream jsonStream = getResourceInputSteam(testJsonFileName);
     String jsonText = loadJsonFixture(testJsonFileName);
-    InputStreamReader reader = new InputStreamReader(jsonStream);
+    InputStreamReader reader = new InputStreamReader(jsonStream, StandardCharsets.UTF_8);
 
     DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader);
     DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText);

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -93,6 +93,11 @@ public class DirectionsResponseTest extends TestUtils {
     DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader);
     DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText);
 
+    System.out.println("vadzim-test: " + responseFromText.routes().get(0).legs().get(0).steps().get(6).pronunciation());
+    assertEquals(
+      responseFromText.routes().get(0).legs().get(0).steps().get(6).pronunciation(),
+      responseFromReader.routes().get(0).legs().get(0).steps().get(6).pronunciation()
+    );
     assertEquals(responseFromText, responseFromReader);
   }
 

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -85,8 +85,9 @@ public class DirectionsResponseTest extends TestUtils {
 
   @Test
   public void deserialization_from_reader() throws Exception {
-    InputStream jsonStream = getResourceInputSteam(DIRECTIONS_V5_PRECISION6_FIXTURE);
-    String jsonText = loadJsonFixture(DIRECTIONS_V5_PRECISION6_FIXTURE);
+    String testJsonFileName = DIRECTIONS_V5_PRECISION6_FIXTURE;
+    InputStream jsonStream = getResourceInputSteam(testJsonFileName);
+    String jsonText = loadJsonFixture(testJsonFileName);
     InputStreamReader reader = new InputStreamReader(jsonStream);
 
     DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader);
@@ -104,8 +105,9 @@ public class DirectionsResponseTest extends TestUtils {
         add(Point.fromLngLat(2.0, 2.0));
       }})
       .build();
-    InputStream jsonStream = getResourceInputSteam(DIRECTIONS_V5_PRECISION6_FIXTURE);
-    String jsonText = loadJsonFixture(DIRECTIONS_V5_PRECISION6_FIXTURE);
+    String testJsonFileName = DIRECTIONS_V5_PRECISION6_FIXTURE;
+    InputStream jsonStream = getResourceInputSteam(testJsonFileName);
+    String jsonText = loadJsonFixture(testJsonFileName);
     InputStreamReader reader = new InputStreamReader(jsonStream);
 
     DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader, testRouteOptions);

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -92,7 +92,7 @@ public class DirectionsResponseTest extends TestUtils {
 
     DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader);
     DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText);
-
+    System.out.println("vadzim-test: " + System.getProperty("file.encoding"));
     System.out.println("vadzim-test: " + responseFromText.routes().get(0).legs().get(0).steps().get(6).pronunciation());
     assertEquals(
       responseFromText.routes().get(0).legs().get(0).steps().get(6).pronunciation(),

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsResponseTest.java
@@ -11,9 +11,7 @@ import com.mapbox.geojson.Point;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -87,11 +85,10 @@ public class DirectionsResponseTest extends TestUtils {
   @Test
   public void deserialization_from_reader() throws Exception {
     String testJsonFileName = DIRECTIONS_V5_PRECISION6_FIXTURE;
-    InputStream jsonStream = getResourceInputSteam(testJsonFileName);
     String jsonText = loadJsonFixture(testJsonFileName);
-    InputStreamReader reader = new InputStreamReader(jsonStream, StandardCharsets.UTF_8);
+    InputStreamReader jsonReader = getResourceInputSteamReader(testJsonFileName);
 
-    DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader);
+    DirectionsResponse responseFromReader = DirectionsResponse.fromJson(jsonReader);
     DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText);
 
     assertEquals(responseFromText, responseFromReader);
@@ -107,11 +104,10 @@ public class DirectionsResponseTest extends TestUtils {
       }})
       .build();
     String testJsonFileName = DIRECTIONS_V5_PRECISION6_FIXTURE;
-    InputStream jsonStream = getResourceInputSteam(testJsonFileName);
+    InputStreamReader jsonReader = getResourceInputSteamReader(testJsonFileName);
     String jsonText = loadJsonFixture(testJsonFileName);
-    InputStreamReader reader = new InputStreamReader(jsonStream, StandardCharsets.UTF_8);
 
-    DirectionsResponse responseFromReader = DirectionsResponse.fromJson(reader, testRouteOptions);
+    DirectionsResponse responseFromReader = DirectionsResponse.fromJson(jsonReader, testRouteOptions);
     DirectionsResponse responseFromText = DirectionsResponse.fromJson(jsonText, testRouteOptions);
 
     assertEquals(responseFromText, responseFromReader);


### PR DESCRIPTION
I want to deserialise direction response from `ByteBuffer` that is kept in native memory. See POC: https://github.com/mapbox/mapbox-java/pull/1526 and NAVAND-1037 for more details.

I decided to introduce a general purpose interface that accepts reader instead of byte buffer, while the transformation of byte buffer to reader will be done on the Navigation SDK side. 