### PR TITLE
Bumped okhttp to version 4.10.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### main
 
+### v7.3.0 - September 23, 2024
+
+- Bumped `okhttp` version to `4.10.0`. [#1595](https://github.com/mapbox/mapbox-java/pull/1595)
+
 ### v7.2.0 - August 28, 2024
 
 - Added `PaymentMethods#etc2` payment method.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
       annotation       : '1.0.0',
       gson             : '2.8.9',
       retrofit         : '2.7.2',
-      okhttp3          : '4.9.0',
+      okhttp3          : '4.10.0',
       mockito          : '4.2.0',
       hamcrestJunit    : '2.0.0.0',
       googleTruth      : '1.0.1',
@@ -25,7 +25,7 @@ ext {
       jacoco     : '0.8.7',
       maven      : '3.6.2',
       artifactory: '4.9.3',
-      kotlin     : '1.3.72',
+      kotlin     : '1.6.21',
       shadowJar  : '4.0.4',
       mapboxSdkRegistry    : '0.7.0'
   ]


### PR DESCRIPTION
Bumped okhttp to version 4.10.0.

Common was bumped last year. https://github.com/mapbox/mapbox-sdk-common/pull/3870