### PR TITLE
Removed unnecessary code to handle start point in lineSliceAlong()

### DIFF
--- a/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
@@ -210,11 +210,6 @@ public final class TurfMisc {
       } else if (travelled > startDist && slice.size() == 0) {
         // This logic handles finding the starting point when startDist is not 0
         double overshot = startDist - travelled;
-        if (overshot == 0) {
-          // This doesn't make sense, why are we stopping when the overshot from startDist is 0?
-          slice.add(pointAtI);
-          return LineString.fromLngLats(slice);
-        }
         Point previousPoint = Point.fromLngLat(coords[((i - 1) * 2)], coords[((i - 1) * 2) + 1]);
         double direction = TurfMeasurement.bearing(pointAtI, previousPoint) - 180;
         Point interpolated = TurfMeasurement.destination(pointAtI, overshot, direction, units);

--- a/services-turf/src/test/java/com/mapbox/turf/TurfMiscTest.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TurfMiscTest.java
@@ -510,6 +510,26 @@ public class TurfMiscTest extends TestUtils {
   }
 
   @Test
+  public void testLineSliceAlongRoute1WithExactStop() throws IOException, TurfException {
+    Feature route1 = Feature.fromJson(loadJsonFixture(LINE_SLICE_ALONG_ROUTE_ONE));
+    LineString lineStringRoute1 = (LineString) route1.geometry();
+
+    double start = 500;
+    Point start_point = TurfMeasurement.along(lineStringRoute1, start, TurfConstants.UNIT_MILES);
+    double exactStop = TurfMeasurement.length(lineStringRoute1, TurfConstants.UNIT_MILES);
+
+    LineString slicedAtExactStop = TurfMisc.lineSliceAlong(route1, start, exactStop,
+            TurfConstants.UNIT_MILES);
+    List<Point> slicedCoordinatesAtExactStop = slicedAtExactStop.coordinates();
+    assertEquals(slicedCoordinatesAtExactStop.get(0).coordinates(), start_point.coordinates());
+    Point lastPointInLine = lineStringRoute1.coordinates().get(
+            lineStringRoute1.coordinates().size() - 1
+    );
+    assertEquals(slicedCoordinatesAtExactStop.get(slicedCoordinatesAtExactStop.size() - 1)
+                    .coordinates(), lastPointInLine.coordinates());
+  }
+
+  @Test
   public void testLineSliceAlongRoute2() throws IOException, TurfException {
 
     Feature route2 = Feature.fromJson(loadJsonFixture(LINE_SLICE_ALONG_ROUTE_TWO));


### PR DESCRIPTION
Removed code which could never occur when calculating the initial point in `lineSliceAlong()`.

Given that `travelled > startDist` then `double overshot = startDist - travelled` could never be 0.

Also added a test to validate when `travelled == stopDist`.
