### PR TITLE
Support for new route properties; Add BRITISH_IMPERIAL voice unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### main
 
+### v7.5.0 - July 31, 2025
+
 - Updated `auto-value-gson` to version [0.0.3](https://github.com/mapbox/auto-value-gson/releases/tag/mapbox-v0.0.3) and `gson` to version 2.13.1. [#1615](https://github.com/mapbox/mapbox-java/pull/1615)
+
 
 ### v7.4.0 - April 11, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Added `StepIntersection#access` property which provides a list representing the access type for each road at the step intersection. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
 - Added `StepIntersection#elevated` property which provides a list indicating whether each road at the step intersection is elevated. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
 - Added `StepIntersection#bridge` property which provides a list indicating whether each road at the step intersection is a bridge. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
+- Added a new voice unit value: `DirectionsCriteria#BRITISH_IMPERIAL`. This value is now included in `DirectionsCriteria#VoiceUnitCriteria`. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
 
 
 ### v7.5.0 - July 31, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### main
 
+- Added `StepIntersection#formOfWay` property which provides a list representing the "form of way" values for all roads at the step intersection. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
+- Added `StepIntersection#geometries` property which provides a list representing the geometry of each road at the step intersection. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
+- Added `StepIntersection#access` property which provides a list representing the access type for each road at the step intersection. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
+- Added `StepIntersection#elevated` property which provides a list indicating whether each road at the step intersection is elevated. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
+- Added `StepIntersection#bridge` property which provides a list indicating whether each road at the step intersection is a bridge. [#1611](https://github.com/mapbox/mapbox-java/pull/1611)
+
+
 ### v7.5.0 - July 31, 2025
 
 - Updated `auto-value-gson` to version [0.0.3](https://github.com/mapbox/auto-value-gson/releases/tag/mapbox-v0.0.3) and `gson` to version 2.13.1. [#1615](https://github.com/mapbox/mapbox-java/pull/1615)

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/DirectionsCriteria.java
@@ -240,6 +240,13 @@ public final class DirectionsCriteria {
   public static final String METRIC = "metric";
 
   /**
+   * Change the units to british imperial for voice and visual information.
+   * Note that this won't change other results such as raw distance measurements which will
+   * always be returned in meters.
+   */
+  public static final String BRITISH_IMPERIAL = "british_imperial";
+
+  /**
    * Returned route starts at the first provided coordinate in the list. Used specifically for the
    * Optimization API.
    *
@@ -594,7 +601,8 @@ public final class DirectionsCriteria {
   @Retention(RetentionPolicy.CLASS)
   @StringDef( {
     IMPERIAL,
-    METRIC
+    METRIC,
+    BRITISH_IMPERIAL
   })
   public @interface VoiceUnitCriteria {
   }

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -506,7 +506,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
 
   /**
    * A type of units to return in the text for voice instructions.
-   * Can be {@link DirectionsCriteria#IMPERIAL} (default) or {@link DirectionsCriteria#METRIC}.
+   * Can be {@link DirectionsCriteria#IMPERIAL} (default), {@link DirectionsCriteria#METRIC},
+   * or {@link DirectionsCriteria#BRITISH_IMPERIAL}.
    * Must be used in conjunction with {@link RouteOptions#steps()}=true and
    * {@link RouteOptions#steps()}=true
    * and {@link RouteOptions#voiceInstructions()}=true.
@@ -1628,7 +1629,8 @@ public abstract class RouteOptions extends DirectionsJsonObject {
 
     /**
      * A type of units to return in the text for voice instructions.
-     * Can be {@link DirectionsCriteria#IMPERIAL} (default) or {@link DirectionsCriteria#METRIC}.
+     * Can be {@link DirectionsCriteria#IMPERIAL} (default), {@link DirectionsCriteria#METRIC},
+     * or {@link DirectionsCriteria#BRITISH_IMPERIAL}.
      * Must be used in conjunction with {@link RouteOptions#steps()}=true and
      * {@link RouteOptions#steps()}=true
      * and {@link RouteOptions#voiceInstructions()}=true.

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -947,6 +947,76 @@ public abstract class RouteOptions extends DirectionsJsonObject {
   public abstract Boolean suppressVoiceInstructionLocalNames();
 
   /**
+   * Defines whether to return "form of way" values for roads at each {@link StepIntersection}.
+   * See {@link StepIntersection#formOfWay()} for details.
+   * Requires {@link RouteOptions#steps()} to be set to true.
+   *
+   * @return boolean representing the `intersectionLinkFormOfWay` value
+   */
+  @SerializedName("intersection_link_form_of_way")
+  @Nullable
+  public abstract Boolean intersectionLinkFormOfWay();
+
+  /**
+   * A comma-separated list of road classes for which intersection geometry data should be included
+   * at each {@link StepIntersection}. See {@link StepIntersection#geometries()} for details.
+   * Possible values include:
+   * - "motorway"
+   * - "trunk"
+   * - "primary"
+   * - "secondary"
+   * - "tertiary"
+   * - "unclassified"
+   * - "residential"
+   * - "service_other"
+   * Geometry data will be provided for each intersection along the requested route.
+   * The geometry format is affected by {@link RouteOptions#geometries}.
+   * Requires {@link RouteOptions#steps()} to be set to true.
+   * Be aware that enabling this option can significantly increase the response size
+   * and the memory required to store the response object. Use this option selectively, for example,
+   * if geometry is only needed for motorways, specify only "motorway".
+   *
+   * @return a comma-separated list of road classes for which intersection geometry data
+   *   should be included
+   */
+  @SerializedName("intersection_link_geometry")
+  @Nullable
+  public abstract String intersectionLinkGeometry();
+
+  /**
+   * Defines whether to return "access" values for roads at each {@link StepIntersection}.
+   * See {@link StepIntersection#access()} for details.
+   * Requires {@link RouteOptions#steps()} to be set to true.
+   *
+   * @return boolean representing the `intersectionLinkAccess` value
+   */
+  @SerializedName("intersection_link_access")
+  @Nullable
+  public abstract Boolean intersectionLinkAccess();
+
+  /**
+   * Defines whether to return "elevated" status for roads at each {@link StepIntersection}.
+   * See {@link StepIntersection#elevated()} for details.
+   * Requires {@link RouteOptions#steps()} to be set to true.
+   *
+   * @return boolean representing the `intersectionLinkAccess` value
+   */
+  @SerializedName("intersection_link_elevated")
+  @Nullable
+  public abstract Boolean intersectionLinkElevated();
+
+  /**
+   * Defines whether to return "bridge" status for roads at each {@link StepIntersection}.
+   * See {@link StepIntersection#bridges()} for details.
+   * Requires {@link RouteOptions#steps()} to be set to true.
+   *
+   * @return boolean representing the `intersectionLinkAccess` value
+   */
+  @SerializedName("intersection_link_bridge")
+  @Nullable
+  public abstract Boolean intersectionLinkBridge();
+
+  /**
    * Gson type adapter for parsing Gson to this class.
    *
    * @param gson the built {@link Gson} object
@@ -1088,6 +1158,11 @@ public abstract class RouteOptions extends DirectionsJsonObject {
       "suppress_voice_instruction_local_names",
       suppressVoiceInstructionLocalNames()
     );
+    appendQueryParameter(sb, "intersection_link_form_of_way", intersectionLinkFormOfWay());
+    appendQueryParameter(sb, "intersection_link_geometry", intersectionLinkGeometry());
+    appendQueryParameter(sb, "intersection_link_access", intersectionLinkAccess());
+    appendQueryParameter(sb, "intersection_link_elevated", intersectionLinkElevated());
+    appendQueryParameter(sb, "intersection_link_bridge", intersectionLinkBridge());
 
     Map<String, SerializableJsonElement> unrecognized = unrecognized();
     if (unrecognized != null) {
@@ -2125,6 +2200,113 @@ public abstract class RouteOptions extends DirectionsJsonObject {
     @NonNull
     public abstract Builder suppressVoiceInstructionLocalNames(
       @Nullable Boolean suppressVoiceInstructionLocalNames
+    );
+
+    /**
+     * Defines whether to return "form of way" values for roads at each {@link StepIntersection}.
+     * See {@link StepIntersection#formOfWay()} for details.
+     * Requires {@link RouteOptions#steps()} to be set to true.
+     *
+     * @param intersectionLinkFormOfWay whether to return "form of way" values
+     * @return this builder
+     */
+    @NonNull
+    public abstract Builder intersectionLinkFormOfWay(
+      @Nullable Boolean intersectionLinkFormOfWay
+    );
+
+    /**
+     * A comma-separated list of road types for which intersection geometry data should be included
+     * at each {@link StepIntersection}. See {@link StepIntersection#geometries()} for details.
+     * Requires {@link RouteOptions#steps()} to be set to true.
+     * Possible values include:
+     * - "motorway"
+     * - "trunk"
+     * - "primary"
+     * - "secondary"
+     * - "tertiary"
+     * - "unclassified"
+     * - "residential"
+     * - "service_other"
+     * Geometry data will be provided for each intersection along the requested route.
+     * Be aware that enabling this option can significantly increase the response size
+     * and the memory required to store the response object. Use this option selectively,
+     * for example, if geometry is only needed for motorways, specify only "motorway".
+     *
+     * @param intersectionLinkGeometry a comma-separated list of road types for which intersection
+     *                                 geometry data should be included
+     * @return this builder
+     */
+    @NonNull
+    public abstract Builder intersectionLinkGeometry(
+      @Nullable String intersectionLinkGeometry
+    );
+
+    /**
+     * A comma-separated list of road types for which intersection geometry data should be included
+     * at each {@link StepIntersection}. See {@link StepIntersection#geometries()} for details.
+     * Requires {@link RouteOptions#steps()} to be set to true.
+     * Possible values include:
+     * - "motorway"
+     * - "trunk"
+     * - "primary"
+     * - "secondary"
+     * - "tertiary"
+     * - "unclassified"
+     * - "residential"
+     * - "service_other"
+     * Geometry data will be provided for each intersection along the requested route.
+     * Be aware that enabling this option can significantly increase the response size
+     * and the memory required to store the response object. Use this option selectively,
+     * for example, if geometry is only needed for motorways, specify only "motorway".
+     *
+     * @param intersectionLinkGeometry a list of road types for which intersection
+     *                                 geometry data should be included
+     * @return this builder
+     */
+    @NonNull
+    public Builder intersectionLinkGeometry(@Nullable List<String> intersectionLinkGeometry) {
+      String result = FormatUtils.join(",", intersectionLinkGeometry);
+      return intersectionLinkGeometry(result);
+    }
+
+    /**
+     * Defines whether to return "access" values for roads at each {@link StepIntersection}.
+     * See {@link StepIntersection#access()} for details.
+     * Requires {@link RouteOptions#steps()} to be set to true.
+     *
+     * @param intersectionLinkAccess whether to return "access" values
+     * @return this builder
+     */
+    @NonNull
+    public abstract Builder intersectionLinkAccess(
+      @Nullable Boolean intersectionLinkAccess
+    );
+
+    /**
+     * Defines whether to return "elevated" status for roads at each {@link StepIntersection}.
+     * See {@link StepIntersection#elevated()} for details.
+     * Requires {@link RouteOptions#steps()} to be set to true.
+     *
+     * @param intersectionLinkElevated whether to return "elevated" status
+     * @return this builder
+     */
+    @NonNull
+    public abstract Builder intersectionLinkElevated(
+      @Nullable Boolean intersectionLinkElevated
+    );
+
+    /**
+     * Defines whether to return "bridge" status for roads at each {@link StepIntersection}.
+     * See {@link StepIntersection#bridges()} for details.
+     * Requires {@link RouteOptions#steps()} to be set to true.
+     *
+     * @param intersectionLinkBridge whether to return "bridge" status
+     * @return this builder
+     */
+    @NonNull
+    public abstract Builder intersectionLinkBridge(
+      @Nullable Boolean intersectionLinkBridge
     );
 
     /**

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/RouteOptions.java
@@ -1000,7 +1000,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * See {@link StepIntersection#elevated()} for details.
    * Requires {@link RouteOptions#steps()} to be set to true.
    *
-   * @return boolean representing the `intersectionLinkAccess` value
+   * @return boolean representing the `intersectionLinkElevated` value
    */
   @SerializedName("intersection_link_elevated")
   @Nullable
@@ -1011,7 +1011,7 @@ public abstract class RouteOptions extends DirectionsJsonObject {
    * See {@link StepIntersection#bridges()} for details.
    * Requires {@link RouteOptions#steps()} to be set to true.
    *
-   * @return boolean representing the `intersectionLinkAccess` value
+   * @return boolean representing the `intersectionLinkBridge` value
    */
   @SerializedName("intersection_link_bridge")
   @Nullable

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
@@ -2,6 +2,7 @@ package com.mapbox.api.directions.v5.models;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -91,6 +92,76 @@ public abstract class StepIntersection extends DirectionsJsonObject {
    */
   @Nullable
   public abstract List<Boolean> entry();
+
+  /**
+   * A list representing the "form of way" values for all roads at the step intersection.
+   * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+   * Each element is one of the following:
+   * - freeway,
+   * - multiple_carriageway,
+   * - single_carriageway,
+   * - roundabout,
+   * - ramp,
+   * - service_road,
+   * - pedestrian_zone,
+   * - unknown
+   * Example:
+   * "form_of_way": [
+   *     "ramp",
+   *     "single_carriageway",
+   *     "freeway"
+   * ]
+   *
+   * @return A list of form of way values for all roads at the step intersection
+   */
+  @Nullable
+  @SerializedName("form_of_way")
+  public abstract List<String> formOfWay();
+
+  /**
+   * A list representing the geometry of each road at the step intersection.
+   * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+   * Each value represents the geometry of a segment up to the next intersection (a SIRN segment).
+   * For on-route segments, the geometry is `null` except for the first and last segment of each leg.
+   * @return A list of geometry for all roads at the step intersection
+   */
+  @Nullable
+  @SerializedName("geometries")
+  public abstract List<String> geometries();
+
+  /**
+   * A list representing the access type for each road at the step intersection.
+   * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+   * Each value is one of the following:
+   * - 0 (none)
+   * - -1 (forward)
+   * - 1 (backward)
+   * - 2 (both).
+   * @return A list of access values for all roads at the intersection
+   */
+  @Nullable
+  @SerializedName("access")
+  public abstract List<Integer> access();
+
+  /**
+   * A list indicating whether each road at the step intersection is elevated.
+   * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+   * Each value is {@code true} if the segment is elevated, otherwise {@code false}.
+   * @return A list of boolean values indicating elevated status for all roads at the intersection.
+   */
+  @Nullable
+  @SerializedName("elevated")
+  public abstract List<Boolean> elevated();
+
+  /**
+   * A list indicating whether each road at the step intersection is a bridge.
+   * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+   * Each value is {@code true} if the segment is a bridge, otherwise {@code false}.
+   * @return A list of boolean values indicating bridge status for all roads at the intersection
+   */
+  @Nullable
+  @SerializedName("bridges")
+  public abstract List<Boolean> bridges();
 
   /**
    * Index into bearings/entry array. Used to calculate the bearing before the turn. Namely, the
@@ -359,6 +430,83 @@ public abstract class StepIntersection extends DirectionsJsonObject {
      */
     @NonNull
     public abstract Builder entry(@Nullable List<Boolean> entry);
+
+    /**
+     * A list representing the "form of way" values for all roads at the step intersection.
+     * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+     * Each element is one of the following:
+     * - freeway,
+     * - multiple_carriageway,
+     * - single_carriageway,
+     * - roundabout,
+     * - ramp,
+     * - service_road,
+     * - pedestrian_zone,
+     * - unknown
+     * Example:
+     * "form_of_way": [
+     *     "ramp",
+     *     "single_carriageway",
+     *     "freeway"
+     * ]
+     *
+     * @param formOfWay a list of form of way values for all roads at the step intersection
+     * @return this builder for chaining options together
+     */
+    @NonNull
+    public abstract Builder formOfWay(List<String> formOfWay);
+
+    /**
+     * A list representing the geometry of each road at the step intersection.
+     * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+     * Each value represents the geometry of a segment up to the next intersection (a SIRN segment).
+     * For on-route segments, the geometry is `null` except for the first and last segment
+     * of each leg.
+     *
+     * @param geometries a list of geometry for all roads at the step intersection
+     * @return this builder for chaining options together
+     */
+    @NonNull
+    public abstract Builder geometries(List<String> geometries);
+
+    /**
+     * A list representing the access type for each road at the step intersection.
+     * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+     * Each value is one of the following:
+     * - 0 (none)
+     * - -1 (forward)
+     * - 1 (backward)
+     * - 2 (both).
+     *
+     * @param access a list of access values for all roads at the intersection
+     * @return this builder for chaining options together
+     */
+    @NonNull
+    public abstract Builder access(List<Integer> access);
+
+    /**
+     * A list indicating whether each road at the step intersection is elevated.
+     * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+     * Each value is {@code true} if the segment is elevated, otherwise {@code false}.
+     *
+     * @param elevated a list of boolean values indicating elevated status for all roads
+     *                 at the intersection.
+     * @return this builder for chaining options together
+     */
+    @NonNull
+    public abstract Builder elevated(List<Boolean> elevated);
+
+    /**
+     * A list indicating whether each road at the step intersection is a bridge.
+     * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
+     * Each value is {@code true} if the segment is a bridge, otherwise {@code false}.
+     *
+     * @param bridges a list of boolean values indicating bridge status for all roads
+     *                at the intersection
+     * @return this builder for chaining options together
+     */
+    @NonNull
+    public abstract Builder bridges(List<Boolean> bridges);
 
     /**
      * Index into bearings/entry array. Used to calculate the bearing before the turn. Namely, the

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
@@ -52,7 +52,7 @@ public abstract class StepIntersection extends DirectionsJsonObject {
    */
   @NonNull
   @SerializedName("location")
-  @SuppressWarnings( {"mutable", "WeakerAccess"})
+  @SuppressWarnings({"mutable", "WeakerAccess"})
   protected abstract double[] rawLocation();
 
   /**
@@ -107,9 +107,9 @@ public abstract class StepIntersection extends DirectionsJsonObject {
    * - unknown
    * Example:
    * "form_of_way": [
-   *     "ramp",
-   *     "single_carriageway",
-   *     "freeway"
+   * "ramp",
+   * "single_carriageway",
+   * "freeway"
    * ]
    *
    * @return A list of form of way values for all roads at the step intersection
@@ -122,7 +122,9 @@ public abstract class StepIntersection extends DirectionsJsonObject {
    * A list representing the geometry of each road at the step intersection.
    * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
    * Each value represents the geometry of a segment up to the next intersection (a SIRN segment).
-   * For on-route segments, the geometry is `null` except for the first and last segment of each leg.
+   * For on-route segments, the geometry is `null` except for the first and last segment
+   * of each leg.
+   *
    * @return A list of geometry for all roads at the step intersection
    */
   @Nullable
@@ -137,6 +139,7 @@ public abstract class StepIntersection extends DirectionsJsonObject {
    * - -1 (forward)
    * - 1 (backward)
    * - 2 (both).
+   *
    * @return A list of access values for all roads at the intersection
    */
   @Nullable
@@ -147,6 +150,7 @@ public abstract class StepIntersection extends DirectionsJsonObject {
    * A list indicating whether each road at the step intersection is elevated.
    * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
    * Each value is {@code true} if the segment is elevated, otherwise {@code false}.
+   *
    * @return A list of boolean values indicating elevated status for all roads at the intersection.
    */
   @Nullable
@@ -157,6 +161,7 @@ public abstract class StepIntersection extends DirectionsJsonObject {
    * A list indicating whether each road at the step intersection is a bridge.
    * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
    * Each value is {@code true} if the segment is a bridge, otherwise {@code false}.
+   *
    * @return A list of boolean values indicating bridge status for all roads at the intersection
    */
   @Nullable
@@ -445,9 +450,9 @@ public abstract class StepIntersection extends DirectionsJsonObject {
      * - unknown
      * Example:
      * "form_of_way": [
-     *     "ramp",
-     *     "single_carriageway",
-     *     "freeway"
+     * "ramp",
+     * "single_carriageway",
+     * "freeway"
      * ]
      *
      * @param formOfWay a list of form of way values for all roads at the step intersection

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
@@ -121,7 +121,7 @@ public abstract class StepIntersection extends DirectionsJsonObject {
   /**
    * A list representing the geometry of each road at the step intersection.
    * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
-   * Each value represents the geometry of a segment up to the next intersection (a SIRN segment).
+   * Each value represents the geometry of a segment up to the next intersection.
    * For on-route segments, the geometry is `null` except for the first and last segment
    * of each leg.
    *
@@ -464,7 +464,7 @@ public abstract class StepIntersection extends DirectionsJsonObject {
     /**
      * A list representing the geometry of each road at the step intersection.
      * This list has a 1:1 correspondence with the {@link #bearings()} and {@link #entry()} lists.
-     * Each value represents the geometry of a segment up to the next intersection (a SIRN segment).
+     * Each value represents the geometry of a segment up to the next intersection.
      * For on-route segments, the geometry is `null` except for the first and last segment
      * of each leg.
      *

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsRouteTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/DirectionsRouteTest.java
@@ -261,4 +261,105 @@ public class DirectionsRouteTest extends TestUtils {
       .build();
     assertEquals(access, lane.access());
   }
+
+  @Test
+  public void directionsRoute_hasFormOfWay() throws IOException {
+    String json = loadJsonFixture("directions_v5_with_toll_costs_and_lanes.json");
+    RouteOptions options = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+      .coordinatesList(new ArrayList<Point>() {{
+        add(Point.fromLngLat(1.0, 1.0));
+        add(Point.fromLngLat(2.0, 2.0));
+      }})
+      .build();
+    String uuid = "123";
+    DirectionsRoute route = DirectionsRoute.fromJson(json, options, uuid);
+
+    final List<String> formOfWay = route.legs().get(0).steps().get(0).intersections().get(0)
+      .formOfWay();
+
+    assertEquals(Arrays.asList("freeway", "ramp", null), formOfWay);
+  }
+
+  @Test
+  public void directionsRoute_hasGeometries() throws IOException {
+    String json = loadJsonFixture("directions_v5_with_toll_costs_and_lanes.json");
+    RouteOptions options = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+      .coordinatesList(new ArrayList<Point>() {{
+        add(Point.fromLngLat(1.0, 1.0));
+        add(Point.fromLngLat(2.0, 2.0));
+      }})
+      .build();
+    String uuid = "123";
+    DirectionsRoute route = DirectionsRoute.fromJson(json, options, uuid);
+
+    final List<String> geometries = route.legs().get(0).steps().get(0).intersections().get(0)
+      .geometries();
+
+    final List<String> expectedGeometries = Arrays.asList(
+      "k}fiyAcxhgOjCRrD?rDS~CSrDSbQ{@rIg@nFSfES~HSjMSrNRjMz@jHz@jMjCnK~CzJrD~MvG",
+      null,
+      null
+    );
+
+    assertEquals(expectedGeometries, geometries);
+  }
+
+  @Test
+  public void directionsRoute_hasAccess() throws IOException {
+    String json = loadJsonFixture("directions_v5_with_toll_costs_and_lanes.json");
+    RouteOptions options = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+      .coordinatesList(new ArrayList<Point>() {{
+        add(Point.fromLngLat(1.0, 1.0));
+        add(Point.fromLngLat(2.0, 2.0));
+      }})
+      .build();
+    String uuid = "123";
+    DirectionsRoute route = DirectionsRoute.fromJson(json, options, uuid);
+
+    assertEquals(
+      Arrays.asList(0, 1, null),
+      route.legs().get(0).steps().get(0).intersections().get(0).access()
+    );
+  }
+
+  @Test
+  public void directionsRoute_hasElevated() throws IOException {
+    String json = loadJsonFixture("directions_v5_with_toll_costs_and_lanes.json");
+    RouteOptions options = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+      .coordinatesList(new ArrayList<Point>() {{
+        add(Point.fromLngLat(1.0, 1.0));
+        add(Point.fromLngLat(2.0, 2.0));
+      }})
+      .build();
+    String uuid = "123";
+    DirectionsRoute route = DirectionsRoute.fromJson(json, options, uuid);
+
+    assertEquals(
+      Arrays.asList(true, false, null),
+      route.legs().get(0).steps().get(0).intersections().get(0).elevated()
+    );
+  }
+
+  @Test
+  public void directionsRoute_hasBridges() throws IOException {
+    String json = loadJsonFixture("directions_v5_with_toll_costs_and_lanes.json");
+    RouteOptions options = RouteOptions.builder()
+      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+      .coordinatesList(new ArrayList<Point>() {{
+        add(Point.fromLngLat(1.0, 1.0));
+        add(Point.fromLngLat(2.0, 2.0));
+      }})
+      .build();
+    String uuid = "123";
+    DirectionsRoute route = DirectionsRoute.fromJson(json, options, uuid);
+
+    assertEquals(
+      Arrays.asList(false, true, null),
+      route.legs().get(0).steps().get(0).intersections().get(0).bridges()
+    );
+  }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/RouteOptionsTest.java
@@ -37,8 +37,54 @@ public class RouteOptionsTest extends TestUtils {
    * Always update this file when new option is introduced.
    */
   private static final String ROUTE_OPTIONS_JSON = "route_options_v5.json";
+
   private static final String ROUTE_OPTIONS_URL =
-    "https://api.mapbox.com/directions/v5/mapbox/driving/-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835?access_token=pk.token&geometries=polyline6&alternatives=false&overview=full&radiuses=%3Bunlimited%3B5.1&steps=true&avoid_maneuver_radius=200.0&bearings=0%2C90%3B90%2C0%3B&layers=-42%3B%3B0&continue_straight=false&annotations=congestion%2Cdistance%2Cduration&language=ru&roundabout_exits=false&voice_instructions=true&banner_instructions=true&voice_units=metric&exclude=toll%2Cferry%2Cpoint%2811.0+-22.0%29&include=hot%2Chov2&approaches=%3Bcurb%3B&waypoints=0%3B1%3B2&waypoint_names=%3BSerangoon+Garden+Market+%26+Food+Centre%3BFunky+%26nAmE*&waypoint_targets=%3B12.2%2C21.2%3B&enable_refresh=true&walking_speed=5.11&walkway_bias=-0.2&alley_bias=0.75&snapping_include_closures=%3Bfalse%3Btrue&snapping_include_static_closures=true%3B%3Bfalse&arrive_by=2021-01-01%27T%2701%3A01&depart_at=2021-02-02%27T%2702%3A02&max_height=1.5&max_width=1.4&max_weight=2.9&compute_toll_cost=true&waypoints_per_route=true&metadata=true&payment_methods=general&suppress_voice_instruction_local_names=true";
+    "https://api.mapbox.com/directions/v5/mapbox/driving/" +
+      "-122.4003312,37.7736941;-122.4187529,37.7689715;-122.4255172,37.7775835" +
+      "?access_token=pk.token" +
+      "&geometries=polyline6" +
+      "&alternatives=false" +
+      "&overview=full" +
+      "&radiuses=%3Bunlimited%3B5.1" +
+      "&steps=true" +
+      "&avoid_maneuver_radius=200.0" +
+      "&bearings=0%2C90%3B90%2C0%3B" +
+      "&layers=-42%3B%3B0" +
+      "&continue_straight=false" +
+      "&annotations=congestion%2Cdistance%2Cduration" +
+      "&language=ru" +
+      "&roundabout_exits=false" +
+      "&voice_instructions=true" +
+      "&banner_instructions=true" +
+      "&voice_units=metric" +
+      "&exclude=toll%2Cferry%2Cpoint%2811.0+-22.0%29" +
+      "&include=hot%2Chov2" +
+      "&approaches=%3Bcurb%3B" +
+      "&waypoints=0%3B1%3B2" +
+      "&waypoint_names=%3BSerangoon+Garden+Market+%26+Food+Centre%3BFunky+%26nAmE*" +
+      "&waypoint_targets=%3B12.2%2C21.2%3B" +
+      "&enable_refresh=true" +
+      "&walking_speed=5.11" +
+      "&walkway_bias=-0.2" +
+      "&alley_bias=0.75" +
+      "&snapping_include_closures=%3Bfalse%3Btrue" +
+      "&snapping_include_static_closures=true%3B%3Bfalse" +
+      "&arrive_by=2021-01-01%27T%2701%3A01" +
+      "&depart_at=2021-02-02%27T%2702%3A02" +
+      "&max_height=1.5" +
+      "&max_width=1.4" +
+      "&max_weight=2.9" +
+      "&compute_toll_cost=true" +
+      "&waypoints_per_route=true" +
+      "&metadata=true" +
+      "&payment_methods=general" +
+      "&suppress_voice_instruction_local_names=true" +
+      "&intersection_link_form_of_way=true" +
+      "&intersection_link_geometry=motorway%2Ctrunk%2Cprimary" +
+      "&intersection_link_access=true" +
+      "&intersection_link_elevated=true" +
+      "&intersection_link_bridge=true";
+
   private static final String ACCESS_TOKEN = "pk.token";
 
   private final String optionsJson = loadJsonFixture(ROUTE_OPTIONS_JSON);
@@ -365,6 +411,36 @@ public class RouteOptionsTest extends TestUtils {
   }
 
   @Test
+  public void intersectionLinkGeometryAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    assertEquals("motorway,trunk,primary", routeOptions.intersectionLinkGeometry());
+  }
+
+  @Test
+  public void intersectionLinkFormOfWayAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    assertEquals(true, routeOptions.intersectionLinkFormOfWay());
+  }
+
+  @Test
+  public void intersectionLinkAccessAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    assertEquals(true, routeOptions.intersectionLinkAccess());
+  }
+
+  @Test
+  public void intersectionLinkElevatedAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    assertEquals(true, routeOptions.intersectionLinkElevated());
+  }
+
+  @Test
+  public void intersectionLinkBridgeAreValid_fromJson() {
+    RouteOptions routeOptions = RouteOptions.fromJson(optionsJson);
+    assertEquals(true, routeOptions.intersectionLinkBridge());
+  }
+
+  @Test
   public void defaultTollCost() {
     RouteOptions options = defaultRouteOptions();
 
@@ -383,6 +459,18 @@ public class RouteOptionsTest extends TestUtils {
     RouteOptions options = defaultRouteOptions();
 
     assertNull(options.waypointsPerRoute());
+  }
+
+  @Test
+  public void defaultIntersectionLinkFormOfWay() {
+    RouteOptions options = defaultRouteOptions();
+    assertNull(options.intersectionLinkFormOfWay());
+  }
+
+  @Test
+  public void defaultIntersectionLinkGeometry() {
+    RouteOptions options = defaultRouteOptions();
+    assertNull(options.intersectionLinkGeometry());
   }
 
   @Test
@@ -1128,6 +1216,11 @@ public class RouteOptionsTest extends TestUtils {
       .waypointsPerRoute(true)
       .paymentMethods(DirectionsCriteria.PAYMENT_METHOD_GENERAL)
       .suppressVoiceInstructionLocalNames(true)
+      .intersectionLinkFormOfWay(true)
+      .intersectionLinkGeometry("motorway,trunk,primary")
+      .intersectionLinkAccess(true)
+      .intersectionLinkElevated(true)
+      .intersectionLinkBridge(true)
       .build();
   }
 
@@ -1237,6 +1330,11 @@ public class RouteOptionsTest extends TestUtils {
       .waypointsPerRoute(true)
       .suppressVoiceInstructionLocalNames(true)
       .paymentMethodsList(Arrays.asList(DirectionsCriteria.PAYMENT_METHOD_GENERAL))
+      .intersectionLinkFormOfWay(true)
+      .intersectionLinkAccess(true)
+      .intersectionLinkElevated(true)
+      .intersectionLinkBridge(true)
+      .intersectionLinkGeometry(Arrays.asList("motorway", "trunk", "primary"))
       .build();
   }
 }

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
@@ -1,16 +1,18 @@
 package com.mapbox.api.directions.v5.models;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import com.mapbox.core.TestUtils;
 import com.mapbox.geojson.Point;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
 import org.junit.Assert;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class StepIntersectionTest extends TestUtils {
 
@@ -245,5 +247,176 @@ public class StepIntersectionTest extends TestUtils {
     Assert.assertNull(stepIntersection.mergingArea());
     String jsonStr = stepIntersection.toJson();
     compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testFormOfWay() {
+    final String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ],"
+      + "\"form_of_way\": [\n"
+      + "    \"freeway\",\n"
+      + "    \"roundabout\",\n"
+      + "    \"ramp\",\n"
+      + "    null\n"
+      + "]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    final List<String> formOfWay = Arrays.asList(
+      "freeway", "roundabout", "ramp", null
+    );
+
+    assertEquals(formOfWay, stepIntersection.formOfWay());
+
+    final String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testNullFormOfWay() {
+    final String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+    assertNull(stepIntersection.formOfWay());
+  }
+
+  @Test
+  public void testGeometries() {
+    final String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ],"
+      + "\"geometries\": [\n"
+      + "    \"{{vacBwuenX?^?|OAzXBdP\",\n"
+      + "    \"}xfbcB_yjkXcEdAcF`KwClEyH|NoQz[iOdUqOhSeT|TgH`FyHnFuKbF}ChAcFhBoGpAqFXeIXeEHuVl@\",\n"
+      + "    null\n"
+      + "]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    final List<String> geometries = Arrays.asList(
+      "{{vacBwuenX?^?|OAzXBdP",
+      "}xfbcB_yjkXcEdAcF`KwClEyH|NoQz[iOdUqOhSeT|TgH`FyHnFuKbF}ChAcFhBoGpAqFXeIXeEHuVl@",
+      null
+    );
+
+    assertEquals(geometries, stepIntersection.geometries());
+
+    final String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testNullGeometries() {
+    String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+    assertNull(stepIntersection.geometries());
+  }
+
+  @Test
+  public void testAccess() {
+    final String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ],"
+      + "\"access\": [\n"
+      + "    0,\n"
+      + "    -1,\n"
+      + "    1,\n"
+      + "    2,\n"
+      + "    null"
+      + "]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    final List<Integer> access = Arrays.asList(
+      0, -1, 1, 2, null
+    );
+
+    assertEquals(access, stepIntersection.access());
+
+    final String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testNullAccess() {
+    String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+    assertNull(stepIntersection.access());
+  }
+
+  @Test
+  public void testElevated() {
+    final String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ],"
+      + "\"elevated\": [\n"
+      + "    true,\n"
+      + "    false,\n"
+      + "    null"
+      + "]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    final List<Boolean> elevated = Arrays.asList(
+      true, false, null
+    );
+
+    assertEquals(elevated, stepIntersection.elevated());
+
+    final String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testNullElevated() {
+    String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+    assertNull(stepIntersection.elevated());
+  }
+
+  @Test
+  public void testBridges() {
+    final String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ],"
+      + "\"bridges\": [\n"
+      + "    true,\n"
+      + "    false,\n"
+      + "    true,\n"
+      + "    null"
+      + "]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    final List<Boolean> bridge = Arrays.asList(
+      true, false, true, null
+    );
+
+    assertEquals(bridge, stepIntersection.bridges());
+
+    final String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testNullBridges() {
+    String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ]"
+      + "}";
+
+    final StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+    assertNull(stepIntersection.bridges());
   }
 }

--- a/services-directions-models/src/test/resources/directions_v5_with_toll_costs_and_lanes.json
+++ b/services-directions-models/src/test/resources/directions_v5_with_toll_costs_and_lanes.json
@@ -143,10 +143,37 @@
                 }
               ],
               "entry": [
-                true
+                true,
+                true,
+                false
               ],
               "bearings": [
-                198
+                90,
+                180,
+                270
+              ],
+              "geometries": [
+                "k}fiyAcxhgOjCRrD?rDS~CSrDSbQ{@rIg@nFSfES~HSjMSrNRjMz@jHz@jMjCnK~CzJrD~MvG",
+                null,
+                null
+              ],
+              "form_of_way": [
+                "freeway", "ramp", null
+              ],
+              "access": [
+                0,
+                1,
+                null
+              ],
+              "elevated": [
+                true,
+                false,
+                null
+              ],
+              "bridges": [
+                false,
+                true,
+                null
               ],
               "duration": 3.749,
               "mapbox_streets_v8": {

--- a/services-directions-models/src/test/resources/route_options_v5.json
+++ b/services-directions-models/src/test/resources/route_options_v5.json
@@ -39,5 +39,10 @@
   "waypoints_per_route": true,
   "compute_toll_cost": true,
   "payment_methods": "general",
-  "suppress_voice_instruction_local_names": true
+  "suppress_voice_instruction_local_names": true,
+  "intersection_link_form_of_way": true,
+  "intersection_link_geometry": "motorway,trunk,primary",
+  "intersection_link_access": true,
+  "intersection_link_elevated": true,
+  "intersection_link_bridge": true
 }


### PR DESCRIPTION
Added support for:
- `StepIntersection#formOfWay`,
- `StepIntersection#geometries`
- `StepIntersection#access`
- `StepIntersection#elevated`
- `StepIntersection#bridge`

Also added a new voice unit value: `DirectionsCriteria#BRITISH_IMPERIAL`.
