### PR TITLE
Adding `country` to `V6StructuredInputQuery`

### DIFF
--- a/samples/src/main/java/com/mapbox/samples/BasicV6BatchGeocoding.java
+++ b/samples/src/main/java/com/mapbox/samples/BasicV6BatchGeocoding.java
@@ -36,11 +36,11 @@ public class BasicV6BatchGeocoding {
       .street("Pennsylvania Avenue NW")
       .postcode("20500")
       .place("Washington, DC")
+      .country("us")
       .build();
 
     final V6ForwardGeocodingRequestOptions structuredInputOptions = V6ForwardGeocodingRequestOptions
       .builder(structuredInputQuery)
-      .country("us")
       .build();
 
     final V6ReverseGeocodingRequestOptions reverseOptions = V6ReverseGeocodingRequestOptions

--- a/samples/src/main/java/com/mapbox/samples/BasicV6StructuredInputForwardGeocoding.java
+++ b/samples/src/main/java/com/mapbox/samples/BasicV6StructuredInputForwardGeocoding.java
@@ -22,11 +22,11 @@ public class BasicV6StructuredInputForwardGeocoding {
       .street("15th St")
       .place("Washington")
       .postcode("20005")
+      .country("United States")
       .build();
 
     final V6ForwardGeocodingRequestOptions requestOptions = V6ForwardGeocodingRequestOptions
       .builder(query)
-      .country("United States")
       .types(V6FeatureType.ADDRESS)
       .autocomplete(false)
       .build();

--- a/services-geocoding/src/main/java/com/mapbox/api/geocoding/v6/V6ForwardGeocodingRequestOptions.java
+++ b/services-geocoding/src/main/java/com/mapbox/api/geocoding/v6/V6ForwardGeocodingRequestOptions.java
@@ -159,7 +159,8 @@ public abstract class V6ForwardGeocodingRequestOptions implements V6RequestOptio
       .region(query.region())
       .postcode(query.postcode())
       .locality(query.locality())
-      .neighborhood(query.neighborhood());
+      .neighborhood(query.neighborhood())
+      .country(query.country());
   }
 
   /**

--- a/services-geocoding/src/main/java/com/mapbox/api/geocoding/v6/V6GeocodingService.java
+++ b/services-geocoding/src/main/java/com/mapbox/api/geocoding/v6/V6GeocodingService.java
@@ -66,7 +66,7 @@ interface V6GeocodingService {
    * @param permanent     {@link MapboxV6Geocoding#permanent()}
    * @param autocomplete  {@link V6ForwardGeocodingRequestOptions#autocomplete()}
    * @param bbox          {@link V6ForwardGeocodingRequestOptions#bbox()}
-   * @param country       {@link V6ForwardGeocodingRequestOptions#country()}
+   * @param country       {@link V6StructuredInputQuery#country()}
    * @param language      {@link V6ForwardGeocodingRequestOptions#language()}
    * @param limit         {@link V6ForwardGeocodingRequestOptions#limit()}
    * @param proximity     {@link V6ForwardGeocodingRequestOptions#proximity()}

--- a/services-geocoding/src/main/java/com/mapbox/api/geocoding/v6/V6StructuredInputQuery.java
+++ b/services-geocoding/src/main/java/com/mapbox/api/geocoding/v6/V6StructuredInputQuery.java
@@ -55,6 +55,10 @@ public abstract class V6StructuredInputQuery {
   @Nullable
   abstract String neighborhood();
 
+  @SerializedName("country")
+  @Nullable
+  abstract String country();
+
   /**
    * Creates a new {@link V6StructuredInputQuery.Builder} object.
    * @return Builder object.
@@ -149,6 +153,15 @@ public abstract class V6StructuredInputQuery {
      */
     public abstract Builder neighborhood(@NonNull String neighborhood);
 
+    /**
+     * Generally recognized countries or, in some cases like Hong Kong, an area of quasi-national
+     * administrative status that has a designated country code under <a href="https://www.iso.org/iso-3166-country-codes.html">ISO 3166-1</a>.
+     *
+     * @param country structured input component.
+     * @return this builder for chaining options together
+     */
+    public abstract Builder country(@NonNull String country);
+
     abstract V6StructuredInputQuery autoBuild();
 
     /**
@@ -169,6 +182,7 @@ public abstract class V6StructuredInputQuery {
         && query.postcode() == null
         && query.locality() == null
         && query.neighborhood() == null
+        && query.country() == null
       ) {
         throw new ServicesException("At least one component must be non null");
       }

--- a/services-geocoding/src/test/java/com/mapbox/api/geocoding/v6/MapboxV6GeocodingTest.java
+++ b/services-geocoding/src/test/java/com/mapbox/api/geocoding/v6/MapboxV6GeocodingTest.java
@@ -166,6 +166,7 @@ public class MapboxV6GeocodingTest extends V6GeocodingTestUtils {
     assertEquals(options.postcode(), url.queryParameter("postcode"));
     assertEquals(options.locality(), url.queryParameter("locality"));
     assertEquals(options.neighborhood(), url.queryParameter("neighborhood"));
+    assertEquals(options.country(), url.queryParameter("country"));
   }
 
   @Test
@@ -201,6 +202,7 @@ public class MapboxV6GeocodingTest extends V6GeocodingTestUtils {
     assertNull(url.queryParameter("postcode"));
     assertNull(url.queryParameter("locality"));
     assertNull(url.queryParameter("neighborhood"));
+    assertNull(url.queryParameter("country"));
   }
 
   @Test

--- a/services-geocoding/src/test/java/com/mapbox/api/geocoding/v6/V6GeocodingTestUtils.java
+++ b/services-geocoding/src/test/java/com/mapbox/api/geocoding/v6/V6GeocodingTestUtils.java
@@ -77,6 +77,7 @@ public abstract class V6GeocodingTestUtils extends TestUtils {
       .postcode("test-postcode")
       .locality("test-locality")
       .neighborhood("test-neighborhood")
+      .country("test-country")
       .build();
 
 

--- a/services-geocoding/src/test/java/com/mapbox/api/geocoding/v6/V6StructuredInputQueryTest.java
+++ b/services-geocoding/src/test/java/com/mapbox/api/geocoding/v6/V6StructuredInputQueryTest.java
@@ -36,6 +36,7 @@ public class V6StructuredInputQueryTest {
       .postcode("test-postcode")
       .locality("test-locality")
       .neighborhood("test-neighborhood")
+      .country("test-country")
       .build();
 
     assertEquals("test-address-line1", query.addressLine1());
@@ -47,6 +48,7 @@ public class V6StructuredInputQueryTest {
     assertEquals("test-postcode", query.postcode());
     assertEquals("test-locality", query.locality());
     assertEquals("test-neighborhood", query.neighborhood());
+    assertEquals("test-country", query.country());
   }
 
   @Test
@@ -63,6 +65,7 @@ public class V6StructuredInputQueryTest {
     assertNull(queryWithAddress.postcode());
     assertNull(queryWithAddress.locality());
     assertNull(queryWithAddress.neighborhood());
+    assertNull(queryWithAddress.country());
 
     final V6StructuredInputQuery queryWithAddressLine1 = V6StructuredInputQuery.builder()
       .addressLine1("test-address-line1")


### PR DESCRIPTION
The `country` field is part of the `Forward geocoding with structured input`: https://docs.mapbox.com/api/search/geocoding#forward-geocoding-with-structured-input

So I'm adding it to our object `V6StructuredInputQuery`.