### PR TITLE
Expose step intersection `duration` as Double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ### main
+- Add `StepIntersection#duration` (previously available through `StepIntersection#getUnrecognizedProperty("duration")`)
 
 ### v7.7.0 - August 13, 2025
 - Add `RouteLeg#notifications`

--- a/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
+++ b/services-directions-models/src/main/java/com/mapbox/api/directions/v5/models/StepIntersection.java
@@ -350,6 +350,16 @@ public abstract class StepIntersection extends DirectionsJsonObject {
   @SerializedName("merging_area")
   public abstract MergingArea mergingArea();
 
+
+  /**
+   * The time required, in seconds, to traverse the intersection. Only available on the driving profile.
+   *
+   * @return The time required, in seconds, to traverse the intersection. Only available on the driving profile.
+   */
+  @Nullable
+  @SerializedName("duration")
+  public abstract Double duration();
+
   /**
    * Convert the current {@link StepIntersection} to its builder holding the currently assigned
    * values. This allows you to modify a single property and then rebuild the object resulting in
@@ -712,6 +722,14 @@ public abstract class StepIntersection extends DirectionsJsonObject {
      */
     @NonNull
     public abstract Builder mergingArea(@Nullable MergingArea mergingArea);
+
+    /**
+     * The time required, in seconds, to traverse the intersection. Only available on the driving profile.
+     *
+     * @return The time required, in seconds, to traverse the intersection. Only available on the driving profile.
+     */
+    @NonNull
+    public abstract Builder duration(@Nullable Double duration);
 
     /**
      * Build a new {@link StepIntersection} object.

--- a/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
+++ b/services-directions-models/src/test/java/com/mapbox/api/directions/v5/models/StepIntersectionTest.java
@@ -59,6 +59,7 @@ public class StepIntersectionTest extends TestUtils {
       .junction(Junction.builder().name("jct_name").build())
       .interchange(Interchange.builder().name("ic_name").build())
       .mergingArea(MergingArea.builder().type(MergingArea.TYPE_FROM_LEFT).build())
+      .duration(12.34)
       .build();
 
     String jsonString = intersection.toJson();
@@ -101,7 +102,8 @@ public class StepIntersectionTest extends TestUtils {
     + "\"traffic_signal\": true,"
     + "\"stop_sign\": true,"
     + "\"merging_area\": {\"type\": \"from_right\"},"
-    + "\"yield_sign\": true"
+    + "\"yield_sign\": true,"
+    + "\"duration\": 12.34"
     + "}";
 
     StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
@@ -114,6 +116,7 @@ public class StepIntersectionTest extends TestUtils {
     assertTrue(stepIntersection.stopSign());
     assertTrue(stepIntersection.yieldSign());
     assertEquals(MergingArea.builder().type(MergingArea.TYPE_FROM_RIGHT).build(), stepIntersection.mergingArea());
+    assertEquals(12.34, stepIntersection.duration(), 0.0001);
 
     Point location = stepIntersection.location();
     assertEquals(13.426579, location.longitude(), 0.0001);
@@ -218,6 +221,33 @@ public class StepIntersectionTest extends TestUtils {
     StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
 
     Assert.assertNull(stepIntersection.interchange());
+    String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testDuration() {
+    String stepIntersectionJsonString = "{"
+      + "\"location\": [ 13.426579, 52.508068 ],"
+      + "\"duration\": 12.34"
+      + "}";
+
+    StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    Assert.assertEquals(12.34, stepIntersection.duration(), 0.0001);
+    String jsonStr = stepIntersection.toJson();
+    compareJson(stepIntersectionJsonString, jsonStr);
+  }
+
+  @Test
+  public void testNullDuration() {
+    String stepIntersectionJsonString = "{"
+            + "\"location\": [ 13.426579, 52.508068 ]"
+            + "}";
+
+    StepIntersection stepIntersection = StepIntersection.fromJson(stepIntersectionJsonString);
+
+    Assert.assertNull(stepIntersection.duration());
     String jsonStr = stepIntersection.toJson();
     compareJson(stepIntersectionJsonString, jsonStr);
   }


### PR DESCRIPTION
Expose `StepIntersection#duration` (previously available through `StepIntersection#getUnrecognizedProperty("duration")`)