### PR TITLE
[NAVAND-2844] Improve array creation while parsing

### DIFF
--- a/services-geojson/src/main/java/com/mapbox/geojson/BaseCoordinatesTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/BaseCoordinatesTypeAdapter.java
@@ -71,7 +71,7 @@ abstract class BaseCoordinatesTypeAdapter<T> extends TypeAdapter<T> {
       throw new NullPointerException();
     }
 
-    List<Double> coordinates = new ArrayList<Double>();
+    List<Double> coordinates = new ArrayList<Double>(3);
     in.beginArray();
     while (in.hasNext()) {
       coordinates.add(in.nextDouble());

--- a/services-geojson/src/main/java/com/mapbox/geojson/gson/BoundingBoxTypeAdapter.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/gson/BoundingBoxTypeAdapter.java
@@ -60,7 +60,7 @@ public class BoundingBoxTypeAdapter extends TypeAdapter<BoundingBox> {
   @Override
   public BoundingBox read(JsonReader in) throws IOException {
 
-    List<Double> rawCoordinates = new ArrayList<Double>();
+    List<Double> rawCoordinates = new ArrayList<Double>(6);
     in.beginArray();
     while (in.hasNext()) {
       rawCoordinates.add(in.nextDouble());


### PR DESCRIPTION
The issue corresponds to [NAVAND-2844](https://mapbox.atlassian.net/browse/NAVAND-2844) jura ticket. 

Reduces array default size in GSON adapters.

[NAVAND-2844]: https://mapbox.atlassian.net/browse/NAVAND-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ