### PR TITLE
Fix for malformed URL when using contours minutes/meters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ### main
+- Fixed malformed URL that resulted from previous inclusion of `contours_meters` as an Isochrone option. [#1599](https://github.com/mapbox/mapbox-java/pull/1599)
 
 ### v7.3.0 - October 04, 2024
 

--- a/services-isochrone/src/main/java/com/mapbox/api/isochrone/MapboxIsochrone.java
+++ b/services-isochrone/src/main/java/com/mapbox/api/isochrone/MapboxIsochrone.java
@@ -87,8 +87,8 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
   public static Builder builder() {
     return new AutoValue_MapboxIsochrone.Builder()
       .baseUrl(Constants.BASE_API_URL)
-      .contoursMinutes("")
-      .contoursMeters("")
+      .contoursMinutes(null)
+      .contoursMeters(null)
       .user(IsochroneCriteria.PROFILE_DEFAULT_USER);
   }
 
@@ -108,7 +108,7 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
   @NonNull
   abstract String coordinates();
 
-  @NonNull
+  @Nullable
   abstract String contoursMinutes();
 
   @Nullable
@@ -268,7 +268,7 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
      */
     // Required for matching with MapboxIsochrone addContoursMinutes() method.
     @SuppressWarnings("WeakerAccess")
-    abstract Builder contoursMinutes(@NonNull String stringListOfMinuteValues);
+    abstract Builder contoursMinutes(@Nullable String stringListOfMinuteValues);
 
     /**
      * A single String which is a comma-separated list of values(s) in meters
@@ -281,7 +281,7 @@ public abstract class MapboxIsochrone extends MapboxService<FeatureCollection, I
      *                                 meters which represent each contour
      * @return this builder for chaining options together
      */
-    abstract Builder contoursMeters(@NonNull String stringListOfMeterValues);
+    abstract Builder contoursMeters(@Nullable String stringListOfMeterValues);
 
     /**
      * A list of separate String which has a list of comma-separated

--- a/services-isochrone/src/test/java/com/mapbox/api/isochrone/MapboxIsochroneTest.java
+++ b/services-isochrone/src/test/java/com/mapbox/api/isochrone/MapboxIsochroneTest.java
@@ -153,6 +153,25 @@ public class MapboxIsochroneTest extends IsochroneTestUtils {
 
     assertTrue(requestUrlString.contains("contours_minutes=14" + commaEquivalent
         + "36" + commaEquivalent + "52"));
+    assertFalse(requestUrlString.contains("contours_meters"));
+  }
+
+  @Test
+  public void build_usingIntegerListForMeters() throws ServicesException, IOException {
+    MapboxIsochrone client = MapboxIsochrone.builder()
+            .accessToken(ACCESS_TOKEN)
+            .coordinates(testPoint)
+            .addContoursMeters(14,36,52)
+            .profile(testProfile)
+            .baseUrl(mockUrl.toString())
+            .build();
+    String requestUrlString = client.cloneCall().request().url().toString();
+
+    System.out.print(requestUrlString);
+
+    assertTrue(requestUrlString.contains("contours_meters=14" + commaEquivalent
+            + "36" + commaEquivalent + "52"));
+    assertFalse(requestUrlString.contains("contours_minutes"));
   }
 
   @Test
@@ -168,6 +187,7 @@ public class MapboxIsochroneTest extends IsochroneTestUtils {
     String requestUrlString = client.cloneCall().request().url().toString();
     assertTrue(requestUrlString.contains("contours_minutes=5" + commaEquivalent +
       "30" + commaEquivalent + "55"));
+    assertFalse(requestUrlString.contains("contours_meters"));
   }
 
   @Test


### PR DESCRIPTION
The recent addition of contours_meters for the Isochrone API resulted in a malformed URL. This is a fix for that regression.