### PR TITLE
Clarify documentation to avoid confusion 

### DIFF
--- a/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
+++ b/services-matching/src/main/java/com/mapbox/api/matching/v5/MapboxMapMatching.java
@@ -280,6 +280,8 @@ public abstract class MapboxMapMatching extends
 
   /**
    * Builds your map matching query by adding parameters.
+   * Create a fresh instance of the builder for new requests given the fact that
+   * some methods like {@link #coordinates(List)} accumulate values.
    *
    * @since 2.0.0
    */

--- a/services-matrix/src/main/java/com/mapbox/api/matrix/v1/MapboxMatrix.java
+++ b/services-matrix/src/main/java/com/mapbox/api/matrix/v1/MapboxMatrix.java
@@ -123,7 +123,12 @@ public abstract class MapboxMatrix extends MapboxService<MatrixResponse, MatrixS
    * <p>
    * By default, the directions profile is set to driving (without traffic) but can be changed to
    * reflect your users use-case.
-   * </p><p>
+   * </p>
+   * <p>
+   * Create a fresh instance of the builder for new requests given the fact that
+   * some methods like {@link #coordinates(List)} accumulate values.
+   * </p>
+   * <p>
    * Note to contributors: All optional booleans in this builder use the object {@code Boolean}
    * rather than the primitive to allow for unset (null) values.
    * </p>


### PR DESCRIPTION
We get a complain from customer that matrix request stoped working after some time until device is rebooted. It turned out that they were reusing builder instance for different requests. 